### PR TITLE
Add LangChain and LlamaIndex VectorStore integrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 .cache/
 *.pyc
 *.bak
+*.so
 *.tq
 *.npy
 codebooks.npz

--- a/README.md
+++ b/README.md
@@ -40,6 +40,44 @@ index.write("my_index.tq")
 loaded = TurboQuantIndex.load("my_index.tq")
 ```
 
+### LangChain
+
+```bash
+pip install turbovec[langchain]
+```
+
+```python
+from langchain_huggingface import HuggingFaceEmbeddings
+from turbovec.langchain import TurboQuantVectorStore
+
+embeddings = HuggingFaceEmbeddings(model_name="BAAI/bge-base-en-v1.5")
+
+store = TurboQuantVectorStore.from_texts(
+    texts=["Document 1...", "Document 2...", "Document 3..."],
+    embedding=embeddings,
+    bit_width=4,
+)
+
+retriever = store.as_retriever(search_kwargs={"k": 5})
+```
+
+### LlamaIndex
+
+```bash
+pip install turbovec[llama-index]
+```
+
+```python
+from llama_index.core import VectorStoreIndex, StorageContext
+from turbovec.llama_index import TurboQuantVectorStore
+
+vector_store = TurboQuantVectorStore.from_params(dim=768, bit_width=4)
+storage_context = StorageContext.from_defaults(vector_store=vector_store)
+
+index = VectorStoreIndex.from_documents(documents, storage_context=storage_context)
+retriever = index.as_retriever(similarity_top_k=5)
+```
+
 ## Rust
 
 ```bash

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.70"
 
 [lib]
-name = "turbovec"
+name = "_turbovec"
 crate-type = ["cdylib"]
 
 [dependencies]

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -45,6 +45,12 @@ Homepage = "https://github.com/RyanCodrai/turbovec"
 Repository = "https://github.com/RyanCodrai/turbovec"
 Issues = "https://github.com/RyanCodrai/turbovec/issues"
 
+[project.optional-dependencies]
+langchain = ["langchain-core>=0.3"]
+llama-index = ["llama-index-core>=0.11"]
+
 [tool.maturin]
 manifest-path = "Cargo.toml"
 features = ["pyo3/extension-module"]
+python-source = "python"
+module-name = "turbovec._turbovec"

--- a/turbovec-python/python/turbovec/__init__.py
+++ b/turbovec-python/python/turbovec/__init__.py
@@ -1,0 +1,3 @@
+from ._turbovec import TurboQuantIndex
+
+__all__ = ["TurboQuantIndex"]

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -1,0 +1,179 @@
+"""LangChain VectorStore backed by turbovec's quantized index.
+
+Install with: ``pip install turbovec[langchain]``.
+"""
+
+from __future__ import annotations
+
+import pickle
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+from ._turbovec import TurboQuantIndex
+
+try:
+    from langchain_core.documents import Document
+    from langchain_core.embeddings import Embeddings
+    from langchain_core.vectorstores import VectorStore
+except ImportError as exc:
+    raise ImportError(
+        "langchain-core is required to use turbovec.langchain. "
+        "Install with: pip install turbovec[langchain]"
+    ) from exc
+
+
+_INDEX_FILENAME = "index.tv"
+_STORE_FILENAME = "docstore.pkl"
+
+
+class TurboQuantVectorStore(VectorStore):
+    """LangChain VectorStore backed by a :class:`TurboQuantIndex`.
+
+    Vectors are quantized to 2–4 bits per dimension. A side-car dictionary
+    holds the original text and metadata keyed by document id.
+    """
+
+    def __init__(
+        self,
+        embedding: Embeddings,
+        index: TurboQuantIndex,
+        *,
+        docs: dict[str, tuple[str, dict[str, Any]]] | None = None,
+        idx_to_id: list[str] | None = None,
+    ) -> None:
+        self._embedding = embedding
+        self._index = index
+        self._docs: dict[str, tuple[str, dict[str, Any]]] = docs if docs is not None else {}
+        self._idx_to_id: list[str] = idx_to_id if idx_to_id is not None else []
+
+    @property
+    def embeddings(self) -> Embeddings:
+        return self._embedding
+
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict] | None = None,
+        ids: list[str] | None = None,
+        **_: Any,
+    ) -> list[str]:
+        texts_list = list(texts)
+        if not texts_list:
+            return []
+        if metadatas is None:
+            metadatas = [{} for _ in texts_list]
+        if ids is None:
+            ids = [str(uuid.uuid4()) for _ in texts_list]
+        if len(metadatas) != len(texts_list) or len(ids) != len(texts_list):
+            raise ValueError("texts, metadatas, and ids must all have the same length")
+
+        vectors = np.asarray(self._embedding.embed_documents(texts_list), dtype=np.float32)
+        if vectors.ndim != 2 or vectors.shape[1] != self._index.dim:
+            raise ValueError(
+                f"embedding dimension {vectors.shape[1]} does not match index dim {self._index.dim}"
+            )
+        if not vectors.flags["C_CONTIGUOUS"]:
+            vectors = np.ascontiguousarray(vectors)
+        self._index.add(vectors)
+
+        for id_, text, meta in zip(ids, texts_list, metadatas):
+            self._idx_to_id.append(id_)
+            self._docs[id_] = (text, dict(meta))
+        return ids
+
+    def similarity_search(self, query: str, k: int = 4, **_: Any) -> list[Document]:
+        return [doc for doc, _score in self.similarity_search_with_score(query, k=k)]
+
+    def similarity_search_with_score(
+        self, query: str, k: int = 4, **_: Any
+    ) -> list[tuple[Document, float]]:
+        qvec = np.asarray(self._embedding.embed_query(query), dtype=np.float32)
+        return self._search_vector(qvec, k)
+
+    def similarity_search_by_vector(
+        self, embedding: list[float], k: int = 4, **_: Any
+    ) -> list[Document]:
+        qvec = np.asarray(embedding, dtype=np.float32)
+        return [doc for doc, _score in self._search_vector(qvec, k)]
+
+    def _search_vector(self, qvec: np.ndarray, k: int) -> list[tuple[Document, float]]:
+        if qvec.ndim == 1:
+            qvec = qvec[None, :]
+        if not qvec.flags["C_CONTIGUOUS"]:
+            qvec = np.ascontiguousarray(qvec)
+        k = min(k, len(self._index))
+        if k == 0:
+            return []
+        scores, indices = self._index.search(qvec, k)
+        results: list[tuple[Document, float]] = []
+        for score, idx in zip(scores[0], indices[0]):
+            id_ = self._idx_to_id[int(idx)]
+            text, meta = self._docs[id_]
+            results.append((Document(page_content=text, metadata=dict(meta)), float(score)))
+        return results
+
+    def delete(self, ids: list[str] | None = None, **_: Any) -> bool | None:
+        raise NotImplementedError(
+            "TurboQuantVectorStore does not support deletion. "
+            "Rebuild the store from the remaining documents."
+        )
+
+    @classmethod
+    def from_texts(
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: list[dict] | None = None,
+        *,
+        dim: int | None = None,
+        bit_width: int = 4,
+        ids: list[str] | None = None,
+        **_: Any,
+    ) -> "TurboQuantVectorStore":
+        if dim is None:
+            probe_text = texts[0] if texts else "probe"
+            probe = np.asarray(embedding.embed_documents([probe_text]), dtype=np.float32)
+            dim = int(probe.shape[1])
+        index = TurboQuantIndex(dim, bit_width)
+        store = cls(embedding=embedding, index=index)
+        if texts:
+            store.add_texts(texts, metadatas=metadatas, ids=ids)
+        return store
+
+    def save_local(self, folder_path: str | Path) -> None:
+        folder = Path(folder_path)
+        folder.mkdir(parents=True, exist_ok=True)
+        self._index.write(str(folder / _INDEX_FILENAME))
+        with open(folder / _STORE_FILENAME, "wb") as f:
+            pickle.dump({"docs": self._docs, "idx_to_id": self._idx_to_id}, f)
+
+    @classmethod
+    def load_local(
+        cls,
+        folder_path: str | Path,
+        embedding: Embeddings,
+        *,
+        allow_dangerous_deserialization: bool = False,
+    ) -> "TurboQuantVectorStore":
+        if not allow_dangerous_deserialization:
+            raise ValueError(
+                "load_local uses pickle to deserialize the document store, which is "
+                "unsafe with untrusted input. Pass allow_dangerous_deserialization=True "
+                "to confirm you trust the source of folder_path."
+            )
+        folder = Path(folder_path)
+        index = TurboQuantIndex.load(str(folder / _INDEX_FILENAME))
+        with open(folder / _STORE_FILENAME, "rb") as f:
+            state = pickle.load(f)
+        return cls(
+            embedding=embedding,
+            index=index,
+            docs=state["docs"],
+            idx_to_id=state["idx_to_id"],
+        )
+
+
+__all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -1,0 +1,179 @@
+"""LlamaIndex VectorStore backed by turbovec's quantized index.
+
+Install with: ``pip install turbovec[llama-index]``.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ._turbovec import TurboQuantIndex
+
+try:
+    from llama_index.core.bridge.pydantic import PrivateAttr
+    from llama_index.core.schema import (
+        BaseNode,
+        MetadataMode,
+        NodeRelationship,
+        RelatedNodeInfo,
+        TextNode,
+    )
+    from llama_index.core.vector_stores.types import (
+        BasePydanticVectorStore,
+        VectorStoreQuery,
+        VectorStoreQueryResult,
+    )
+except ImportError as exc:
+    raise ImportError(
+        "llama-index-core is required to use turbovec.llama_index. "
+        "Install with: pip install turbovec[llama-index]"
+    ) from exc
+
+
+_INDEX_FILENAME = "index.tv"
+_STORE_FILENAME = "nodes.pkl"
+
+
+class TurboQuantVectorStore(BasePydanticVectorStore):
+    """LlamaIndex VectorStore backed by a :class:`TurboQuantIndex`.
+
+    Vectors are quantized to 2–4 bits per dimension. A side-car dictionary
+    holds node text and metadata keyed by ``node_id``.
+    """
+
+    stores_text: bool = True
+    is_embedding_query: bool = True
+    flat_metadata: bool = False
+
+    _index: Any = PrivateAttr()
+    _nodes: dict[str, dict[str, Any]] = PrivateAttr()
+    _idx_to_node_id: list[str] = PrivateAttr()
+
+    def __init__(self, index: TurboQuantIndex, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._index = index
+        self._nodes = {}
+        self._idx_to_node_id = []
+
+    @classmethod
+    def class_name(cls) -> str:
+        return "TurboQuantVectorStore"
+
+    @classmethod
+    def from_params(cls, dim: int, bit_width: int = 4) -> "TurboQuantVectorStore":
+        return cls(index=TurboQuantIndex(dim, bit_width))
+
+    @property
+    def client(self) -> TurboQuantIndex:
+        return self._index
+
+    def add(self, nodes: list[BaseNode], **_: Any) -> list[str]:
+        if not nodes:
+            return []
+        embeddings = [node.get_embedding() for node in nodes]
+        vectors = np.asarray(embeddings, dtype=np.float32)
+        if vectors.ndim != 2 or vectors.shape[1] != self._index.dim:
+            raise ValueError(
+                f"node embedding dim {vectors.shape[1]} does not match index dim {self._index.dim}"
+            )
+        if not vectors.flags["C_CONTIGUOUS"]:
+            vectors = np.ascontiguousarray(vectors)
+        self._index.add(vectors)
+
+        ids: list[str] = []
+        for node in nodes:
+            nid = node.node_id
+            self._idx_to_node_id.append(nid)
+            self._nodes[nid] = {
+                "text": node.get_content(metadata_mode=MetadataMode.NONE),
+                "metadata": dict(node.metadata),
+                "ref_doc_id": node.ref_doc_id,
+            }
+            ids.append(nid)
+        return ids
+
+    def delete(self, ref_doc_id: str, **_: Any) -> None:
+        raise NotImplementedError(
+            "TurboQuantVectorStore does not support deletion. "
+            "Rebuild the store from the remaining nodes."
+        )
+
+    def query(self, query: VectorStoreQuery, **_: Any) -> VectorStoreQueryResult:
+        if query.query_embedding is None:
+            raise ValueError(
+                "TurboQuantVectorStore requires a pre-computed query_embedding "
+                "(is_embedding_query=True)."
+            )
+        qvec = np.asarray(query.query_embedding, dtype=np.float32)
+        if qvec.ndim == 1:
+            qvec = qvec[None, :]
+        if not qvec.flags["C_CONTIGUOUS"]:
+            qvec = np.ascontiguousarray(qvec)
+
+        k = min(query.similarity_top_k, len(self._index))
+        if k == 0:
+            return VectorStoreQueryResult(nodes=[], similarities=[], ids=[])
+
+        scores, indices = self._index.search(qvec, k)
+
+        result_nodes: list[TextNode] = []
+        similarities: list[float] = []
+        ids: list[str] = []
+        for score, idx in zip(scores[0], indices[0]):
+            nid = self._idx_to_node_id[int(idx)]
+            state = self._nodes[nid]
+            node = TextNode(
+                id_=nid,
+                text=state["text"],
+                metadata=dict(state["metadata"]),
+            )
+            if state["ref_doc_id"] is not None:
+                node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(
+                    node_id=state["ref_doc_id"]
+                )
+            result_nodes.append(node)
+            similarities.append(float(score))
+            ids.append(nid)
+
+        return VectorStoreQueryResult(nodes=result_nodes, similarities=similarities, ids=ids)
+
+    def persist(self, persist_path: str, fs: Any = None) -> None:
+        if fs is not None:
+            raise NotImplementedError("fsspec filesystems are not supported yet; pass a local path.")
+        folder = Path(persist_path)
+        folder.mkdir(parents=True, exist_ok=True)
+        self._index.write(str(folder / _INDEX_FILENAME))
+        with open(folder / _STORE_FILENAME, "wb") as f:
+            pickle.dump({"nodes": self._nodes, "idx_to_node_id": self._idx_to_node_id}, f)
+
+    @classmethod
+    def from_persist_path(
+        cls,
+        persist_path: str,
+        fs: Any = None,
+        *,
+        allow_dangerous_deserialization: bool = False,
+    ) -> "TurboQuantVectorStore":
+        if fs is not None:
+            raise NotImplementedError("fsspec filesystems are not supported yet; pass a local path.")
+        if not allow_dangerous_deserialization:
+            raise ValueError(
+                "from_persist_path uses pickle to deserialize the node store, which is "
+                "unsafe with untrusted input. Pass allow_dangerous_deserialization=True "
+                "to confirm you trust the source of persist_path."
+            )
+        folder = Path(persist_path)
+        index = TurboQuantIndex.load(str(folder / _INDEX_FILENAME))
+        with open(folder / _STORE_FILENAME, "rb") as f:
+            state = pickle.load(f)
+        store = cls(index=index)
+        store._nodes = state["nodes"]
+        store._idx_to_node_id = state["idx_to_node_id"]
+        return store
+
+
+__all__ = ["TurboQuantVectorStore"]

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -80,7 +80,7 @@ impl TurboQuantIndex {
 }
 
 #[pymodule]
-fn turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
+fn _turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TurboQuantIndex>()?;
     Ok(())
 }

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("langchain_core")
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+
+from turbovec import TurboQuantIndex
+from turbovec.langchain import TurboQuantVectorStore
+
+
+class StubEmbeddings(Embeddings):
+    """Deterministic text->vector function for tests.
+
+    Hashes the input string to seed an RNG, producing a reproducible
+    unit-norm vector. Similar strings do not map to similar vectors —
+    that's fine for structural tests, and callers shouldn't rely on
+    semantic ordering here.
+    """
+
+    def __init__(self, dim: int = 64) -> None:
+        self.dim = dim
+
+    def _embed(self, text: str) -> list[float]:
+        rng = np.random.default_rng(abs(hash(text)) % (2**32))
+        v = rng.standard_normal(self.dim).astype(np.float32)
+        v /= np.linalg.norm(v) + 1e-9
+        return v.tolist()
+
+    def embed_documents(self, texts):
+        return [self._embed(t) for t in texts]
+
+    def embed_query(self, text):
+        return self._embed(text)
+
+
+def test_from_texts_infers_dim_and_indexes():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["apple", "banana", "cherry", "date"], emb, bit_width=4
+    )
+    assert len(store._idx_to_id) == 4
+    assert store._index.dim == 64
+    assert store._index.bit_width == 4
+
+
+def test_similarity_search_returns_documents():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["a", "b", "c"], emb, bit_width=4)
+    results = store.similarity_search("a", k=2)
+    assert len(results) == 2
+    assert all(isinstance(r, Document) for r in results)
+
+
+def test_metadata_roundtrip():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["hello", "world"],
+        emb,
+        metadatas=[{"source": "a"}, {"source": "b"}],
+        bit_width=4,
+    )
+    scored = store.similarity_search_with_score("hello", k=2)
+    assert len(scored) == 2
+    sources = {doc.metadata["source"] for doc, _ in scored}
+    assert sources == {"a", "b"}
+
+
+def test_add_texts_uses_provided_ids():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts([], emb, dim=64, bit_width=4)
+    returned = store.add_texts(["x", "y"], ids=["id-x", "id-y"])
+    assert returned == ["id-x", "id-y"]
+    assert set(store._docs.keys()) == {"id-x", "id-y"}
+
+
+def test_k_larger_than_ntotal_is_clamped():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["one", "two"], emb, bit_width=4)
+    results = store.similarity_search("one", k=100)
+    assert len(results) == 2
+
+
+def test_empty_store_search_returns_empty():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts([], emb, dim=64, bit_width=4)
+    assert store.similarity_search("anything", k=5) == []
+
+
+def test_save_and_load_roundtrip(tmp_path):
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["one", "two", "three"],
+        emb,
+        metadatas=[{"n": 1}, {"n": 2}, {"n": 3}],
+        bit_width=4,
+    )
+    store.save_local(tmp_path)
+
+    loaded = TurboQuantVectorStore.load_local(
+        tmp_path, emb, allow_dangerous_deserialization=True
+    )
+    assert len(loaded._docs) == 3
+    results = loaded.similarity_search("one", k=3)
+    assert {doc.page_content for doc in results} == {"one", "two", "three"}
+
+
+def test_load_local_refuses_without_flag(tmp_path):
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
+    store.save_local(tmp_path)
+    with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
+        TurboQuantVectorStore.load_local(tmp_path, emb)
+
+
+def test_delete_not_supported():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(["x"], emb, bit_width=4)
+    with pytest.raises(NotImplementedError):
+        store.delete(["some-id"])
+
+
+def test_mismatched_dim_raises():
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore(emb, index=TurboQuantIndex(32, 4))
+    with pytest.raises(ValueError, match="embedding dimension"):
+        store.add_texts(["hi"])

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("llama_index.core")
+
+from llama_index.core.schema import NodeRelationship, RelatedNodeInfo, TextNode
+from llama_index.core.vector_stores.types import VectorStoreQuery
+
+from turbovec import TurboQuantIndex
+from turbovec.llama_index import TurboQuantVectorStore
+
+
+def _unit_vec(seed: int, dim: int) -> list[float]:
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal(dim).astype(np.float32)
+    v /= np.linalg.norm(v) + 1e-9
+    return v.tolist()
+
+
+def _make_node(text: str, seed: int, dim: int = 64, metadata: dict | None = None,
+               ref_doc_id: str | None = None) -> TextNode:
+    node = TextNode(text=text, metadata=metadata or {}, embedding=_unit_vec(seed, dim))
+    if ref_doc_id is not None:
+        node.relationships[NodeRelationship.SOURCE] = RelatedNodeInfo(node_id=ref_doc_id)
+    return node
+
+
+def test_from_params_creates_index():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    assert store._index.dim == 64
+    assert store._index.bit_width == 4
+    assert store.stores_text is True
+    assert store.is_embedding_query is True
+
+
+def test_add_and_query_returns_nodes():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [_make_node(f"doc {i}", seed=i) for i in range(5)]
+    ids = store.add(nodes)
+    assert len(ids) == 5
+    assert set(ids) == {n.node_id for n in nodes}
+
+    query = VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=3)
+    result = store.query(query)
+    assert len(result.nodes) == 3
+    assert len(result.similarities) == 3
+    assert len(result.ids) == 3
+    assert all(isinstance(n, TextNode) for n in result.nodes)
+
+
+def test_metadata_and_text_roundtrip():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("hello world", seed=1, metadata={"source": "a", "page": 7}),
+        _make_node("goodbye world", seed=2, metadata={"source": "b", "page": 12}),
+    ]
+    store.add(nodes)
+
+    result = store.query(VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=2))
+    texts = {n.get_content() for n in result.nodes}
+    assert texts == {"hello world", "goodbye world"}
+    sources = {n.metadata["source"] for n in result.nodes}
+    assert sources == {"a", "b"}
+
+
+def test_ref_doc_id_preserved_through_query():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_node("child text", seed=3, ref_doc_id="parent-doc-123")
+    store.add([node])
+
+    result = store.query(VectorStoreQuery(query_embedding=_unit_vec(3, 64), similarity_top_k=1))
+    returned = result.nodes[0]
+    assert returned.ref_doc_id == "parent-doc-123"
+
+
+def test_empty_query_returns_empty():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    result = store.query(VectorStoreQuery(query_embedding=_unit_vec(0, 64), similarity_top_k=5))
+    assert result.nodes == []
+    assert result.similarities == []
+    assert result.ids == []
+
+
+def test_k_larger_than_ntotal_is_clamped():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("a", seed=1), _make_node("b", seed=2)])
+    result = store.query(VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=100))
+    assert len(result.nodes) == 2
+
+
+def test_query_without_embedding_raises():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("a", seed=1)])
+    with pytest.raises(ValueError, match="query_embedding"):
+        store.query(VectorStoreQuery(query_embedding=None, similarity_top_k=1))
+
+
+def test_mismatched_dim_raises():
+    store = TurboQuantVectorStore(index=TurboQuantIndex(32, 4))
+    with pytest.raises(ValueError, match="embedding dim"):
+        store.add([_make_node("x", seed=1, dim=64)])
+
+
+def test_persist_and_from_persist_path_roundtrip(tmp_path):
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    nodes = [
+        _make_node("one", seed=1, metadata={"n": 1}),
+        _make_node("two", seed=2, metadata={"n": 2}),
+        _make_node("three", seed=3, metadata={"n": 3}),
+    ]
+    store.add(nodes)
+    store.persist(str(tmp_path))
+
+    loaded = TurboQuantVectorStore.from_persist_path(
+        str(tmp_path), allow_dangerous_deserialization=True
+    )
+    result = loaded.query(VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=3))
+    assert {n.get_content() for n in result.nodes} == {"one", "two", "three"}
+
+
+def test_from_persist_path_refuses_without_flag(tmp_path):
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("x", seed=1)])
+    store.persist(str(tmp_path))
+    with pytest.raises(ValueError, match="allow_dangerous_deserialization"):
+        TurboQuantVectorStore.from_persist_path(str(tmp_path))
+
+
+def test_delete_not_supported():
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    store.add([_make_node("x", seed=1, ref_doc_id="parent-1")])
+    with pytest.raises(NotImplementedError):
+        store.delete("parent-1")


### PR DESCRIPTION
## Summary
- Adds drop-in `TurboQuantVectorStore` for both LangChain (`from turbovec.langchain import TurboQuantVectorStore`) and LlamaIndex (`from turbovec.llama_index import TurboQuantVectorStore`), gated behind optional extras.
- Restructures `turbovec-python` to maturin's mixed layout so Python modules can ship alongside the pyo3 cdylib. Public API unchanged — `from turbovec import TurboQuantIndex` still works via `__init__.py` re-export.
- README Python section gains LangChain and LlamaIndex usage snippets.

## What users get

\`\`\`bash
pip install turbovec[langchain]   # or turbovec[llama-index]
\`\`\`

**LangChain** — full \`VectorStore\` contract: \`add_texts\`, \`similarity_search(_with_score)\`, \`similarity_search_by_vector\`, \`from_texts\`, \`save_local\`, \`load_local\`. \`delete()\` raises \`NotImplementedError\` (rebuild rather than tombstone for now). \`load_local\` requires \`allow_dangerous_deserialization=True\`.

**LlamaIndex** — \`BasePydanticVectorStore\` subclass: \`add\`, \`query\`, \`persist\`, \`from_persist_path\`, \`from_params\` factory. \`stores_text=True\`, \`is_embedding_query=True\`. \`ref_doc_id\` preserved through the round-trip. \`delete()\` raises \`NotImplementedError\`.

## Package restructure (prerequisite)

The previous layout shipped a pure pyo3 cdylib named \`turbovec.so\` with no room for Python source files. The new layout:

\`\`\`
turbovec/
  __init__.py         re-exports TurboQuantIndex
  _turbovec.so        pyo3 extension (renamed to avoid collision)
  langchain.py        optional, needs [langchain] extra
  llama_index.py      optional, needs [llama-index] extra
\`\`\`

## Tests

21 pytest tests across both integrations, skipped gracefully if the optional extra isn't installed.

\`\`\`bash
cd turbovec-python
python -m venv .venv && source .venv/bin/activate
pip install maturin pytest numpy langchain-core llama-index-core
maturin develop --release
pytest tests/ -v
\`\`\`

All 21 green locally.

## Test plan
- [x] \`cargo check\` — Rust side still compiles with cdylib rename
- [x] \`maturin develop --release\` — mixed layout builds cleanly
- [x] \`pytest tests/test_langchain.py\` — 10/10 passing
- [x] \`pytest tests/test_llama_index.py\` — 11/11 passing
- [ ] Manual smoke test with a real HuggingFace embedding model (optional before merge)

## Out of scope
- Haystack \`DocumentStore\` adapter — next PR.
- GPU support — separate track, likely Triton kernel in Python.
- Deletion by id / tombstoning — intentionally deferred; rebuilding is the supported workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)