### PR TITLE
deps: bump pyo3 to >=0.29 to clear RUSTSEC-2026-0176/0177

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,15 +438,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,15 +480,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "nalgebra"
@@ -678,9 +660,9 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.27.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
  "libc",
  "ndarray",
@@ -830,35 +812,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -866,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -878,13 +857,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
@@ -984,12 +962,6 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "safe_arch"
@@ -1174,12 +1146,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "version_check"

--- a/deny.toml
+++ b/deny.toml
@@ -24,10 +24,6 @@ ignore = [
     # the gate lands green against today's tree while still catching anything
     # NEW. Each has a known fix and should be cleared, not kept.
     # ---------------------------------------------------------------------
-    # pyo3 0.27.2 → fixed in >=0.29.0 (via a rust-numpy bump). Touches the
-    # shipped extension module, so it belongs in its own reviewed PR.
-    "RUSTSEC-2026-0176", # OOB read in PyList/PyTuple nth/nth_back iterators
-    "RUSTSEC-2026-0177", # missing Sync bound on PyCFunction::new_closure
     # crossbeam-epoch 0.9.18 → fixed in >=0.9.20 (transitive via faer).
     # Lockfile-only `cargo update -p crossbeam-epoch`.
     "RUSTSEC-2026-0204", # invalid pointer deref in fmt::Pointer for Atomic/Shared

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 turbovec-core = { package = "turbovec", path = "../turbovec" }
-pyo3 = { version = "0.27.0", features = ["extension-module", "abi3-py39"] }
-numpy = "0.27.0"
+pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py39"] }
+numpy = "0.29.0"
 # Same major as the core's dep, so both resolve to one rayon-core and
 # the pool built at module init is the pool the kernels use.
 rayon = "1.10"
 
 [build-dependencies]
-pyo3-build-config = "0.27.0"
+pyo3-build-config = "0.29.0"


### PR DESCRIPTION
## What

Bumps the shipped Python extension module off **pyo3 0.27.2**, which carries two open RustSec advisories that #220 baselined in `deny.toml` for a dedicated remediation PR:

- **RUSTSEC-2026-0176** — OOB read in `PyList`/`PyTuple` `nth`/`nth_back` iterators
- **RUSTSEC-2026-0177** — missing `Sync` bound on `PyCFunction::new_closure`

Both are fixed in **pyo3 ≥ 0.29.0**. pyo3 was pinned to the 0.27 line transitively by rust-numpy, so `numpy` is bumped in lockstep.

## Version changes (`turbovec-python/Cargo.toml`)

| crate | before | after |
|-------|--------|-------|
| `pyo3` | 0.27.0 | 0.29.0 |
| `numpy` | 0.27.0 | 0.29.0 |
| `pyo3-build-config` | 0.27.0 | 0.29.0 |

`Cargo.lock` resolves `pyo3` and `numpy` to **0.29.0** (and drops the now-unused `indoc`/`memoffset`/`rustversion`/`unindent` that pyo3 0.27 pulled in).

## API migration

**None required.** The binding source already used the 0.29-compatible `Bound` API throughout (`py.detach`, `Bound::cast`, `into_pyarray(py)`, `PyBytes::new(py, …)`), so `turbovec-python/src/lib.rs` compiles clean against pyo3 0.29 with **no source edits and no deprecation warnings**. The advisory-affected surfaces (`PyList`/`PyTuple` iterators, `new_closure`) are not used by the bindings; the fix is purely the dependency bump.

## deny.toml

Removes the two now-cleared entries from the triaged-baseline ignore block and updates the surrounding comment. The three unrelated deferred advisories are left untouched for their own follow-ups:

- `RUSTSEC-2024-0436` (paste, unmaintained)
- `RUSTSEC-2026-0204` (crossbeam-epoch, lockfile-only)
- `RUSTSEC-2026-0097` (rand, lockfile-only)

## Verification (ran the code)

**`maturin develop --release`** (scratch venv, Python 3.11, abi3-py39):
```
   Compiling numpy v0.29.0
   Compiling turbovec-python v0.8.0 (.../turbovec-python)
    Finished `release` profile [optimized] target(s) in 29.29s
📦 Built wheel for abi3 Python ≥ 3.9 ... turbovec-0.8.0-cp39-abi3-macosx_11_0_arm64.whl
🛠 Installed turbovec-0.8.0
```
Rebuild with `cargo build --release -p turbovec-python` after touching `lib.rs`: **0 warnings**.

**`cargo test --workspace`** — exit 0, all green, e.g.:
```
test result: ok. 6 passed; 0 failed; ...   (swap_remove.rs)
test result: ok. 2 passed; 0 failed; ...   (tqplus_calibration.rs)
   Doc-tests turbovec
test result: ok. 3 passed; 0 failed; ...
```

**`pytest` (turbovec-python/tests)**:
```
634 passed in 87.81s (0:01:27)
```

**`cargo deny check advisories`** (with 0176/0177 removed from the ignore list, cargo-deny 0.20.2):
```
advisories ok
```
Confirms 0176/0177 no longer fire now that pyo3 is 0.29; the remaining three ignored advisories still match their pinned deps.

## Scope

pyo3 bump + the `numpy` bump it forces + the two `deny.toml` ignore removals. No crossbeam-epoch/rand changes, no unrelated deps, no other cleanup.

Follows up on #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
