### PR TITLE
ci: raise @claude max-turns from 40 to 100

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,7 +84,7 @@ jobs:
           # while these tools are enabled.
           claude_args: |
             --model claude-fable-5
-            --max-turns 40
+            --max-turns 100
             --allowedTools "Bash,Edit,Write,Read,Grep,Glob,LS,WebSearch,WebFetch,Task,TodoWrite"
 
       # Reflect the outcome: 🚀 on success, 😕 on failure. The 👀 stays,


### PR DESCRIPTION
The @claude run on #238 hit the 40-turn ceiling and failed with `Reached maximum number of turns (40)` before finishing. Bumps the limit to 100 so multi-step tasks have room to complete.