### PR TITLE
ci: intake — enable track_progress so triage actually posts

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -38,6 +38,9 @@ jobs:
           # content, so the tool set below stays read-only.
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_non_write_users: "*"
+          # Automation mode posts nothing unless this creates a tracking comment
+          # for the model to fill via mcp__github_comment__update_claude_comment.
+          track_progress: true
           # Self-contained read-only triage — NOT the /intake skill, which is
           # written for the owner path (it reaches for build/web tools this
           # workflow doesn't have, so the model burns turns on denied calls and


### PR DESCRIPTION
Third and (confidently) final piece. #250 stopped the tool-churning and #253 added the comment tool, but intake still posted nothing: `mcp__github_comment__update_claude_comment` only *updates* a tracking comment, and automation mode doesn't create one unless `track_progress: true` is set. This adds it. Everything else unchanged (still read-only).