### PR TITLE
skill: Add summarize skill for plain-English summaries

### DIFF
--- a/.claude/skills/summarize/SKILL.md
+++ b/.claude/skills/summarize/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: summarize
+description: Write a short, plain-English summary of whatever it's attached to — an issue, a pull request, or a diff. Two or three paragraphs, no jargon, aimed at a non-expert. Use when asked to summarize or explain something simply.
+---
+
+# Summarize (plain English)
+
+Summarize whatever this is attached to — the issue, pull request, or diff.
+
+- Two or three short paragraphs. No headers, no bullet points.
+- Plain English, simple enough for a non-expert. Say what it does and why
+  it matters; skip the implementation and format details.
+- Direct and matter-of-fact. No hype, no marketing language.
+- Describe turbovec on its own terms — don't reach for comparisons to
+  other libraries to explain it.


### PR DESCRIPTION
Adds `.claude/skills/summarize/SKILL.md` — a reusable skill that produces a 2–3 paragraph, plain-English, no-hype summary of whatever it's pointed at (issue, PR, or diff).

**Usage after merge:** comment `@claude /summarize` on any issue or PR.

Since `.claude/skills/` is loaded in the `@claude` mention flow (the action checks out the repo and reads project settings), no workflow change is needed. If `/summarize` doesn't invoke the skill in a mention (the mention-mode tool allowlist is restrictive), the fallbacks are a natural-language ask (`@claude use the summarize skill to explain this`) or allowing the Skill tool via `claude_args`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)