### PR TITLE
ci: TEMP diagnostic — show_full_output to capture @claude error

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,3 +43,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-fable-5"
+          # TEMPORARY (diagnostic): unmask the SDK error to identify the auth
+          # failure. Revert immediately after — prints full Claude output to
+          # the public Actions log.
+          show_full_output: true


### PR DESCRIPTION
**Temporary, revert after one run.** Adds `show_full_output: true` so the next `@claude` comment prints the exact SDK error into the Actions log, instead of the masked "full output hidden for security".

We need the literal string to tell apart two causes ([search findings](https://github.com/anthropics/claude-code-action/issues/1281)):
- `OAuth token has expired` / `does not meet scope requirement` → regenerating the token fixes it.
- `Could not resolve authentication credentials` / `validateHeaders` → the known Max-OAuth propagation bug (#1281), which regeneration does **not** fix.

The failure happens on turn 1 before Claude reads any files, so the only new thing surfaced is the error itself. I'll open a revert PR immediately once we've read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)