### PR TITLE
ci: Remove diagnostic show_full_output

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,3 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: "--model claude-fable-5"
-          # TEMPORARY (diagnostic): unmask the SDK error to identify the auth
-          # failure. Revert immediately after — prints full Claude output to
-          # the public Actions log.
-          show_full_output: true


### PR DESCRIPTION
Reverts the temporary `show_full_output: true` from #239 now that we've captured the error.

**Diagnosis:** the `@claude` failure is `401 OAuth access token is invalid` — the token propagates fine to the API (so *not* the #1281 propagation bug), but the stored `CLAUDE_CODE_OAUTH_TOKEN` secret is a revoked/stale token. Fix is to regenerate via `claude setup-token` and reset the secret; no workflow change needed for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)