### PR TITLE
ci: Stage-3 detection — supply-chain (cargo-deny + pip-audit) and workflow security audit (zizmor)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Install OpenBLAS
         if: runner.os == 'Linux'
@@ -47,6 +49,8 @@ jobs:
         os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -21,6 +21,8 @@ jobs:
       id-token: write # OIDC → crates.io trusted publishing token
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - name: Install openblas for tests and cargo publish verification
         run: sudo apt-get update && sudo apt-get install -y libopenblas-dev pkg-config
       # `cargo publish` only does a verification *build*; run the test

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -24,6 +24,8 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
@@ -99,6 +101,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
@@ -132,6 +136,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
@@ -162,6 +168,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,58 @@
+name: Security audit
+
+# Static security audit of the GitHub Actions workflows themselves (zizmor):
+# unpinned actions, over-broad token permissions, template-injection sinks,
+# credential-persisting checkouts, cache poisoning, and similar CI/CD supply-
+# chain footguns. Runs on any workflow change and weekly.
+#
+# Source-code static analysis (CodeQL) is handled separately via GitHub's
+# CodeQL "default setup" (Settings → Security → Code scanning), which
+# auto-manages its own pinned workflow and covers Python out of the box —
+# see this PR's description for the rationale.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+  schedule:
+    # Weekly, Monday 06:37 UTC — offset from the supply-chain cron so the two
+    # scheduled audits don't contend for a runner at the same minute.
+    - cron: "37 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  actions-audit:
+    name: GitHub Actions audit (zizmor)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+      - name: Install zizmor
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install zizmor
+      # `--offline` keeps the audit hermetic (no GitHub API calls, no token
+      # needed). Non-gating for now (continue-on-error) so a newly-shipped
+      # zizmor lint can't wedge unrelated PRs; the baseline is clean today, so
+      # this can be tightened to a hard gate once it has proven stable.
+      - name: Run zizmor
+        continue-on-error: true
+        run: |
+          zizmor --version
+          zizmor --offline --persona regular .github/workflows/

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,0 +1,101 @@
+name: Supply chain
+
+# Dependency-vulnerability scanning for both language surfaces:
+#   - cargo-deny  → RustSec advisories + supply-chain hygiene for the crate
+#   - pip-audit   → known-vuln scan for the Python package's dependencies
+# Runs when a dependency manifest changes, and weekly to catch advisories
+# disclosed against dependencies that haven't otherwise moved.
+
+on:
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "turbovec-python/pyproject.toml"
+      - "deny.toml"
+      - ".github/workflows/supply-chain.yml"
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "turbovec-python/pyproject.toml"
+      - "deny.toml"
+      - ".github/workflows/supply-chain.yml"
+  schedule:
+    # Weekly, Monday 06:17 UTC. Odd minute to dodge the top-of-hour scheduler
+    # congestion GitHub warns about for cron-triggered workflows.
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  cargo-deny:
+    name: cargo-deny (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      # cargo-deny reads Cargo.toml / Cargo.lock metadata only — it never
+      # builds the crate, so no OpenBLAS or extra toolchain beyond the
+      # preinstalled cargo is required.
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+      # advisories → RustSec vulnerabilities + yanked crates.
+      # bans        → duplicate/ wildcard hygiene (non-fatal, see deny.toml).
+      # sources     → reject crates from unexpected registries or git.
+      # Licenses are compliance, not security, and are deliberately excluded.
+      - name: cargo-deny check
+        run: cargo deny check advisories bans sources
+
+  pip-audit:
+    name: pip-audit (Python)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+      - name: Install pip-audit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pip-audit
+      # Gate on the one hard runtime dependency turbovec ships. `-r` resolves
+      # and audits the closure of just this requirement set, isolated from the
+      # tooling installed above, so the gate reflects turbovec's deps alone.
+      - name: Audit core runtime dependency
+        run: |
+          echo "numpy>=1.20" > "${RUNNER_TEMP}/core-requirements.txt"
+          pip-audit -r "${RUNNER_TEMP}/core-requirements.txt" --progress-spinner off
+      # The four framework integrations are optional extras (mirrors
+      # [project.optional-dependencies] in turbovec-python/pyproject.toml).
+      # Their transitive closures are large and churn independently of
+      # turbovec, so audit them for visibility but do not gate the check on
+      # upstream advisories that nobody here can action.
+      - name: Audit optional integration extras (informational)
+        continue-on-error: true
+        run: |
+          {
+            echo "numpy>=1.20"
+            echo "langchain-core>=0.3"
+            echo "llama-index-core>=0.11"
+            echo "haystack-ai>=2.23.0"
+            echo "agno>=2.5.4"
+          } > "${RUNNER_TEMP}/extras-requirements.txt"
+          pip-audit -r "${RUNNER_TEMP}/extras-requirements.txt" --progress-spinner off

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,54 @@
+# cargo-deny configuration — supply-chain gate for the Rust crate.
+# Enforced in CI by .github/workflows/supply-chain.yml (advisories, bans,
+# sources). Schema: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Audit the whole dependency graph, including the target- and feature-gated
+# BLAS variants of `ndarray` pulled in on linux/macos.
+all-features = true
+
+[advisories]
+version = 2
+# New RustSec advisories filed against already-pinned dependencies are the
+# main thing the weekly scheduled run exists to surface. Keep this list tight
+# and documented — every entry is a consciously accepted residual.
+ignore = [
+    # `paste` is unmaintained (RUSTSEC-2024-0436): an informational advisory,
+    # not a runtime vulnerability. No maintained drop-in exists upstream and
+    # it arrives transitively. Accepted in #218; revisit if a successor lands.
+    "RUSTSEC-2024-0436",
+
+    # ---------------------------------------------------------------------
+    # TRIAGED BASELINE — remediate in a dedicated follow-up PR, then delete.
+    # These advisories predate this workflow; they are ignored here only so
+    # the gate lands green against today's tree while still catching anything
+    # NEW. Each has a known fix and should be cleared, not kept.
+    # ---------------------------------------------------------------------
+    # pyo3 0.27.2 → fixed in >=0.29.0 (via a rust-numpy bump). Touches the
+    # shipped extension module, so it belongs in its own reviewed PR.
+    "RUSTSEC-2026-0176", # OOB read in PyList/PyTuple nth/nth_back iterators
+    "RUSTSEC-2026-0177", # missing Sync bound on PyCFunction::new_closure
+    # crossbeam-epoch 0.9.18 → fixed in >=0.9.20 (transitive via faer).
+    # Lockfile-only `cargo update -p crossbeam-epoch`.
+    "RUSTSEC-2026-0204", # invalid pointer deref in fmt::Pointer for Atomic/Shared
+    # rand 0.8.5 → fixed in >=0.8.6 (within the pinned 0.8 line).
+    # Lockfile-only `cargo update -p rand`.
+    "RUSTSEC-2026-0097", # unsoundness with a custom logger using rand::rng()
+]
+
+[bans]
+# Duplicate transitive versions are a hygiene signal, not a security failure —
+# surface them in the log without failing the gate.
+multiple-versions = "warn"
+wildcards = "warn"
+
+[sources]
+# crates.io is the only expected source. An unknown registry or a git
+# dependency slipping into the tree is a supply-chain red flag, so fail on it.
+unknown-registry = "deny"
+unknown-git = "deny"
+
+# NB: license compliance is intentionally out of scope for this file. It is a
+# legal/compliance concern rather than a security one, and an allow-list is the
+# single biggest source of false CI failures; `cargo deny check` is invoked
+# here with `advisories bans sources`, never `licenses`.


### PR DESCRIPTION
## Related issue

No tracked issue — this is the **Stage-3 detection infrastructure** explicitly deferred from #218 ("Separate follow-up PR (kept out of this one)"), landed ahead of onboarding Write collaborators.

## Summary

- **`.github/workflows/supply-chain.yml`** — dependency-vulnerability scanning for both language surfaces:
  - `cargo-deny` → RustSec **advisories** + **bans** + **sources** for the crate (licenses intentionally excluded — that's compliance, not security).
  - `pip-audit` → known-vuln scan of the Python dependencies. Gates on the one hard runtime dep (`numpy`); the four optional framework extras are audited **informationally** (`continue-on-error`) since their transitive closures churn independently of turbovec.
  - Triggers: dependency-manifest changes, plus a weekly cron to catch advisories disclosed against unmoved deps.
- **`.github/workflows/security-audit.yml`** — `zizmor` static audit of the workflows themselves (unpinned actions, over-broad token scopes, template-injection sinks, credential-persisting checkouts, cache poisoning). Non-gating for now so a newly-shipped lint can't wedge unrelated PRs; the baseline is clean today.
- **`deny.toml`** — cargo-deny config.
- **Hardening surfaced by the new audit:** `persist-credentials: false` added to all **seven** `actions/checkout` steps across `ci.yml`, `release-pypi.yml`, `release-crates.yml` (+ the two new workflows), closing zizmor's `artipacked` findings.

Both new workflows follow the #218 conventions: top-level `permissions: {}`, jobs opt into `contents: read` only, and every action is SHA-pinned.

## ⚠️ The audit found 4 real, pre-existing advisories

These exist in `main` today — this PR is just what makes them visible. To land the gate green they are in a **documented, triaged ignore-baseline** in `deny.toml` (every *new* advisory still fails the gate). Each has a known fix and should be cleared in a dedicated remediation PR:

| Advisory | Crate | Now → Fixed in | Fix |
|---|---|---|---|
| RUSTSEC-2026-0176 | pyo3 0.27.2 | ≥ 0.29.0 | rust-numpy/pyo3 minor bump — touches the shipped extension |
| RUSTSEC-2026-0177 | pyo3 0.27.2 | ≥ 0.29.0 | same bump |
| RUSTSEC-2026-0204 | crossbeam-epoch 0.9.18 | ≥ 0.9.20 | lockfile-only `cargo update -p crossbeam-epoch` |
| RUSTSEC-2026-0097 | rand 0.8.5 | ≥ 0.8.6 | lockfile-only `cargo update -p rand` |

Two are trivial lockfile bumps; the pyo3 pair is a minor upgrade of the binding worth its own reviewed PR. Happy to open that next.

## Out of scope (by design)

Source-code static analysis (CodeQL) is best handled by GitHub's **CodeQL default setup** (Settings → Security → Code scanning) rather than a hand-pinned advanced workflow — it auto-manages its own pinned workflow and covers Python out of the box, and avoids a hand-maintained SHA that would drift against the very convention #218 established. Enable it as a repo setting, alongside the ruleset/environment protections already applied out-of-band.

## Motivation

#218 hardened the CI/release supply chain but explicitly left *detection* (scheduled advisory + workflow audits) to a follow-up. This is that follow-up: it gives ongoing, automated visibility into dependency vulnerabilities and workflow misconfigurations before untrusted contributors arrive.

## Test plan

Package code is unchanged, so `cargo test` / `pytest` are unaffected. Validated the CI configuration locally:

- [x] all five workflows parse (`yaml.safe_load`)
- [x] `deny.toml` parses (`tomllib`)
- [x] `cargo-deny check advisories bans sources` → `advisories ok, bans ok, sources ok` (exit 0) with the documented baseline
- [x] `zizmor --offline .github/workflows/` → **No findings** (0) after the `persist-credentials` fixes
- [x] `pip-audit` clean on the core runtime dependency (`numpy>=1.20`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hF1nYXWsc2mKcpnEHECoj

---
_Generated by [Claude Code](https://claude.ai/code/session_015hF1nYXWsc2mKcpnEHECoj)_