### PR TITLE
ci: add Dependabot config (cargo, pip, github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+# Dependabot version updates.
+#
+# Complements the Stage-3 detection in .github/workflows/supply-chain.yml:
+# cargo-deny / pip-audit *detect* vulnerable dependencies and gate CI; this
+# file has Dependabot open the *bump PRs* that clear them. Dependabot security
+# alerts + automated security fixes are enabled at the repo level separately.
+#
+# github-actions updates keep the SHA-pinned actions (see the CI/release
+# workflows) current — Dependabot rewrites the pinned SHA and updates the
+# trailing # vX.Y.Z comment, preserving the pinning convention from #218.
+version: 2
+updates:
+  # Rust crate + workspace (root Cargo.toml / Cargo.lock).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      # Batch low-risk patch/minor bumps into one PR to cut review churn;
+      # majors still come through individually.
+      cargo-minor:
+        update-types: ["minor", "patch"]
+
+  # Python package dependencies (turbovec-python/pyproject.toml).
+  - package-ecosystem: "pip"
+    directory: "/turbovec-python"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+
+  # The GitHub Actions used across ci.yml / release-*.yml / the Stage-3
+  # workflows — all SHA-pinned, so these PRs keep the pins fresh.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` — the version-update companion to the Stage-3 supply-chain detection in #220.

- **cargo** (root workspace) — weekly; minor/patch grouped into one PR, majors individual.
- **pip** (`turbovec-python/pyproject.toml`) — weekly.
- **github-actions** — weekly; keeps the SHA-pinned actions fresh while preserving the pinning convention from #218 (Dependabot rewrites the SHA + trailing version comment).

## How it fits
`cargo-deny` / `pip-audit` (#220) *detect* vulnerable deps and gate CI; Dependabot opens the *bump PRs* that clear them — closing the loop so the #220 advisory baseline doesn't grow. Repo-level Dependabot **alerts + automated security fixes** are enabled separately (already on).

## Scope
Config only — no code or workflow changes. Nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)