### PR TITLE
security: clear crossbeam-epoch (RUSTSEC-2026-0204) + stale rand baseline entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -17,19 +17,6 @@ ignore = [
     # not a runtime vulnerability. No maintained drop-in exists upstream and
     # it arrives transitively. Accepted in #218; revisit if a successor lands.
     "RUSTSEC-2024-0436",
-
-    # ---------------------------------------------------------------------
-    # TRIAGED BASELINE — remediate in a dedicated follow-up PR, then delete.
-    # These advisories predate this workflow; they are ignored here only so
-    # the gate lands green against today's tree while still catching anything
-    # NEW. Each has a known fix and should be cleared, not kept.
-    # ---------------------------------------------------------------------
-    # crossbeam-epoch 0.9.18 → fixed in >=0.9.20 (transitive via faer).
-    # Lockfile-only `cargo update -p crossbeam-epoch`.
-    "RUSTSEC-2026-0204", # invalid pointer deref in fmt::Pointer for Atomic/Shared
-    # rand 0.8.5 → fixed in >=0.8.6 (within the pinned 0.8 line).
-    # Lockfile-only `cargo update -p rand`.
-    "RUSTSEC-2026-0097", # unsoundness with a custom logger using rand::rng()
 ]
 
 [bans]


### PR DESCRIPTION
## Summary
Clears the last actionable advisory from the #220 triage baseline.

- **crossbeam-epoch 0.9.18 → 0.9.20** (`cargo update -p crossbeam-epoch`, lockfile-only) — clears **RUSTSEC-2026-0204** (invalid pointer deref in `fmt::Pointer`). Transitive via rayon (`turbovec → rayon → rayon-core → crossbeam-deque → crossbeam-epoch`); not reachable in turbovec's usage, but no reason to keep it baselined now that a fix exists.
- Removes **RUSTSEC-2026-0097** (rand) from the `deny.toml` ignore list — it was already fixed by #222 (rand 0.8.6 on main), so the entry was stale.

## Baseline after this
Only **RUSTSEC-2024-0436** (paste, unmaintained/informational, no upstream fix) remains. Every actionable advisory from the original #220 triage is now cleared — pyo3 pair (#223), rand (#222), crossbeam-epoch (here).

## Verification
`cargo deny check advisories` → **advisories ok** locally with both entries removed (confirms nothing else fires). Lockfile-only dep change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)