### PR TITLE
ci: give intake a tool to post its triage comment

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -54,5 +54,5 @@ jobs:
           claude_args: |
             --model claude-fable-5
             --max-turns 15
-            --allowedTools "Read,Grep,Glob,LS"
+            --allowedTools "Read,Grep,Glob,LS,mcp__github_comment__update_claude_comment"
             --disallowedTools "Bash,Edit,Write,WebFetch,WebSearch"


### PR DESCRIPTION
Follow-up to #250. Intake now runs cleanly (0 denied tools) but posts nothing — its read-only allowlist has no comment-writing tool, and automation mode (unlike @claude mention-mode) doesn't add one automatically. So it triages internally and finishes silent.

Adds `mcp__github_comment__update_claude_comment` to the allowlist — the one write path it needs. Still read-only otherwise (no shell, web, or file edits).