### PR TITLE
ci: Auto-triage new issues with /intake

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -1,0 +1,45 @@
+name: Issue Intake
+
+# Auto-triage every newly opened issue with the /intake skill. Unlike the
+# @claude workflow, this fires for ANYONE (including external contributors
+# with no write access), so it is deliberately locked down: read-only
+# tools, minimal permissions, no code execution, no PR authoring.
+
+on:
+  issues:
+    types: [opened]
+
+permissions: {}
+
+# One intake run per issue; bounds fan-out if issues arrive in a burst.
+concurrency:
+  group: intake-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  intake:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10 # hard cap on subscription spend per issue
+    permissions:
+      contents: read # read the code to research the issue
+      issues: write # post the triage comment
+      id-token: write # OIDC token exchange for the Claude GitHub App
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # allowed_non_write_users requires github_token (not App/OIDC auth);
+          # '*' lets external-authored issues trigger the run. Untrusted
+          # content, so the tool set below stays read-only.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
+          prompt: "/intake"
+          claude_args: |
+            --model claude-fable-5
+            --max-turns 20
+            --allowedTools "Read,Grep,Glob,LS"


### PR DESCRIPTION
Adds `.github/workflows/intake.yml` — runs the `/intake` skill automatically on every newly opened issue.

## Design: separate and locked down
This is intentionally a **separate** workflow from `@claude`, because it fires for **anyone** who opens an issue (including external contributors with no write access), where `@claude` is owner-only and powerful. So intake is minimal:
- **Read-only tools:** `Read,Grep,Glob,LS` — no Bash, no Edit/Write, no `gh`. Even if an issue tries prompt injection, there's no execution or write path beyond posting one comment.
- **Minimal permissions:** `contents: read`, `issues: write`, `id-token: write`.
- **`allowed_non_write_users: "*"`** (with `github_token`) so external-authored issues can trigger it — this is required; automation mode still blocks non-write authors otherwise.
- **Abuse bounds:** per-issue `concurrency` group + `timeout-minutes: 10`.

## Things to verify on first run (flagged, not certain)
- **Auth stacking:** passing both `claude_code_oauth_token` (Anthropic) and `github_token` (GitHub trust) is expected to work but isn't explicitly documented — worth confirming on the first real issue. The comment may post as `github-actions[bot]` rather than `claude[bot]` because `allowed_non_write_users` forces `github_token` over App/OIDC auth.
- **Cost/abuse:** on a public repo, anyone opening issues spends your Max subscription. The timeout + read-only scope limit the blast radius; if spam becomes a problem, gate on `github.event.issue.author_association` (e.g. skip or label-only for non-collaborators).
- Ensure your Claude Code is ≥2.1.128 (read-tool `/proc` exfil hardening) — relevant since this processes untrusted input.

Depends on the `intake` skill (#242) being merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)