### PR TITLE
ci: Default @claude to Fable 5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,3 +42,4 @@ jobs:
       - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: "--model claude-fable-5"


### PR DESCRIPTION
Sets `claude_args: --model claude-fable-5` on the Claude Code workflow so `@claude` runs on Fable 5 rather than the action default (`claude-sonnet-5`).

Note: this only changes which model is used; it does **not** address the current `is_error:true` auth/usage failure the workflow is hitting on the first API call — that's tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)