### PR TITLE
security: collaboration hardening ahead of inviting write collaborators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,20 +23,20 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install OpenBLAS
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
 
       - name: turbovec test suite
-        run: cargo test -p turbovec --release
+        run: cargo test -p turbovec --release --locked
 
       # Standalone cargo project that path-deps turbovec — exercises the same
       # link path a downstream `cargo add turbovec` user hits. Catches BLAS
       # link-propagation regressions of the class fixed in #69.
       - name: Downstream consumer smoke test
-        run: cargo run --release --manifest-path examples/downstream-smoke/Cargo.toml
+        run: cargo run --release --locked --manifest-path examples/downstream-smoke/Cargo.toml
 
   python:
     name: Python (${{ matrix.os }})
@@ -46,9 +46,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
@@ -65,7 +65,7 @@ jobs:
       - name: Build turbovec wheel
         shell: bash
         working-directory: turbovec-python
-        run: maturin build --release --out dist
+        run: maturin build --release --locked --out dist
 
       # Install the freshly-built wheel + the four integration extras so the
       # haystack / langchain / llama-index / agno test files run instead of

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -6,8 +6,7 @@ on:
       - "v*"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   crates-io:
@@ -18,20 +17,21 @@ jobs:
       name: crates-io
       url: https://crates.io/crates/turbovec
     permissions:
-      id-token: write
+      contents: read # checkout the tagged tree (job perms replace top-level {})
+      id-token: write # OIDC → crates.io trusted publishing token
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install openblas for tests and cargo publish verification
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
       # `cargo publish` only does a verification *build*; run the test
       # suite first so a tag on a commit that compiles but fails tests
       # cannot publish.
       - name: Run tests before publish
-        run: cargo test -p turbovec --release
+        run: cargo test -p turbovec --release --locked
       - name: Authenticate with crates.io
         id: auth
-        uses: rust-lang/crates-io-auth-action@v1
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
       - name: Publish turbovec
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-        run: cargo publish -p turbovec
+        run: cargo publish -p turbovec --locked

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -6,8 +6,7 @@ on:
       - "py-v*"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   linux:
@@ -16,21 +15,24 @@ jobs:
     # is native and the in-container `apt-get install libopenblas-dev`
     # picks up the right openblas variant without cross-compile gymnastics.
     runs-on: ${{ matrix.target == 'aarch64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    # Build/test only: reads the checked-out tree, needs no write scopes.
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
         target: [x86_64, aarch64]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.target }}
           manylinux: manylinux_2_28
-          args: --release --out dist
+          args: --release --locked --out dist
           working-directory: turbovec-python
           before-script-linux: |
             if command -v dnf >/dev/null 2>&1; then
@@ -62,7 +64,7 @@ jobs:
       # publishes wheels for the interpreter; otherwise falls back to an
       # import-only check of the extension module.
       - name: Set up Python 3.9 and 3.14
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: |
             3.9
@@ -85,7 +87,7 @@ jobs:
             fi
           done
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheels-linux-${{ matrix.target }}
           path: turbovec-python/dist
@@ -93,16 +95,18 @@ jobs:
   macos:
     name: macOS aarch64
     runs-on: macos-14
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: aarch64
-          args: --release --out dist
+          args: --release --locked --out dist
           working-directory: turbovec-python
       # Same rationale as the linux job: install the freshly-built wheel
       # and run the test suite so linkage regressions that only surface at
@@ -116,7 +120,7 @@ jobs:
           python -m pip install dist/*.whl
           python -m pytest tests/ -v
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheels-macos-aarch64
           path: turbovec-python/dist
@@ -124,16 +128,18 @@ jobs:
   windows:
     name: Windows x64
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Build wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: x64
-          args: --release --out dist
+          args: --release --locked --out dist
           working-directory: turbovec-python
       - name: Install wheel and run tests
         shell: bash
@@ -144,7 +150,7 @@ jobs:
           python -m pip install dist/*.whl
           python -m pytest tests/ -v
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: wheels-windows-x64
           path: turbovec-python/dist
@@ -152,13 +158,15 @@ jobs:
   sdist:
     name: sdist
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - name: Build sdist
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           command: sdist
           args: --out dist
@@ -179,7 +187,7 @@ jobs:
           python -m pip install dist/*.tar.gz
           python -m pytest tests/ -v
       - name: Upload sdist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sdist
           path: turbovec-python/dist
@@ -193,13 +201,14 @@ jobs:
       name: pypi
       url: https://pypi.org/project/turbovec
     permissions:
-      id-token: write
+      contents: read # checkout context + same-run download-artifact
+      id-token: write # OIDC trusted publishing to PyPI
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           merge-multiple: true
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
         with:
           packages-dir: dist

--- a/examples/downstream-smoke/Cargo.lock
+++ b/examples/downstream-smoke/Cargo.lock
@@ -19,37 +19,28 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -80,19 +71,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8f1e641542c07631228b1e0dc04b69ae3c1d58ef65d5691a439711d805c698"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -100,18 +82,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -120,30 +102,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "dbgf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ca96b45ca70b8045e0462f191bd209fcb3c3bfe8dbfb1257ada54c4dd59169"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "downstream-smoke"
@@ -179,9 +141,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "enum-as-inner"
@@ -192,7 +154,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -221,7 +183,7 @@ checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -232,7 +194,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -405,16 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c81fb5260e37854d09d5c87183309fd8c555b75289427884b25660bc87a85e"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,9 +398,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -474,9 +426,9 @@ checksum = "b0bdabb30db18805d5290b3da7ceaccbddba795620b86c02145d688e04900a73"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+checksum = "3f607c237553f086e7043417a51df26b2eb899d3caff94e6a67592ff992fedc7"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -484,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "nalgebra"
@@ -514,7 +466,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -617,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -688,9 +640,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -698,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -708,32 +660,31 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
- "sha2",
 ]
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
 
 [[package]]
 name = "portable-atomic-util"
@@ -755,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -803,18 +754,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -917,9 +868,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -927,33 +878,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -983,9 +923,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1023,12 +974,12 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "turbovec"
-version = "0.7.0"
+version = "0.9.0"
 dependencies = [
  "faer",
  "ndarray",
@@ -1042,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -1116,20 +1067,20 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]


### PR DESCRIPTION
## Context

Ahead of inviting Write collaborators, a four-agent security audit swept the CI/release supply chain. This is the Stage-2 "collaboration hardening" PR: file-based hardening of the three existing workflows so an untrusted contributor (or a compromised upstream action) has the smallest possible blast radius. No repo settings, no new workflows, no package/benchmark code touched.

## What this PR changes

Three mechanical hardening changes across `ci.yml`, `release-pypi.yml`, `release-crates.yml`.

### 1. SHA-pin every third-party action

Previously nothing was SHA-pinned; two actions were branch-pinned (`pypa/gh-action-pypi-publish@release/v1`, `rust-lang/crates-io-auth-action@v1`). Every `uses:` is now pinned to a full 40-hex commit SHA with a trailing `# vX.Y.Z` comment so Dependabot can still bump it. Branch-pinned actions are pinned to their **latest stable release tag's** commit — not the moving branch head. Every SHA below was re-resolved live against the upstream repo for this PR.

| Action | Was | Resolved commit SHA | Version |
|---|---|---|---|
| actions/checkout | `@v4` | `11d5960a326750d5838078e36cf38b85af677262` | v4.4.0 |
| actions/setup-python | `@v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| actions/upload-artifact | `@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| actions/download-artifact | `@v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| PyO3/maturin-action | `@v1` | `e83996d129638aa358a18fbd1dfb82f0b0fb5d3b` | v1.51.0 |
| pypa/gh-action-pypi-publish | `@release/v1` (branch) | `ba38be9e461d3875417946c167d0b5f3d385a247` | v1.14.1 |
| rust-lang/crates-io-auth-action | `@v1` | `c6f97d42243bad5fab37ca0427f495c86d5b1a18` | v1.0.5 |

### 2. Least-privilege `permissions:` blocks

The default workflow token was already read-only; these blocks make the intent explicit and minimal. Release-workflow permissions are **tag-triggered and cannot be exercised by CI**, so the changes below are validated by reasoning + `actionlint`, **not** a live release — where uncertain, a scope was kept rather than risk breaking the next real release.

| Workflow / job | Final permissions | Justification |
|---|---|---|
| **ci.yml** (top-level) | `contents: read` | Already correct; verified. No job needs more (build + test only). |
| **release-pypi.yml** (top-level) | `{}` | Default deny; each job opts in. |
| release-pypi `linux` / `macos` / `windows` / `sdist` | `contents: read` | Checkout + native build + wheel/sdist smoke test; artifact **upload** uses `ACTIONS_RUNTIME_TOKEN`, not `GITHUB_TOKEN` scopes. |
| release-pypi `release` (publish) | `contents: read` + `id-token: write` | `id-token: write` for OIDC trusted publishing to PyPI. `contents: read` kept as a safe baseline (job context; harmless read-only). **No `actions: read`** — `download-artifact@v4` in the *same run* uses `ACTIONS_RUNTIME_TOKEN`; `actions: read` is only needed for cross-run downloads via `run-id`, which this job does not do. Not over-granted. |
| **release-crates.yml** (top-level) | `{}` | Default deny. |
| release-crates `crates-io` (publish) | `contents: read` + `id-token: write` | `id-token: write` for OIDC → crates.io trusted-publishing token. The audit found the job set only `id-token: write`; because job-level perms **replace** the top-level block, once top-level became `{}` the job would have lost `contents: read` and `checkout` would fail. `contents: read` is added back. |

### 3. `--locked` on every cargo/maturin build invocation

`Cargo.lock` is committed. Adding `--locked` means a PR that edits only `Cargo.toml` cannot silently resolve a different transitive dependency into a CI or release build.

| Workflow | Invocation | Now |
|---|---|---|
| ci.yml | `cargo test -p turbovec --release` | `… --release --locked` |
| ci.yml | `cargo run --release --manifest-path examples/downstream-smoke/Cargo.toml` | `cargo run --release --locked --manifest-path …` |
| ci.yml | `maturin build --release --out dist` | `maturin build --release --locked --out dist` |
| release-pypi.yml (linux/macos/windows) | maturin-action `args: --release --out dist` | `args: --release --locked --out dist` |
| release-crates.yml | `cargo test -p turbovec --release` | `… --release --locked` |
| release-crates.yml | `cargo publish -p turbovec` | `cargo publish -p turbovec --locked` |

**`maturin sdist` intentionally left unchanged:** verified against `maturin 1.12.6` — the `sdist` subcommand accepts no `--locked`/`--frozen` flag (it does not compile, it only packages source), so adding one would break the sdist job. `maturin build` does accept `--locked`, and it is applied there.

**`--locked` immediately caught a drifted lockfile (the guard doing its job).** The first CI run failed the three Rust jobs on `cargo run --release --locked --manifest-path examples/downstream-smoke/Cargo.toml`: the standalone downstream-smoke example's committed `Cargo.lock` still pinned `turbovec 0.7.0` while the crate is now `0.9.0` (it had been showing as modified in the working tree since before this work). This is exactly the class of drift `--locked` exists to catch. Fixed by regenerating that lockfile (`cargo generate-lockfile`) so it matches its manifest — committed as part of this PR, not worked around by dropping `--locked`. The main workspace `Cargo.lock` was already in sync. Verified locally that the downstream-smoke `--locked` run and the workspace `--locked` build both pass after the sync.

### CHANGELOG

Omitted, per repo convention. The CHANGELOG's Unreleased surfaces are `turbovec — Rust crate`, `turbovec — Python package`, `Benchmarks`, and `Docs` — every entry describes a change to a shipped or user-facing surface (e.g. the #108 security work landed under the Rust-crate surfaces because it changed shipped code). This PR changes only `.github/workflows/` — no crate code, no Python package, no benchmark script, no docs, and there is no CI/infra surface to file it under. Happy to add a line if you'd prefer one.

## Applied separately as repo *settings* (not in this PR)

A PR cannot change repository configuration, so these are being applied out-of-band and are listed here so reviewers see the whole picture:

- **Required-reviewer + tag deployment-branch policy** on the `pypi` and `crates-io` environments, so a publish is gated on a maintainer approval and can only run from a release tag.
- **Ruleset consolidation** on `main` (branch protection / required checks).
- **Dependabot** for GitHub Actions (so the SHA pins above get bumped) and Cargo.
- **Wiki disabled** (reduce writable surface for new collaborators).

## Separate follow-up PR (kept out of this one)

Per repo convention (ship the fix; flag regression-prevention infra separately), the **regression/detection infrastructure is a distinct Stage-3 PR** and is deliberately **not** created here:

- `security-audit.yml` (e.g. scheduled CodeQL / permissions audit).
- `supply-chain.yml` running `cargo-deny` + `pip-audit`.

## Residuals consciously accepted

- **Non-`main` branch force-push** remains allowed (only `main` is protected) — acceptable for topic branches.
- **Release-asset edits** post-publish remain possible for maintainers.
- **RUSTSEC-2024-0436** (`paste` unmaintained) — informational advisory, no fix available upstream, no action taken.

## Validation

- `actionlint` 1.7.12: clean (exit 0) on all three workflows.
- `python -c "yaml.safe_load(...)"`: all three parse.
- ci.yml changes (SHA pins, `contents: read`, `--locked`) are **live-exercised by this PR's own CI run**. Release-workflow changes are reasoned + actionlint-verified only (tag-triggered, not runnable from a PR).

Awaiting maintainer review — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
