### PR TITLE
ci: two permission tiers for @claude (owner vs collaborator)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,13 +30,12 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
-    # Write scopes so Claude can push branches, open PRs, and comment —
-    # not just review. Matches the canonical claude-code-action example.
+    # Scopes for the collaborator tier (auto GITHUB_TOKEN): push branches,
+    # open PRs, comment — but the branch ruleset still blocks merging main.
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write # OIDC token exchange for the Claude GitHub App
       actions: read # let Claude read CI results on PRs
     steps:
       # Acknowledge immediately with 👀 so the trigger is visibly "seen",
@@ -71,14 +70,20 @@ jobs:
       - id: claude
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
-          # Authenticate the gh CLI so Claude can open/edit PRs from Bash.
-          GH_TOKEN: ${{ github.token }}
+          # gh CLI uses the same tier-selected token as the action below.
+          GH_TOKEN: ${{ github.actor_id == '10856497' && secrets.CLAUDE_OWNER_TOKEN || github.token }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Full local-parity toolset: arbitrary shell (build/test/gh/etc.),
-          # file edits, and web access. Safe because this workflow is
-          # owner-only (see the actor guard above) — do NOT widen the guard
-          # while these tools are enabled.
+          # TWO PERMISSION TIERS, selected by who triggered the run:
+          #   - Owner (actor_id 10856497): CLAUDE_OWNER_TOKEN, an admin PAT.
+          #     Can do everything the owner can — including merge PRs (bypasses
+          #     the branch ruleset). Releases stay blocked by the pypi/crates
+          #     environment required-reviewers regardless of token.
+          #   - Anyone else: the auto GITHUB_TOKEN scoped by the block above =
+          #     contributor level (push branches + PRs, but ruleset blocks merge).
+          # To let collaborators use @claude, widen the actor guard above; the
+          # token below keeps merge power owner-only automatically.
+          github_token: ${{ github.actor_id == '10856497' && secrets.CLAUDE_OWNER_TOKEN || github.token }}
           claude_args: |
             --model claude-fable-5
             --max-turns 40


### PR DESCRIPTION
## What this does

Gives the `@claude` agent **two permission tiers, chosen automatically by who triggered the run** — so `@claude` can be opened to collaborators later without handing them merge power.

| Trigger | Token used | Effective access |
|---|---|---|
| **Owner** (`github.actor_id == 10856497`) | `CLAUDE_OWNER_TOKEN` (admin PAT) | Everything the owner can do — merge PRs, push, bypass — **except** publishing releases |
| **Anyone else** | auto `GITHUB_TOKEN` (scoped by the `permissions:` block) | Write-collaborator level — push branches, open PRs, comment; **cannot merge** |

The action's `github_token` is selected with one expression:

```yaml
github_token: ${{ github.actor_id == '10856497' && secrets.CLAUDE_OWNER_TOKEN || github.token }}
```

Only the owner's runs ever receive the admin token, so **merge power stays owner-only automatically** — even after the actor guard is widened to invite collaborators.

## Why it's safe

- **Merge is gated by *your* approval, not by the token.** `.github/CODEOWNERS` (`* @RyanCodrai`) plus the `main` ruleset's `require_code_owner_review` means every PR to `main` needs *your* approval specifically. So whoever clicks merge — a collaborator, or the collaborator-tier bot — the change has already passed through you. No extra push restriction is needed.
- **Releases stay blocked for both tiers.** Publishing to PyPI/crates.io runs only in the tag-triggered release workflows, behind the `pypi` / `crates-io` environment required-reviewers. `@claude` isn't in those workflows and can't approve the environment, so it cannot publish — even owner-tier.
- **Owner tier is deliberately narrower than full admin.** The recommended `CLAUDE_OWNER_TOKEN` scope is **Contents + Pull requests + Issues (Read/Write)** — *not* Administration or Workflows. So owner-tier `@claude` can merge and push, but cannot rewrite rulesets/settings/secrets or edit CI. (Widen the PAT if you ever want literal admin parity.)

## Parity with the human roles

- **Owner tier ↔ you (admin):** matches on merge / push / comment. Intentionally *cannot* publish releases, change repo config, or edit workflows.
- **Collaborator tier ↔ Write collaborator:** matches on push branches / open PRs / comment. Merges remain behind your CODEOWNERS approval, same as for a human collaborator.

No tier is over-privileged versus its human role; the only unders are intentional (release, admin-config, CI edits).

## Setup (owner-only, one-time)

1. Create a fine-grained PAT on this repo — **Contents + Pull requests + Issues: Read/Write**.
2. Add it as a secret: `gh secret set CLAUDE_OWNER_TOKEN`.
3. Merge this PR.

## Inviting collaborators later

Widen the actor guard (currently `github.actor_id == '10856497'`) to an allow-list of IDs — the token expression keeps merge power owner-only automatically.

## Changes

- `.github/workflows/claude.yml`: tier-selected `github_token`; drop the App/OIDC (`id-token`) auth path in favor of the tier token; clarify the `permissions:` block comment as the collaborator-tier scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
