### PR TITLE
Hill-climb insertion & removal performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,6 @@ appears under each surface it touches.
   are bit-identical across the scalar, NEON, and AVX2 paths, enforced
   by cross-path identity tests.
 
-#### Changed
-
-- **Stored per-vector scales may differ by ~1 ULP from earlier v5
-  builds** for newly encoded vectors: the scale's f64 reconstruction
-  inner product now accumulates through four fixed chains instead of
-  one serial chain (deterministic, identical across platforms and
-  thread counts; packed codes are unchanged and previously written
-  files load byte-identical). Recall is unaffected.
-- `add` on a populated index no longer holds allocation-sized
-  intermediates: encode appends in place and reuses a per-index scratch
-  buffer, which is shrunk whenever it exceeds 4x the current batch's
-  need.
-
 - **File format v5 for `.tv` / `.tvim`: a deterministic block-Hadamard
   rotation, replacing the dense QR rotation (hard break).** The
   coordinate rotation that every quantized code is encoded through is now
@@ -107,6 +94,16 @@ appears under each surface it touches.
 
 #### Changed
 
+- **Stored per-vector scales may differ by ~1 ULP from earlier v5
+  builds** for newly encoded vectors: the scale's f64 reconstruction
+  inner product now accumulates through four fixed chains instead of
+  one serial chain (deterministic, identical across platforms and
+  thread counts; packed codes are unchanged and previously written
+  files load byte-identical). Recall is unaffected.
+- `add` on a populated index no longer holds allocation-sized
+  intermediates: encode appends in place and reuses a per-index scratch
+  buffer, which is shrunk whenever it exceeds 4x the current batch's
+  need.
 - **`MAX_DIM` lowered from 65536 to 16384.** A loaded `.tv`/`.tvim`
   header declaring a huge `dim` drives allocations (codebook, blocked
   layout, per-query rotate scratch) not bounded by the file's own size,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ appears under each surface it touches.
 
 #### Added
 
+- **Insertion and removal are substantially faster** across a ~35-commit
+  optimization pass (arm d=1536 2-bit: cold bulk add ~4.7x, warm append
+  ~4-6x, single add ~3x, removals ~25% faster; x86 gains larger from a
+  lower base). Encode kernels are now SIMD on both aarch64 (NEON) and
+  x86_64 (AVX2, runtime-detected with a scalar fallback); packed codes
+  are bit-identical across the scalar, NEON, and AVX2 paths, enforced
+  by cross-path identity tests.
+
+#### Changed
+
+- **Stored per-vector scales may differ by ~1 ULP from earlier v5
+  builds** for newly encoded vectors: the scale's f64 reconstruction
+  inner product now accumulates through four fixed chains instead of
+  one serial chain (deterministic, identical across platforms and
+  thread counts; packed codes are unchanged and previously written
+  files load byte-identical). Recall is unaffected.
+- `add` on a populated index no longer holds allocation-sized
+  intermediates: encode appends in place and reuses a per-index scratch
+  buffer, which is shrunk whenever it exceeds 4x the current batch's
+  need.
+
 - **File format v5 for `.tv` / `.tvim`: a deterministic block-Hadamard
   rotation, replacing the dense QR rotation (hard break).** The
   coordinate rotation that every quantized code is encoded through is now

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 139160,
-  "tq_warm_insert_vecs_per_sec": 143381,
-  "tq_single_add_us": 40.83,
-  "faiss_bulk_insert_vecs_per_sec": 464397
+  "tq_bulk_insert_vecs_per_sec": 800353,
+  "tq_warm_insert_vecs_per_sec": 1719814,
+  "tq_single_add_us": 5.2,
+  "faiss_bulk_insert_vecs_per_sec": 590899
 }

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 37427,
-  "tq_warm_insert_vecs_per_sec": 123499,
-  "tq_single_add_us": 40.54,
-  "faiss_bulk_insert_vecs_per_sec": 76400
+  "tq_bulk_insert_vecs_per_sec": 136253,
+  "tq_warm_insert_vecs_per_sec": 274401,
+  "tq_single_add_us": 5.14,
+  "faiss_bulk_insert_vecs_per_sec": 75374
 }

--- a/benchmarks/results/speed_insert_d1536_2bit_x86_mt.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_x86_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 32090,
-  "tq_warm_insert_vecs_per_sec": 42429,
-  "tq_single_add_us": 257.66,
-  "faiss_bulk_insert_vecs_per_sec": 147821
+  "tq_bulk_insert_vecs_per_sec": 138721,
+  "tq_warm_insert_vecs_per_sec": 209043,
+  "tq_single_add_us": 23.19,
+  "faiss_bulk_insert_vecs_per_sec": 147617
 }

--- a/benchmarks/results/speed_insert_d1536_2bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 10561,
-  "tq_warm_insert_vecs_per_sec": 22868,
-  "tq_single_add_us": 256.51,
-  "faiss_bulk_insert_vecs_per_sec": 26546
+  "tq_bulk_insert_vecs_per_sec": 29532,
+  "tq_warm_insert_vecs_per_sec": 45381,
+  "tq_single_add_us": 23.28,
+  "faiss_bulk_insert_vecs_per_sec": 27754
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 123714,
-  "tq_warm_insert_vecs_per_sec": 155943,
-  "tq_single_add_us": 43.0,
-  "faiss_bulk_insert_vecs_per_sec": 266005
+  "tq_bulk_insert_vecs_per_sec": 564866,
+  "tq_warm_insert_vecs_per_sec": 1562032,
+  "tq_single_add_us": 5.8,
+  "faiss_bulk_insert_vecs_per_sec": 332445
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 34723,
-  "tq_warm_insert_vecs_per_sec": 117518,
-  "tq_single_add_us": 41.87,
-  "faiss_bulk_insert_vecs_per_sec": 49707
+  "tq_bulk_insert_vecs_per_sec": 120934,
+  "tq_warm_insert_vecs_per_sec": 235147,
+  "tq_single_add_us": 5.76,
+  "faiss_bulk_insert_vecs_per_sec": 49523
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_x86_mt.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_x86_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 28180,
-  "tq_warm_insert_vecs_per_sec": 39143,
-  "tq_single_add_us": 282.37,
-  "faiss_bulk_insert_vecs_per_sec": 120667
+  "tq_bulk_insert_vecs_per_sec": 101799,
+  "tq_warm_insert_vecs_per_sec": 148116,
+  "tq_single_add_us": 34.86,
+  "faiss_bulk_insert_vecs_per_sec": 116916
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 8526,
-  "tq_warm_insert_vecs_per_sec": 15920,
-  "tq_single_add_us": 283.09,
-  "faiss_bulk_insert_vecs_per_sec": 31775
+  "tq_bulk_insert_vecs_per_sec": 21447,
+  "tq_warm_insert_vecs_per_sec": 29414,
+  "tq_single_add_us": 34.92,
+  "faiss_bulk_insert_vecs_per_sec": 31528
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 51249,
-  "tq_warm_insert_vecs_per_sec": 83867,
-  "tq_single_add_us": 335.37,
-  "faiss_bulk_insert_vecs_per_sec": 272894
+  "tq_bulk_insert_vecs_per_sec": 435542,
+  "tq_warm_insert_vecs_per_sec": 849561,
+  "tq_single_add_us": 10.16,
+  "faiss_bulk_insert_vecs_per_sec": 263082
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 12973,
-  "tq_warm_insert_vecs_per_sec": 51891,
-  "tq_single_add_us": 356.25,
-  "faiss_bulk_insert_vecs_per_sec": 36470
+  "tq_bulk_insert_vecs_per_sec": 66697,
+  "tq_warm_insert_vecs_per_sec": 134144,
+  "tq_single_add_us": 10.32,
+  "faiss_bulk_insert_vecs_per_sec": 37067
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_x86_mt.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_x86_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 11616,
-  "tq_warm_insert_vecs_per_sec": 17266,
-  "tq_single_add_us": 1161.68,
-  "faiss_bulk_insert_vecs_per_sec": 76404
+  "tq_bulk_insert_vecs_per_sec": 71990,
+  "tq_warm_insert_vecs_per_sec": 113954,
+  "tq_single_add_us": 46.08,
+  "faiss_bulk_insert_vecs_per_sec": 74160
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 4268,
-  "tq_warm_insert_vecs_per_sec": 10105,
-  "tq_single_add_us": 1185.15,
-  "faiss_bulk_insert_vecs_per_sec": 13894
+  "tq_bulk_insert_vecs_per_sec": 14585,
+  "tq_warm_insert_vecs_per_sec": 22206,
+  "tq_single_add_us": 46.38,
+  "faiss_bulk_insert_vecs_per_sec": 13901
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 49886,
-  "tq_warm_insert_vecs_per_sec": 95951,
-  "tq_single_add_us": 342.33,
-  "faiss_bulk_insert_vecs_per_sec": 164376
+  "tq_bulk_insert_vecs_per_sec": 336295,
+  "tq_warm_insert_vecs_per_sec": 749393,
+  "tq_single_add_us": 11.42,
+  "faiss_bulk_insert_vecs_per_sec": 172716
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 12578,
-  "tq_warm_insert_vecs_per_sec": 50904,
-  "tq_single_add_us": 341.87,
-  "faiss_bulk_insert_vecs_per_sec": 24250
+  "tq_bulk_insert_vecs_per_sec": 58624,
+  "tq_warm_insert_vecs_per_sec": 112011,
+  "tq_single_add_us": 11.48,
+  "faiss_bulk_insert_vecs_per_sec": 24450
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_x86_mt.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_x86_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 10602,
-  "tq_warm_insert_vecs_per_sec": 15325,
-  "tq_single_add_us": 1232.82,
-  "faiss_bulk_insert_vecs_per_sec": 60218
+  "tq_bulk_insert_vecs_per_sec": 54642,
+  "tq_warm_insert_vecs_per_sec": 78528,
+  "tq_single_add_us": 69.27,
+  "faiss_bulk_insert_vecs_per_sec": 60450
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 3606,
-  "tq_warm_insert_vecs_per_sec": 7039,
-  "tq_single_add_us": 1229.52,
-  "faiss_bulk_insert_vecs_per_sec": 15713
+  "tq_bulk_insert_vecs_per_sec": 10723,
+  "tq_warm_insert_vecs_per_sec": 14515,
+  "tq_single_add_us": 69.29,
+  "faiss_bulk_insert_vecs_per_sec": 15709
 }

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.233,
-  "tq_idmap_removes_per_sec": 4300644,
-  "tq_swap_remove_us_per_op": 0.192
+  "tq_idmap_remove_us_per_op": 0.193,
+  "tq_idmap_removes_per_sec": 5194715,
+  "tq_swap_remove_us_per_op": 0.168
 }

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.198,
-  "tq_idmap_removes_per_sec": 5045027,
-  "tq_swap_remove_us_per_op": 0.174
+  "tq_idmap_remove_us_per_op": 0.15,
+  "tq_idmap_removes_per_sec": 6680919,
+  "tq_swap_remove_us_per_op": 0.127
 }

--- a/benchmarks/results/speed_remove_d1536_2bit_x86_mt.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_x86_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.417,
-  "tq_idmap_removes_per_sec": 2398418,
-  "tq_swap_remove_us_per_op": 0.358
+  "tq_idmap_remove_us_per_op": 0.316,
+  "tq_idmap_removes_per_sec": 3168647,
+  "tq_swap_remove_us_per_op": 0.316
 }

--- a/benchmarks/results/speed_remove_d1536_2bit_x86_st.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_x86_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.414,
-  "tq_idmap_removes_per_sec": 2414925,
-  "tq_swap_remove_us_per_op": 0.352
+  "tq_idmap_remove_us_per_op": 0.305,
+  "tq_idmap_removes_per_sec": 3278821,
+  "tq_swap_remove_us_per_op": 0.316
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.266,
-  "tq_idmap_removes_per_sec": 3758492,
-  "tq_swap_remove_us_per_op": 0.228
+  "tq_idmap_remove_us_per_op": 0.269,
+  "tq_idmap_removes_per_sec": 3724025,
+  "tq_swap_remove_us_per_op": 0.181
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.222,
-  "tq_idmap_removes_per_sec": 4499657,
-  "tq_swap_remove_us_per_op": 0.185
+  "tq_idmap_remove_us_per_op": 0.182,
+  "tq_idmap_removes_per_sec": 5488198,
+  "tq_swap_remove_us_per_op": 0.154
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_x86_mt.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_x86_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.618,
-  "tq_idmap_removes_per_sec": 1618045,
-  "tq_swap_remove_us_per_op": 0.474
+  "tq_idmap_remove_us_per_op": 0.554,
+  "tq_idmap_removes_per_sec": 1804836,
+  "tq_swap_remove_us_per_op": 0.466
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_x86_st.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_x86_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.622,
-  "tq_idmap_removes_per_sec": 1606659,
-  "tq_swap_remove_us_per_op": 0.464
+  "tq_idmap_remove_us_per_op": 0.54,
+  "tq_idmap_removes_per_sec": 1852310,
+  "tq_swap_remove_us_per_op": 0.492
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.257,
-  "tq_idmap_removes_per_sec": 3891492,
-  "tq_swap_remove_us_per_op": 0.209
+  "tq_idmap_remove_us_per_op": 0.27,
+  "tq_idmap_removes_per_sec": 3705064,
+  "tq_swap_remove_us_per_op": 0.186
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.213,
-  "tq_idmap_removes_per_sec": 4695736,
-  "tq_swap_remove_us_per_op": 0.177
+  "tq_idmap_remove_us_per_op": 0.174,
+  "tq_idmap_removes_per_sec": 5750101,
+  "tq_swap_remove_us_per_op": 0.164
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_x86_mt.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_x86_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.599,
-  "tq_idmap_removes_per_sec": 1669999,
-  "tq_swap_remove_us_per_op": 0.468
+  "tq_idmap_remove_us_per_op": 0.545,
+  "tq_idmap_removes_per_sec": 1833196,
+  "tq_swap_remove_us_per_op": 0.474
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_x86_st.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_x86_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "x86",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.624,
-  "tq_idmap_removes_per_sec": 1603434,
-  "tq_swap_remove_us_per_op": 0.478
+  "tq_idmap_remove_us_per_op": 0.555,
+  "tq_idmap_removes_per_sec": 1801723,
+  "tq_swap_remove_us_per_op": 0.466
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.302,
-  "tq_idmap_removes_per_sec": 3314459,
-  "tq_swap_remove_us_per_op": 0.261
+  "tq_idmap_remove_us_per_op": 0.287,
+  "tq_idmap_removes_per_sec": 3480945,
+  "tq_swap_remove_us_per_op": 0.256
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.303,
-  "tq_idmap_removes_per_sec": 3298099,
-  "tq_swap_remove_us_per_op": 0.23
+  "tq_idmap_remove_us_per_op": 0.241,
+  "tq_idmap_removes_per_sec": 4153212,
+  "tq_swap_remove_us_per_op": 0.22
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_x86_mt.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_x86_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.983,
-  "tq_idmap_removes_per_sec": 1017356,
-  "tq_swap_remove_us_per_op": 0.741
+  "tq_idmap_remove_us_per_op": 0.801,
+  "tq_idmap_removes_per_sec": 1248717,
+  "tq_swap_remove_us_per_op": 0.621
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_x86_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.968,
-  "tq_idmap_removes_per_sec": 1033440,
-  "tq_swap_remove_us_per_op": 0.759
+  "tq_idmap_remove_us_per_op": 0.825,
+  "tq_idmap_removes_per_sec": 1212110,
+  "tq_swap_remove_us_per_op": 0.645
 }

--- a/docs/arm_insert_mt.svg
+++ b/docs/arm_insert_mt.svg
@@ -18,47 +18,47 @@
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">200K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">1000K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">400K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">2000K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">600K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">3000K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">800K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">4000K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">1000K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">5000K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="109.3" y="314.4" width="43.12" height="37.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="308.4" text-anchor="middle" class="value-accent">139K</text>
-<rect x="160.4" y="313.3" width="43.12" height="38.7" rx="6" fill="#0f766e" />
-<text x="182.0" y="307.3" text-anchor="middle" class="value">143K</text>
-<rect x="211.6" y="226.6" width="43.12" height="125.4" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="220.6" text-anchor="middle" class="value">464K</text>
+<rect x="109.3" y="308.8" width="43.12" height="43.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="302.8" text-anchor="middle" class="value-accent">800K</text>
+<rect x="160.4" y="259.1" width="43.12" height="92.9" rx="6" fill="#0f766e" />
+<text x="182.0" y="253.1" text-anchor="middle" class="value">1720K</text>
+<rect x="211.6" y="320.1" width="43.12" height="31.9" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="314.1" text-anchor="middle" class="value">591K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="318.6" width="43.12" height="33.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="312.6" text-anchor="middle" class="value-accent">124K</text>
-<rect x="356.4" y="309.9" width="43.12" height="42.1" rx="6" fill="#0f766e" />
-<text x="378.0" y="303.9" text-anchor="middle" class="value">156K</text>
-<rect x="407.6" y="280.2" width="43.12" height="71.8" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="274.2" text-anchor="middle" class="value">266K</text>
+<rect x="305.3" y="321.5" width="43.12" height="30.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="315.5" text-anchor="middle" class="value-accent">565K</text>
+<rect x="356.4" y="267.7" width="43.12" height="84.3" rx="6" fill="#0f766e" />
+<text x="378.0" y="261.7" text-anchor="middle" class="value">1562K</text>
+<rect x="407.6" y="334.0" width="43.12" height="18.0" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="328.0" text-anchor="middle" class="value">332K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="338.2" width="43.12" height="13.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="332.2" text-anchor="middle" class="value-accent">51K</text>
-<rect x="552.4" y="329.4" width="43.12" height="22.6" rx="6" fill="#0f766e" />
-<text x="574.0" y="323.4" text-anchor="middle" class="value">84K</text>
-<rect x="603.6" y="278.3" width="43.12" height="73.7" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="272.3" text-anchor="middle" class="value">273K</text>
+<rect x="501.3" y="328.5" width="43.12" height="23.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="322.5" text-anchor="middle" class="value-accent">436K</text>
+<rect x="552.4" y="306.1" width="43.12" height="45.9" rx="6" fill="#0f766e" />
+<text x="574.0" y="300.1" text-anchor="middle" class="value">850K</text>
+<rect x="603.6" y="337.8" width="43.12" height="14.2" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="331.8" text-anchor="middle" class="value">263K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="338.5" width="43.12" height="13.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="332.5" text-anchor="middle" class="value-accent">50K</text>
-<rect x="748.4" y="326.1" width="43.12" height="25.9" rx="6" fill="#0f766e" />
-<text x="770.0" y="320.1" text-anchor="middle" class="value">96K</text>
-<rect x="799.6" y="307.6" width="43.12" height="44.4" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="301.6" text-anchor="middle" class="value">164K</text>
+<rect x="697.3" y="333.8" width="43.12" height="18.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="327.8" text-anchor="middle" class="value-accent">336K</text>
+<rect x="748.4" y="311.5" width="43.12" height="40.5" rx="6" fill="#0f766e" />
+<text x="770.0" y="305.5" text-anchor="middle" class="value">749K</text>
+<rect x="799.6" y="342.7" width="43.12" height="9.3" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="336.7" text-anchor="middle" class="value">173K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/arm_insert_st.svg
+++ b/docs/arm_insert_st.svg
@@ -18,47 +18,47 @@
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">40K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">100K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">80K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">200K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">120K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">300K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">160K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">400K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">200K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">500K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="109.3" y="301.5" width="43.12" height="50.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="295.5" text-anchor="middle" class="value-accent">37K</text>
-<rect x="160.4" y="185.3" width="43.12" height="166.7" rx="6" fill="#0f766e" />
-<text x="182.0" y="179.3" text-anchor="middle" class="value">123K</text>
-<rect x="211.6" y="248.9" width="43.12" height="103.1" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="242.9" text-anchor="middle" class="value">76K</text>
+<rect x="109.3" y="278.4" width="43.12" height="73.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="272.4" text-anchor="middle" class="value-accent">136K</text>
+<rect x="160.4" y="203.8" width="43.12" height="148.2" rx="6" fill="#0f766e" />
+<text x="182.0" y="197.8" text-anchor="middle" class="value">274K</text>
+<rect x="211.6" y="311.3" width="43.12" height="40.7" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="305.3" text-anchor="middle" class="value">75K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="305.1" width="43.12" height="46.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="299.1" text-anchor="middle" class="value-accent">35K</text>
-<rect x="356.4" y="193.4" width="43.12" height="158.6" rx="6" fill="#0f766e" />
-<text x="378.0" y="187.4" text-anchor="middle" class="value">118K</text>
-<rect x="407.6" y="284.9" width="43.12" height="67.1" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="278.9" text-anchor="middle" class="value">50K</text>
+<rect x="305.3" y="286.7" width="43.12" height="65.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="280.7" text-anchor="middle" class="value-accent">121K</text>
+<rect x="356.4" y="225.0" width="43.12" height="127.0" rx="6" fill="#0f766e" />
+<text x="378.0" y="219.0" text-anchor="middle" class="value">235K</text>
+<rect x="407.6" y="325.3" width="43.12" height="26.7" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="319.3" text-anchor="middle" class="value">50K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="334.5" width="43.12" height="17.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="328.5" text-anchor="middle" class="value-accent">13.0K</text>
-<rect x="552.4" y="281.9" width="43.12" height="70.1" rx="6" fill="#0f766e" />
-<text x="574.0" y="275.9" text-anchor="middle" class="value">52K</text>
-<rect x="603.6" y="302.8" width="43.12" height="49.2" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="296.8" text-anchor="middle" class="value">36K</text>
+<rect x="501.3" y="316.0" width="43.12" height="36.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="310.0" text-anchor="middle" class="value-accent">67K</text>
+<rect x="552.4" y="279.6" width="43.12" height="72.4" rx="6" fill="#0f766e" />
+<text x="574.0" y="273.6" text-anchor="middle" class="value">134K</text>
+<rect x="603.6" y="332.0" width="43.12" height="20.0" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="326.0" text-anchor="middle" class="value">37K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="335.0" width="43.12" height="17.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="329.0" text-anchor="middle" class="value-accent">12.6K</text>
-<rect x="748.4" y="283.3" width="43.12" height="68.7" rx="6" fill="#0f766e" />
-<text x="770.0" y="277.3" text-anchor="middle" class="value">51K</text>
-<rect x="799.6" y="319.3" width="43.12" height="32.7" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="313.3" text-anchor="middle" class="value">24K</text>
+<rect x="697.3" y="320.3" width="43.12" height="31.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="314.3" text-anchor="middle" class="value-accent">59K</text>
+<rect x="748.4" y="291.5" width="43.12" height="60.5" rx="6" fill="#0f766e" />
+<text x="770.0" y="285.5" text-anchor="middle" class="value">112K</text>
+<rect x="799.6" y="338.8" width="43.12" height="13.2" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="332.8" text-anchor="middle" class="value">24K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/arm_remove_st.svg
+++ b/docs/arm_remove_st.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">0.5</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="245.1" width="44" height="106.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="258.0" width="44" height="94.0" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="239.1" text-anchor="middle" class="value-accent">0.20</text>
-<text x="207.0" y="252.0" text-anchor="middle" class="value">0.17</text>
+<rect x="135.0" y="271.0" width="44" height="81.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="283.4" width="44" height="68.6" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="265.0" text-anchor="middle" class="value-accent">0.15</text>
+<text x="207.0" y="277.4" text-anchor="middle" class="value">0.13</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="232.1" width="44" height="119.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="252.1" width="44" height="99.9" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="226.1" text-anchor="middle" class="value-accent">0.22</text>
-<text x="403.0" y="246.1" text-anchor="middle" class="value">0.18</text>
+<rect x="331.0" y="253.7" width="44" height="98.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="268.8" width="44" height="83.2" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="247.7" text-anchor="middle" class="value-accent">0.18</text>
+<text x="403.0" y="262.8" text-anchor="middle" class="value">0.15</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="237.0" width="44" height="115.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="256.4" width="44" height="95.6" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="231.0" text-anchor="middle" class="value-accent">0.21</text>
-<text x="599.0" y="250.4" text-anchor="middle" class="value">0.18</text>
+<rect x="527.0" y="258.0" width="44" height="94.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="263.4" width="44" height="88.6" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="252.0" text-anchor="middle" class="value-accent">0.17</text>
+<text x="599.0" y="257.4" text-anchor="middle" class="value">0.16</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="188.4" width="44" height="163.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="227.8" width="44" height="124.2" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="182.4" text-anchor="middle" class="value-accent">0.30</text>
-<text x="795.0" y="221.8" text-anchor="middle" class="value">0.23</text>
+<rect x="723.0" y="221.9" width="44" height="130.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="233.2" width="44" height="118.8" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="215.9" text-anchor="middle" class="value-accent">0.24</text>
+<text x="795.0" y="227.2" text-anchor="middle" class="value">0.22</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">µs / op</text>

--- a/docs/x86_insert_mt.svg
+++ b/docs/x86_insert_mt.svg
@@ -18,47 +18,47 @@
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">40K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">100K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">80K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">200K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">120K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">300K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">160K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">400K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">200K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">500K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="109.3" y="308.7" width="43.12" height="43.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="302.7" text-anchor="middle" class="value-accent">32K</text>
-<rect x="160.4" y="294.7" width="43.12" height="57.3" rx="6" fill="#0f766e" />
-<text x="182.0" y="288.7" text-anchor="middle" class="value">42K</text>
-<rect x="211.6" y="152.4" width="43.12" height="199.6" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="146.4" text-anchor="middle" class="value">148K</text>
+<rect x="109.3" y="277.1" width="43.12" height="74.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="271.1" text-anchor="middle" class="value-accent">139K</text>
+<rect x="160.4" y="239.1" width="43.12" height="112.9" rx="6" fill="#0f766e" />
+<text x="182.0" y="233.1" text-anchor="middle" class="value">209K</text>
+<rect x="211.6" y="272.3" width="43.12" height="79.7" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="266.3" text-anchor="middle" class="value">148K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="314.0" width="43.12" height="38.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="308.0" text-anchor="middle" class="value-accent">28K</text>
-<rect x="356.4" y="299.2" width="43.12" height="52.8" rx="6" fill="#0f766e" />
-<text x="378.0" y="293.2" text-anchor="middle" class="value">39K</text>
-<rect x="407.6" y="189.1" width="43.12" height="162.9" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="183.1" text-anchor="middle" class="value">121K</text>
+<rect x="305.3" y="297.0" width="43.12" height="55.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="291.0" text-anchor="middle" class="value-accent">102K</text>
+<rect x="356.4" y="272.0" width="43.12" height="80.0" rx="6" fill="#0f766e" />
+<text x="378.0" y="266.0" text-anchor="middle" class="value">148K</text>
+<rect x="407.6" y="288.9" width="43.12" height="63.1" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="282.9" text-anchor="middle" class="value">117K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="336.3" width="43.12" height="15.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="330.3" text-anchor="middle" class="value-accent">11.6K</text>
-<rect x="552.4" y="328.7" width="43.12" height="23.3" rx="6" fill="#0f766e" />
-<text x="574.0" y="322.7" text-anchor="middle" class="value">17.3K</text>
-<rect x="603.6" y="248.9" width="43.12" height="103.1" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="242.9" text-anchor="middle" class="value">76K</text>
+<rect x="501.3" y="313.1" width="43.12" height="38.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="307.1" text-anchor="middle" class="value-accent">72K</text>
+<rect x="552.4" y="290.5" width="43.12" height="61.5" rx="6" fill="#0f766e" />
+<text x="574.0" y="284.5" text-anchor="middle" class="value">114K</text>
+<rect x="603.6" y="312.0" width="43.12" height="40.0" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="306.0" text-anchor="middle" class="value">74K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="337.7" width="43.12" height="14.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="331.7" text-anchor="middle" class="value-accent">10.6K</text>
-<rect x="748.4" y="331.3" width="43.12" height="20.7" rx="6" fill="#0f766e" />
-<text x="770.0" y="325.3" text-anchor="middle" class="value">15.3K</text>
-<rect x="799.6" y="270.7" width="43.12" height="81.3" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="264.7" text-anchor="middle" class="value">60K</text>
+<rect x="697.3" y="322.5" width="43.12" height="29.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="316.5" text-anchor="middle" class="value-accent">55K</text>
+<rect x="748.4" y="309.6" width="43.12" height="42.4" rx="6" fill="#0f766e" />
+<text x="770.0" y="303.6" text-anchor="middle" class="value">79K</text>
+<rect x="799.6" y="319.4" width="43.12" height="32.6" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="313.4" text-anchor="middle" class="value">60K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/x86_insert_st.svg
+++ b/docs/x86_insert_st.svg
@@ -18,47 +18,47 @@
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">10K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">20K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">20K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">40K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">30K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">60K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">40K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">80K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">50K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">100K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="109.3" y="295.0" width="43.12" height="57.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="289.0" text-anchor="middle" class="value-accent">10.6K</text>
-<rect x="160.4" y="228.5" width="43.12" height="123.5" rx="6" fill="#0f766e" />
-<text x="182.0" y="222.5" text-anchor="middle" class="value">23K</text>
-<rect x="211.6" y="208.7" width="43.12" height="143.3" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="202.7" text-anchor="middle" class="value">27K</text>
+<rect x="109.3" y="272.3" width="43.12" height="79.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="266.3" text-anchor="middle" class="value-accent">30K</text>
+<rect x="160.4" y="229.5" width="43.12" height="122.5" rx="6" fill="#0f766e" />
+<text x="182.0" y="223.5" text-anchor="middle" class="value">45K</text>
+<rect x="211.6" y="277.1" width="43.12" height="74.9" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="271.1" text-anchor="middle" class="value">28K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="306.0" width="43.12" height="46.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="300.0" text-anchor="middle" class="value-accent">8.5K</text>
-<rect x="356.4" y="266.0" width="43.12" height="86.0" rx="6" fill="#0f766e" />
-<text x="378.0" y="260.0" text-anchor="middle" class="value">15.9K</text>
-<rect x="407.6" y="180.4" width="43.12" height="171.6" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="174.4" text-anchor="middle" class="value">32K</text>
+<rect x="305.3" y="294.1" width="43.12" height="57.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="288.1" text-anchor="middle" class="value-accent">21K</text>
+<rect x="356.4" y="272.6" width="43.12" height="79.4" rx="6" fill="#0f766e" />
+<text x="378.0" y="266.6" text-anchor="middle" class="value">29K</text>
+<rect x="407.6" y="266.9" width="43.12" height="85.1" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="260.9" text-anchor="middle" class="value">32K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="329.0" width="43.12" height="23.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="323.0" text-anchor="middle" class="value-accent">4.3K</text>
-<rect x="552.4" y="297.4" width="43.12" height="54.6" rx="6" fill="#0f766e" />
-<text x="574.0" y="291.4" text-anchor="middle" class="value">10.1K</text>
-<rect x="603.6" y="277.0" width="43.12" height="75.0" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="271.0" text-anchor="middle" class="value">13.9K</text>
+<rect x="501.3" y="312.6" width="43.12" height="39.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="306.6" text-anchor="middle" class="value-accent">14.6K</text>
+<rect x="552.4" y="292.0" width="43.12" height="60.0" rx="6" fill="#0f766e" />
+<text x="574.0" y="286.0" text-anchor="middle" class="value">22K</text>
+<rect x="603.6" y="314.5" width="43.12" height="37.5" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="308.5" text-anchor="middle" class="value">13.9K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="332.5" width="43.12" height="19.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="326.5" text-anchor="middle" class="value-accent">3.6K</text>
-<rect x="748.4" y="314.0" width="43.12" height="38.0" rx="6" fill="#0f766e" />
-<text x="770.0" y="308.0" text-anchor="middle" class="value">7.0K</text>
-<rect x="799.6" y="267.1" width="43.12" height="84.9" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="261.1" text-anchor="middle" class="value">15.7K</text>
+<rect x="697.3" y="323.0" width="43.12" height="29.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="317.0" text-anchor="middle" class="value-accent">10.7K</text>
+<rect x="748.4" y="312.8" width="43.12" height="39.2" rx="6" fill="#0f766e" />
+<text x="770.0" y="306.8" text-anchor="middle" class="value">14.5K</text>
+<rect x="799.6" y="309.6" width="43.12" height="42.4" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="303.6" text-anchor="middle" class="value">15.7K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/x86_remove_st.svg
+++ b/docs/x86_remove_st.svg
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">1.5</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="277.5" width="44" height="74.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="288.6" width="44" height="63.4" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="271.5" text-anchor="middle" class="value-accent">0.41</text>
-<text x="207.0" y="282.6" text-anchor="middle" class="value">0.35</text>
+<rect x="135.0" y="297.1" width="44" height="54.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="295.1" width="44" height="56.9" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="291.1" text-anchor="middle" class="value-accent">0.30</text>
+<text x="207.0" y="289.1" text-anchor="middle" class="value">0.32</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="240.0" width="44" height="112.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="268.5" width="44" height="83.5" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="234.0" text-anchor="middle" class="value-accent">0.62</text>
-<text x="403.0" y="262.5" text-anchor="middle" class="value">0.46</text>
+<rect x="331.0" y="254.8" width="44" height="97.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="263.4" width="44" height="88.6" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="248.8" text-anchor="middle" class="value-accent">0.54</text>
+<text x="403.0" y="257.4" text-anchor="middle" class="value">0.49</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="239.7" width="44" height="112.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="266.0" width="44" height="86.0" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="233.7" text-anchor="middle" class="value-accent">0.62</text>
-<text x="599.0" y="260.0" text-anchor="middle" class="value">0.48</text>
+<rect x="527.0" y="252.1" width="44" height="99.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="268.1" width="44" height="83.9" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="246.1" text-anchor="middle" class="value-accent">0.56</text>
+<text x="599.0" y="262.1" text-anchor="middle" class="value">0.47</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="177.8" width="44" height="174.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="215.4" width="44" height="136.6" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="171.8" text-anchor="middle" class="value-accent">0.97</text>
-<text x="795.0" y="209.4" text-anchor="middle" class="value">0.76</text>
+<rect x="723.0" y="203.5" width="44" height="148.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="235.9" width="44" height="116.1" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="197.5" text-anchor="middle" class="value-accent">0.82</text>
+<text x="795.0" y="229.9" text-anchor="middle" class="value">0.65</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">µs / op</text>

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -320,7 +320,11 @@ impl TurboQuantIndex {
         // this add; a concurrent add simply starts from an empty
         // buffer.
         let mut owned = std::mem::take(&mut *self.snap.lock().expect("snap lock poisoned"));
-        if slice.len() < PAR_COPY_MIN_LEN {
+        if slice.len() < PAR_COPY_MIN_LEN || !pool_idle() {
+            // Small input — or the rayon pool is busy with a long batch,
+            // in which case queueing the copy behind it while holding
+            // the GIL would stall every Python thread; a bounded serial
+            // copy is the safe fallback (see pool_idle).
             owned.clear();
             owned.extend_from_slice(slice);
         } else {
@@ -342,6 +346,12 @@ impl TurboQuantIndex {
             with_pool_if(n_rows > 1, || inner.add_2d(&owned, dim))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        // Shrink before returning the buffer when it is far larger than
+        // this call needed, so a one-time bulk load doesn't pin its full
+        // snapshot capacity for the index lifetime.
+        if owned.capacity() > 4 * slice.len() {
+            owned.shrink_to(slice.len());
+        }
         *self.snap.lock().expect("snap lock poisoned") = owned;
         Ok(())
     }

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -616,8 +616,13 @@ impl IdMapIndex {
     /// present, `False` otherwise. Integers outside the `uint64` range are
     /// never present, so they return `False`.
     fn remove(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
+        let _ = py;
         Ok(match extract_membership_id("id", id)? {
-            Some(v) => py.detach(|| lock_write(&self.inner).remove(v)),
+            // No GIL detach: the removal is O(1) (two hash-map updates
+            // and a swap), far cheaper than the detach round-trip. Lock
+            // holders never need the GIL to make progress, so briefly
+            // blocking on the write lock while attached cannot deadlock.
+            Some(v) => lock_write(&self.inner).remove(v),
             None => false,
         })
     }

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1,4 +1,7 @@
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
+
+mod par_copy;
+use par_copy::{par_copy, PAR_COPY_MIN_LEN};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
 
@@ -275,14 +278,28 @@ impl TurboQuantIndex {
         // under `with_pool` while the GIL is still held — the sentinel
         // global pool is single-threaded, so a bare par_iter would fold
         // serial. No index lock is taken inside the closure (see the
-        // `with_pool` invariant).
-        let owned = with_pool(|| par_copy(slice))?;
+        // `with_pool` invariant). Small inputs skip the pool handoff
+        // entirely: a single-vector add must not pay an `install` for a
+        // 6 KB memcpy.
+        let owned = if slice.len() < PAR_COPY_MIN_LEN {
+            slice.to_vec()
+        } else {
+            with_pool(|| par_copy(slice))?
+        };
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
+        //
+        // Single-row adds take the same inline bypass as nq==1 search:
+        // every rayon bridge in a one-row encode (normalize, rotate,
+        // quantize, and the sub-chunk validation scan) has length 1 and
+        // folds on the calling thread, so skipping the pool `install`
+        // handoff cannot change results — it only removes the per-call
+        // latency. The forked-child guard mirrors `with_pool_if`.
+        let n_rows = if dim == 0 { 0 } else { slice.len() / dim };
         py.detach(|| {
             let mut guard = lock_write(&self.inner);
             let inner = &mut *guard;
-            with_pool(|| inner.add_2d(&owned, dim))
+            with_pool_if(n_rows > 1, || inner.add_2d(&owned, dim))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     }
@@ -1090,38 +1107,6 @@ fn register_fork_handlers(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyRes
         register.call((), Some(&kwargs))?;
     }
     Ok(())
-}
-
-/// Chunked parallel copy of a float buffer.
-///
-/// Equivalent to `slice.to_vec()`, but the memcpy is split across the
-/// current rayon pool. Callers must run it under `with_pool` — the
-/// global pool is pinned to a single sentinel thread, so a bare call
-/// would fold back to a serial copy. Used to snapshot large numpy
-/// buffers on the `add` path, where a serial copy of n·dim floats
-/// throttles multi-threaded insert throughput.
-fn par_copy(slice: &[f32]) -> Vec<f32> {
-    use rayon::prelude::*;
-    const CHUNK: usize = 1 << 20;
-    if slice.len() < CHUNK {
-        return slice.to_vec();
-    }
-    let mut owned: Vec<f32> = Vec::with_capacity(slice.len());
-    let spare = &mut owned.spare_capacity_mut()[..slice.len()];
-    spare
-        .par_chunks_mut(CHUNK)
-        .zip(slice.par_chunks(CHUNK))
-        .for_each(|(dst, src)| {
-            for (d, &s) in dst.iter_mut().zip(src.iter()) {
-                d.write(s);
-            }
-        });
-    // SAFETY: every element of the spare capacity up to slice.len() was
-    // just written by the parallel copy above.
-    unsafe {
-        owned.set_len(slice.len());
-    }
-    owned
 }
 
 /// Cap applied to an explicit `RAYON_NUM_THREADS` request. Threads

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -216,6 +216,31 @@ fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_,
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
+/// Write-lock for O(1) ops called while attached to the GIL: try the
+/// lock without blocking (the uncontended fast path — cheaper than a
+/// GIL detach round-trip), and only when another thread holds the lock
+/// (e.g. a multi-second bulk add) detach before waiting, so a brief
+/// removal never stalls every Python thread behind a long writer.
+fn lock_write_gil_aware<'l, T: Send + Sync>(
+    py: Python<'_>,
+    lock: &'l std::sync::RwLock<T>,
+) -> std::sync::RwLockWriteGuard<'l, T> {
+    loop {
+        match lock.try_write() {
+            Ok(guard) => return guard,
+            Err(std::sync::TryLockError::Poisoned(p)) => return p.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => {
+                // A guard cannot cross the GIL release, so wait for the
+                // lock detached (acquire and immediately drop), then
+                // retry attached. Another thread may slip in between —
+                // the loop just waits again; each iteration makes
+                // progress once the long writer finishes.
+                py.detach(|| drop(lock_write(lock)));
+            }
+        }
+    }
+}
+
 // Locking discipline (both pyclasses): the pyclass is `frozen`, so pyo3
 // performs no runtime borrow-checking of its own and every method takes
 // `&self`; the inner index sits behind an `RwLock` instead. Concurrent
@@ -479,12 +504,13 @@ impl TurboQuantIndex {
             // Bounds check and removal share one write guard, so a
             // concurrent writer cannot shrink the index in between.
             //
-            // No GIL detach: the removal is O(1), cheaper than the
-            // detach round-trip; lock holders never need the GIL, so
-            // briefly blocking while attached cannot deadlock (same
-            // reasoning as IdMapIndex.remove and the single-row add).
+            // No GIL detach on the uncontended path: the removal is
+            // O(1), cheaper than the detach round-trip. When another
+            // thread holds the write lock (a long bulk add), the
+            // gil-aware helper detaches before waiting so other Python
+            // threads keep running.
             let removed = {
-                let mut inner = lock_write(&self.inner);
+                let mut inner = lock_write_gil_aware(py, &self.inner);
                 let len = inner.len();
                 if i < len {
                     Ok(inner.swap_remove(i))
@@ -600,7 +626,9 @@ impl IdMapIndex {
         // reuses the per-index buffer (see `TurboQuantIndex::add`).
         let mut v_owned =
             std::mem::take(&mut *self.snap.lock().expect("snap lock poisoned"));
-        if v_slice.len() < PAR_COPY_MIN_LEN {
+        if v_slice.len() < PAR_COPY_MIN_LEN || !pool_idle() {
+            // Small input, or the pool is busy with a long batch —
+            // bounded serial copy while attached (see TurboQuantIndex::add).
             v_owned.clear();
             v_owned.extend_from_slice(v_slice);
         } else {
@@ -613,6 +641,11 @@ impl IdMapIndex {
             with_pool(|| inner.add_with_ids_2d(&v_owned, dim, &i_owned))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        // Same shrink policy as TurboQuantIndex::add.
+        let mut v_owned = v_owned;
+        if v_owned.capacity() > 4 * v_slice.len() {
+            v_owned.shrink_to(v_slice.len());
+        }
         *self.snap.lock().expect("snap lock poisoned") = v_owned;
         Ok(())
     }
@@ -621,13 +654,13 @@ impl IdMapIndex {
     /// present, `False` otherwise. Integers outside the `uint64` range are
     /// never present, so they return `False`.
     fn remove(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
-        let _ = py;
         Ok(match extract_membership_id("id", id)? {
-            // No GIL detach: the removal is O(1) (two hash-map updates
-            // and a swap), far cheaper than the detach round-trip. Lock
-            // holders never need the GIL to make progress, so briefly
-            // blocking on the write lock while attached cannot deadlock.
-            Some(v) => lock_write(&self.inner).remove(v),
+            // No GIL detach on the uncontended path: the removal is O(1)
+            // (two hash-map updates and a swap), far cheaper than the
+            // detach round-trip. When another thread holds the write
+            // lock (a long bulk add), the gil-aware helper detaches
+            // before waiting so other Python threads keep running.
+            Some(v) => lock_write_gil_aware(py, &self.inner).remove(v),
             None => false,
         })
     }
@@ -1094,7 +1127,23 @@ fn in_forked_child() -> bool {
 /// (which blocks on rayon's latch and never steals) and move only a plain
 /// `&T` / `&mut T` into `f`.
 fn with_pool<R: Send>(f: impl FnOnce() -> R + Send) -> PyResult<R> {
-    Ok(current_pool()?.pool.install(f))
+    POOL_IN_FLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let result = current_pool().map(|c| c.pool.install(f));
+    POOL_IN_FLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+    result
+}
+
+/// Number of `with_pool` jobs currently running or queued. Used by
+/// GIL-attached callers (the add snapshot copy) to avoid queueing behind
+/// a long-running batch while holding the GIL: when the pool is busy
+/// they fall back to bounded serial work instead of waiting. The check
+/// is advisory — a race simply means one snapshot copies serially (or
+/// briefly queues), never an error.
+static POOL_IN_FLIGHT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// True when no `with_pool` job is currently in flight.
+fn pool_idle() -> bool {
+    POOL_IN_FLIGHT.load(std::sync::atomic::Ordering::Relaxed) == 0
 }
 
 /// Hybrid dispatch. `parallel == false` (single-query search) runs inline on

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -478,7 +478,12 @@ impl TurboQuantIndex {
         if let Ok(i) = idx.extract::<usize>() {
             // Bounds check and removal share one write guard, so a
             // concurrent writer cannot shrink the index in between.
-            let removed = py.detach(|| {
+            //
+            // No GIL detach: the removal is O(1), cheaper than the
+            // detach round-trip; lock holders never need the GIL, so
+            // briefly blocking while attached cannot deadlock (same
+            // reasoning as IdMapIndex.remove and the single-row add).
+            let removed = {
                 let mut inner = lock_write(&self.inner);
                 let len = inner.len();
                 if i < len {
@@ -486,7 +491,7 @@ impl TurboQuantIndex {
                 } else {
                     Err(len)
                 }
-            });
+            };
             match removed {
                 Ok(moved) => return Ok(moved),
                 Err(len) => {

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -268,8 +268,15 @@ impl TurboQuantIndex {
         // once released, another Python thread may write to the (possibly
         // writable) source array, and rust-numpy's borrow flags cannot
         // prevent Python-side writes. The copy is O(n·dim) against the
-        // quantization kernel, so it is cheap by comparison.
-        let owned = slice.to_vec();
+        // quantization kernel — but done serially it was the largest
+        // single-threaded span left on the add path, so split it across
+        // the rayon pool (same pool, and therefore the same
+        // RAYON_NUM_THREADS clamp, as the encode kernels). The copy runs
+        // under `with_pool` while the GIL is still held — the sentinel
+        // global pool is single-threaded, so a bare par_iter would fold
+        // serial. No index lock is taken inside the closure (see the
+        // `with_pool` invariant).
+        let owned = with_pool(|| par_copy(slice))?;
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
         py.detach(|| {
@@ -1083,6 +1090,38 @@ fn register_fork_handlers(py: Python<'_>, module: &Bound<'_, PyModule>) -> PyRes
         register.call((), Some(&kwargs))?;
     }
     Ok(())
+}
+
+/// Chunked parallel copy of a float buffer.
+///
+/// Equivalent to `slice.to_vec()`, but the memcpy is split across the
+/// current rayon pool. Callers must run it under `with_pool` — the
+/// global pool is pinned to a single sentinel thread, so a bare call
+/// would fold back to a serial copy. Used to snapshot large numpy
+/// buffers on the `add` path, where a serial copy of n·dim floats
+/// throttles multi-threaded insert throughput.
+fn par_copy(slice: &[f32]) -> Vec<f32> {
+    use rayon::prelude::*;
+    const CHUNK: usize = 1 << 20;
+    if slice.len() < CHUNK {
+        return slice.to_vec();
+    }
+    let mut owned: Vec<f32> = Vec::with_capacity(slice.len());
+    let spare = &mut owned.spare_capacity_mut()[..slice.len()];
+    spare
+        .par_chunks_mut(CHUNK)
+        .zip(slice.par_chunks(CHUNK))
+        .for_each(|(dst, src)| {
+            for (d, &s) in dst.iter_mut().zip(src.iter()) {
+                d.write(s);
+            }
+        });
+    // SAFETY: every element of the spare capacity up to slice.len() was
+    // just written by the parallel copy above.
+    unsafe {
+        owned.set_len(slice.len());
+    }
+    owned
 }
 
 /// Cap applied to an explicit `RAYON_NUM_THREADS` request. Threads

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1,7 +1,7 @@
 use numpy::{IntoPyArray, PyArray2, PyReadonlyArray1, PyReadonlyArray2};
 
 mod par_copy;
-use par_copy::{par_copy, PAR_COPY_MIN_LEN};
+use par_copy::{par_copy_into, PAR_COPY_MIN_LEN};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyType};
 
@@ -234,6 +234,13 @@ fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_,
 
 #[pyclass(frozen)]
 struct TurboQuantIndex {
+    /// Reusable GIL-safety snapshot buffer for `add`. Purely scratch:
+    /// contents are meaningless between calls; kept so repeated adds
+    /// reuse one warm allocation instead of paying a fresh multi-MB
+    /// mmap + page-fault walk per call. Taken (mem::take) for the
+    /// duration of one add and put back after, so concurrent adds
+    /// simply fall back to a fresh buffer.
+    snap: std::sync::Mutex<Vec<f32>>,
     inner: std::sync::RwLock<turbovec_core::TurboQuantIndex>,
 }
 
@@ -257,6 +264,7 @@ impl TurboQuantIndex {
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -281,11 +289,18 @@ impl TurboQuantIndex {
         // `with_pool` invariant). Small inputs skip the pool handoff
         // entirely: a single-vector add must not pay an `install` for a
         // 6 KB memcpy.
-        let owned = if slice.len() < PAR_COPY_MIN_LEN {
-            slice.to_vec()
+        // Reuse the per-index snapshot buffer so repeated adds keep one
+        // warm allocation (a fresh multi-MB buffer per call costs a
+        // page-fault walk). Taken out of the mutex for the duration of
+        // this add; a concurrent add simply starts from an empty
+        // buffer.
+        let mut owned = std::mem::take(&mut *self.snap.lock().expect("snap lock poisoned"));
+        if slice.len() < PAR_COPY_MIN_LEN {
+            owned.clear();
+            owned.extend_from_slice(slice);
         } else {
-            with_pool(|| par_copy(slice))?
-        };
+            with_pool(|| par_copy_into(slice, &mut owned))?;
+        }
         // `add_2d` handles both eager (dim must match) and lazy (locks
         // dim on first call) cases.
         //
@@ -301,7 +316,9 @@ impl TurboQuantIndex {
             let inner = &mut *guard;
             with_pool_if(n_rows > 1, || inner.add_2d(&owned, dim))
         })?
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        *self.snap.lock().expect("snap lock poisoned") = owned;
+        Ok(())
     }
 
     /// Run a top-`k` search against the index.
@@ -403,6 +420,7 @@ impl TurboQuantIndex {
             .map_err(|e| load_err(path, e))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -432,6 +450,7 @@ impl TurboQuantIndex {
             .map_err(from_bytes_err)?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -522,6 +541,8 @@ impl TurboQuantIndex {
 
 #[pyclass(frozen)]
 struct IdMapIndex {
+    /// See `TurboQuantIndex::snap`.
+    snap: std::sync::Mutex<Vec<f32>>,
     inner: std::sync::RwLock<turbovec_core::IdMapIndex>,
 }
 
@@ -545,6 +566,7 @@ impl IdMapIndex {
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -569,15 +591,25 @@ impl IdMapIndex {
         let i_slice = i.as_slice().ok_or_else(|| not_contiguous_err("ids"))?;
         // Snapshot both numpy buffers before releasing the GIL (another
         // Python thread may write to them once it is released); the core
-        // then validates and quantizes the snapshot.
-        let v_owned = v_slice.to_vec();
+        // then validates and quantizes the snapshot. The vector snapshot
+        // reuses the per-index buffer (see `TurboQuantIndex::add`).
+        let mut v_owned =
+            std::mem::take(&mut *self.snap.lock().expect("snap lock poisoned"));
+        if v_slice.len() < PAR_COPY_MIN_LEN {
+            v_owned.clear();
+            v_owned.extend_from_slice(v_slice);
+        } else {
+            with_pool(|| par_copy_into(v_slice, &mut v_owned))?;
+        }
         let i_owned = i_slice.to_vec();
         py.detach(|| {
             let mut guard = lock_write(&self.inner);
             let inner = &mut *guard;
             with_pool(|| inner.add_with_ids_2d(&v_owned, dim, &i_owned))
         })?
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        *self.snap.lock().expect("snap lock poisoned") = v_owned;
+        Ok(())
     }
 
     /// Remove the vector with external id `id`. Returns `True` if it was
@@ -749,6 +781,7 @@ impl IdMapIndex {
             .map_err(|e| load_err(path, e))?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 
@@ -779,6 +812,7 @@ impl IdMapIndex {
             .map_err(from_bytes_err)?;
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
+            snap: std::sync::Mutex::new(Vec::new()),
         })
     }
 

--- a/turbovec-python/src/par_copy.rs
+++ b/turbovec-python/src/par_copy.rs
@@ -1,0 +1,34 @@
+//! Chunked parallel buffer copy — an audited rayon chokepoint file
+//! (fork safety, issue #147). The only caller runs it inside
+//! `with_pool`, so the parallel iterators below always execute on the
+//! process-local, fork-safe pool.
+
+use rayon::prelude::*;
+
+/// Below this many floats a plain serial `to_vec` wins: the pool
+/// `install` handoff costs more than the memcpy it parallelizes.
+pub(crate) const PAR_COPY_MIN_LEN: usize = 1 << 20;
+
+/// Equivalent to `slice.to_vec()`, with the memcpy split across the
+/// current rayon pool. Callers must run it under `with_pool` — the
+/// global pool is pinned to a single sentinel thread, so a bare call
+/// would fold back to a serial copy.
+pub(crate) fn par_copy(slice: &[f32]) -> Vec<f32> {
+    const CHUNK: usize = 1 << 20;
+    let mut owned: Vec<f32> = Vec::with_capacity(slice.len());
+    let spare = &mut owned.spare_capacity_mut()[..slice.len()];
+    spare
+        .par_chunks_mut(CHUNK)
+        .zip(slice.par_chunks(CHUNK))
+        .for_each(|(dst, src)| {
+            for (d, &s) in dst.iter_mut().zip(src.iter()) {
+                d.write(s);
+            }
+        });
+    // SAFETY: every element of the spare capacity up to slice.len() was
+    // just written by the parallel copy above.
+    unsafe {
+        owned.set_len(slice.len());
+    }
+    owned
+}

--- a/turbovec-python/src/par_copy.rs
+++ b/turbovec-python/src/par_copy.rs
@@ -9,13 +9,12 @@ use rayon::prelude::*;
 /// `install` handoff costs more than the memcpy it parallelizes.
 pub(crate) const PAR_COPY_MIN_LEN: usize = 1 << 20;
 
-/// Equivalent to `slice.to_vec()`, with the memcpy split across the
-/// current rayon pool. Callers must run it under `with_pool` — the
-/// global pool is pinned to a single sentinel thread, so a bare call
-/// would fold back to a serial copy.
-pub(crate) fn par_copy(slice: &[f32]) -> Vec<f32> {
+/// Parallel copy into a caller-provided buffer, reusing its
+/// allocation. The buffer's prior contents are discarded.
+pub(crate) fn par_copy_into(slice: &[f32], owned: &mut Vec<f32>) {
     const CHUNK: usize = 1 << 20;
-    let mut owned: Vec<f32> = Vec::with_capacity(slice.len());
+    owned.clear();
+    owned.reserve(slice.len());
     let spare = &mut owned.spare_capacity_mut()[..slice.len()];
     spare
         .par_chunks_mut(CHUNK)
@@ -30,5 +29,4 @@ pub(crate) fn par_copy(slice: &[f32]) -> Vec<f32> {
     unsafe {
         owned.set_len(slice.len());
     }
-    owned
 }

--- a/turbovec-python/src/par_copy.rs
+++ b/turbovec-python/src/par_copy.rs
@@ -12,7 +12,7 @@ pub(crate) const PAR_COPY_MIN_LEN: usize = 1 << 20;
 /// Parallel copy into a caller-provided buffer, reusing its
 /// allocation. The buffer's prior contents are discarded.
 pub(crate) fn par_copy_into(slice: &[f32], owned: &mut Vec<f32>) {
-    const CHUNK: usize = 1 << 20;
+    const CHUNK: usize = 1 << 23;
     owned.clear();
     owned.reserve(slice.len());
     let spare = &mut owned.spare_capacity_mut()[..slice.len()];

--- a/turbovec-python/tests/test_fork_safety.py
+++ b/turbovec-python/tests/test_fork_safety.py
@@ -427,7 +427,7 @@ _RAYON_CALL = re.compile(r"\.par_[a-z_]*\s*\(|\binto_par_iter\s*\(|\brayon::[a-z
 # appears in any other file, a new un-chokepointed parallel site has been
 # introduced: route it through `with_pool` and, if it legitimately belongs
 # in a new file, add that file here in the same change.
-_RAYON_ALLOWED_FILES = {"encode.rs", "search.rs"}
+_RAYON_ALLOWED_FILES = {"encode.rs", "search.rs", "par_copy.rs"}
 
 
 def _repo_root() -> pathlib.Path:
@@ -466,7 +466,11 @@ def test_audited_files_still_have_rayon():
     containing rayon calls, the allowlist is stale and must be revisited."""
     root = _repo_root()
     for name in _RAYON_ALLOWED_FILES:
-        matches = list((root / "turbovec" / "src").rglob(name))
+        matches = [
+            m
+            for d in ("turbovec", "turbovec-python")
+            for m in (root / d / "src").rglob(name)
+        ]
         assert matches, f"audited file {name} not found"
         text = matches[0].read_text()
         code = "\n".join(ln.split("//", 1)[0] for ln in text.splitlines())

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -98,9 +98,58 @@ fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
     None
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(target_arch = "x86_64")]
 #[inline]
 fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
+    if std::arch::is_x86_feature_detected!("avx2") {
+        unsafe { first_invalid_in_chunk_avx2(chunk, max_magnitude) }
+    } else {
+        first_invalid_in_chunk_scalar(chunk, max_magnitude)
+    }
+}
+
+/// AVX2 all-clean fast path: 8 lanes per compare of `|x| < bound`
+/// (NaN/Inf/huge all fail), with a scalar pinpoint on a failing group so
+/// the reported index matches the scalar scan exactly.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn first_invalid_in_chunk_avx2(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
+    use std::arch::x86_64::*;
+    let n = chunk.len();
+    let groups = n / 8;
+    let bound = _mm256_set1_ps(max_magnitude);
+    let abs_mask = _mm256_castsi256_ps(_mm256_set1_epi32(0x7fff_ffff));
+    for g in 0..groups {
+        let x = _mm256_loadu_ps(chunk.as_ptr().add(g * 8));
+        let ok = _mm256_cmp_ps::<_CMP_LT_OQ>(_mm256_and_ps(x, abs_mask), bound);
+        if _mm256_movemask_ps(ok) != 0xff {
+            for j in g * 8..n {
+                let v = chunk[j];
+                if !(v.abs() < max_magnitude) {
+                    return Some(j);
+                }
+            }
+            unreachable!("vector scan flagged a group with no invalid element");
+        }
+    }
+    for j in groups * 8..n {
+        let v = chunk[j];
+        if !(v.abs() < max_magnitude) {
+            return Some(j);
+        }
+    }
+    None
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[inline]
+fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
+    first_invalid_in_chunk_scalar(chunk, max_magnitude)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline]
+fn first_invalid_in_chunk_scalar(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
     chunk
         .iter()
         .position(|x| !x.is_finite() || x.abs() >= max_magnitude)
@@ -676,11 +725,192 @@ fn scale_from_inner(inner: f64, norm: f32) -> f32 {
     }
 }
 
-// ─── Fused quantize + scale + pack (fallback) ───────────────────────────────
+// ─── Fused quantize + scale + pack (x86_64) ─────────────────────────────────
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(target_arch = "x86_64")]
+#[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn fused_quantize_scale_pack<const BITS: usize>(
+    rot_orig: &[f32],
+    shift: &[f32],
+    scale_tq: &[f32],
+    inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
+    boundaries: &[f32],
+    centroids: &[f32],
+    norm: f32,
+    packed_row: &mut [u8],
+    dim: usize,
+    bytes_per_plane: usize,
+) -> f32 {
+    if std::arch::is_x86_feature_detected!("avx2") {
+        unsafe {
+            fused_quantize_scale_pack_avx2::<BITS>(
+                rot_orig, shift, scale_tq, inv_scale_tq, centroid_orig,
+                boundaries, centroids, norm, packed_row, dim, bytes_per_plane,
+            )
+        }
+    } else {
+        fused_quantize_scale_pack_scalar::<BITS>(
+            rot_orig, shift, scale_tq, inv_scale_tq, centroid_orig,
+            boundaries, centroids, norm, packed_row, dim, bytes_per_plane,
+        )
+    }
+}
+
+/// AVX2 kernel mirroring the scalar path exactly: calibration
+/// `(x + shift) * scale` and every boundary compare are element-wise
+/// IEEE ops (8 lanes at a time), the reconstruction terms accumulate
+/// into the same four f64 chains (term j -> chain j % 4, two __m128d
+/// registers) with the same final combine, and the pack loop is the
+/// scalar OR into the zeroed row — so the packed codes and stored
+/// scales are bit-identical to the scalar kernel.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+#[allow(clippy::too_many_arguments)]
+unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
+    rot_orig: &[f32],
+    shift: &[f32],
+    scale_tq: &[f32],
+    inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
+    boundaries: &[f32],
+    centroids: &[f32],
+    norm: f32,
+    packed_row: &mut [u8],
+    dim: usize,
+    bytes_per_plane: usize,
+) -> f32 {
+    use std::arch::x86_64::*;
+
+    let mut acc_a = _mm_setzero_pd();
+    let mut acc_b = _mm_setzero_pd();
+    let chunks = dim / 8;
+
+    for c in 0..chunks {
+        let offset = c * 8;
+        // Calibrated values, 8 lanes: (x + shift) * scale_tq — the same
+        // two IEEE ops per element as the scalar path.
+        let vals = _mm256_mul_ps(
+            _mm256_add_ps(
+                _mm256_loadu_ps(rot_orig.as_ptr().add(offset)),
+                _mm256_loadu_ps(shift.as_ptr().add(offset)),
+            ),
+            _mm256_loadu_ps(scale_tq.as_ptr().add(offset)),
+        );
+
+        // Boundary count per lane (acc -= cmp adds 1 where val > b).
+        let mut acc = _mm256_setzero_si256();
+        if BITS == 4 {
+            let mid = _mm256_set1_ps(boundaries[7]);
+            let m = _mm256_cmp_ps::<_CMP_GT_OQ>(vals, mid);
+            acc = _mm256_slli_epi32::<3>(_mm256_srli_epi32::<31>(_mm256_castps_si256(m)));
+            for k in 0..7 {
+                let b_low = _mm256_set1_ps(boundaries[k]);
+                let b_high = _mm256_set1_ps(boundaries[8 + k]);
+                let bv = _mm256_blendv_ps(b_low, b_high, m);
+                let gt = _mm256_cmp_ps::<_CMP_GT_OQ>(vals, bv);
+                acc = _mm256_sub_epi32(acc, _mm256_castps_si256(gt));
+            }
+        } else if BITS == 2 {
+            let mid = _mm256_set1_ps(boundaries[1]);
+            let m = _mm256_cmp_ps::<_CMP_GT_OQ>(vals, mid);
+            acc = _mm256_slli_epi32::<1>(_mm256_srli_epi32::<31>(_mm256_castps_si256(m)));
+            let bv = _mm256_blendv_ps(
+                _mm256_set1_ps(boundaries[0]),
+                _mm256_set1_ps(boundaries[2]),
+                m,
+            );
+            let gt = _mm256_cmp_ps::<_CMP_GT_OQ>(vals, bv);
+            acc = _mm256_sub_epi32(acc, _mm256_castps_si256(gt));
+        } else {
+            for bi in 0..(1usize << BITS) - 1 {
+                let bv = _mm256_set1_ps(boundaries[bi]);
+                let gt = _mm256_cmp_ps::<_CMP_GT_OQ>(vals, bv);
+                acc = _mm256_sub_epi32(acc, _mm256_castps_si256(gt));
+            }
+        }
+        let mut counts32 = [0i32; 8];
+        _mm256_storeu_si256(counts32.as_mut_ptr() as *mut __m256i, acc);
+
+        // Reconstruction terms, then the four fixed f64 chains
+        // (term j -> chain j % 4; a = {0,1}, b = {2,3}).
+        let mut terms = [0.0f64; 8];
+        match centroid_orig {
+            Some(table) => {
+                for k in 0..8 {
+                    let d = offset + k;
+                    terms[k] = (rot_orig[d] as f64)
+                        * table[counts32[k] as usize * dim + d];
+                }
+            }
+            None => {
+                for k in 0..8 {
+                    let d = offset + k;
+                    let centroid_in_orig = (centroids[counts32[k] as usize] as f64)
+                        * (inv_scale_tq[d] as f64)
+                        - (shift[d] as f64);
+                    terms[k] = (rot_orig[d] as f64) * centroid_in_orig;
+                }
+            }
+        }
+        acc_a = _mm_add_pd(acc_a, _mm_loadu_pd(terms.as_ptr()));
+        acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(2)));
+        acc_a = _mm_add_pd(acc_a, _mm_loadu_pd(terms.as_ptr().add(4)));
+        acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(6)));
+
+        // Pack (scalar OR into the zeroed row, as the scalar kernel).
+        for k in 0..8 {
+            let j = offset + k;
+            let code = counts32[k] as u8;
+            let byte_pos = j / 8;
+            let bit_pos = 7 - (j % 8);
+            for p in 0..BITS {
+                if code & (1 << p) != 0 {
+                    packed_row[p * bytes_per_plane + byte_pos] |= 1 << bit_pos;
+                }
+            }
+        }
+    }
+
+    // Fixed combine ((a0 + a1) + (b0 + b1)) — identical to the scalar
+    // chains' combine.
+    let mut a2 = [0.0f64; 2];
+    let mut b2 = [0.0f64; 2];
+    _mm_storeu_pd(a2.as_mut_ptr(), acc_a);
+    _mm_storeu_pd(b2.as_mut_ptr(), acc_b);
+    let inner = (a2[0] + a2[1]) + (b2[0] + b2[1]);
+    scale_from_inner(inner, norm)
+}
+
+// ─── Fused quantize + scale + pack (fallback) ───────────────────────────────
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn fused_quantize_scale_pack<const BITS: usize>(
+    rot_orig: &[f32],
+    shift: &[f32],
+    scale_tq: &[f32],
+    inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
+    boundaries: &[f32],
+    centroids: &[f32],
+    norm: f32,
+    packed_row: &mut [u8],
+    dim: usize,
+    bytes_per_plane: usize,
+) -> f32 {
+    fused_quantize_scale_pack_scalar::<BITS>(
+        rot_orig, shift, scale_tq, inv_scale_tq, centroid_orig,
+        boundaries, centroids, norm, packed_row, dim, bytes_per_plane,
+    )
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[allow(clippy::too_many_arguments)]
+#[inline(always)]
+fn fused_quantize_scale_pack_scalar<const BITS: usize>(
     rot_orig: &[f32],
     shift: &[f32],
     scale_tq: &[f32],

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -209,29 +209,49 @@ fn compute_tqplus_calibration(
     let lo_idx = ((n as f64) * TQPLUS_P_LO) as usize;
     let hi_idx = (((n as f64) * TQPLUS_P_HI) as usize).min(n - 1);
 
-    // Each coord is independent — fan out over coords.
-    shift.par_iter_mut().zip(scale.par_iter_mut()).enumerate().for_each(
-        |(d, (sh, sc))| {
-            let mut coord: Vec<f32> = (0..n).map(|i| rotated[i * dim + d]).collect();
-            // Only the two quantile order statistics are needed, so two
-            // O(n) selects replace a full O(n log n) sort. Select the
-            // upper quantile first, then the lower one within the left
-            // partition — the values are identical to indexing a fully
-            // sorted array. This is the dominant first-add cost at scale
-            // (dim independent selects over n values each).
-            let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
-            let (left, hi_val, _) = coord.select_nth_unstable_by(hi_idx, cmp);
-            let qe_hi = *hi_val;
-            let (_, lo_val, _) = left.select_nth_unstable_by(lo_idx, cmp);
-            let qe_lo = *lo_val;
-            let qe_span = qe_hi - qe_lo;
-            if qe_span > 1e-6 {
-                *sc = qc_span / qe_span;
-                *sh = qc_lo / *sc - qe_lo;
+    // Coords are independent, but gathering one column at a time strides
+    // `dim * 4` bytes per element — every read is a fresh cache line, and
+    // the whole n*dim batch is re-streamed once per coordinate. Instead,
+    // fan out over TILES of coordinates: each tile makes one sequential
+    // pass over the rows, scattering into `tile` contiguous column
+    // buffers (each row contributes a contiguous 4*tile-byte read). The
+    // collected values per coord are identical, so the selected quantiles
+    // — and every downstream encoded byte — are unchanged.
+    const CALIB_COORD_TILE: usize = 64;
+    shift
+        .par_chunks_mut(CALIB_COORD_TILE)
+        .zip(scale.par_chunks_mut(CALIB_COORD_TILE))
+        .enumerate()
+        .for_each(|(tile_idx, (sh_tile, sc_tile))| {
+            let d0 = tile_idx * CALIB_COORD_TILE;
+            let tile = sh_tile.len();
+            let mut cols = vec![0.0f32; tile * n];
+            for i in 0..n {
+                let row = &rotated[i * dim + d0..i * dim + d0 + tile];
+                for (c, &v) in row.iter().enumerate() {
+                    cols[c * n + i] = v;
+                }
             }
-            // else: leave as (shift=0, scale=1) for this coord
-        },
-    );
+            for (c, (sh, sc)) in sh_tile.iter_mut().zip(sc_tile.iter_mut()).enumerate() {
+                let coord = &mut cols[c * n..(c + 1) * n];
+                // Only the two quantile order statistics are needed, so
+                // two O(n) selects replace a full O(n log n) sort. Select
+                // the upper quantile first, then the lower one within the
+                // left partition — the values are identical to indexing a
+                // fully sorted array.
+                let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
+                let (left, hi_val, _) = coord.select_nth_unstable_by(hi_idx, cmp);
+                let qe_hi = *hi_val;
+                let (_, lo_val, _) = left.select_nth_unstable_by(lo_idx, cmp);
+                let qe_lo = *lo_val;
+                let qe_span = qe_hi - qe_lo;
+                if qe_span > 1e-6 {
+                    *sc = qc_span / qe_span;
+                    *sh = qc_lo / *sc - qe_lo;
+                }
+                // else: leave as (shift=0, scale=1) for this coord
+            }
+        });
 
     (shift, scale)
 }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -399,39 +399,12 @@ fn simd_norm(row: &[f32]) -> f32 {
     }
 }
 
-#[cfg(target_arch = "aarch64")]
-#[inline(always)]
-fn simd_scale(row: &[f32], scale: f32, out: &mut [f32]) {
-    use std::arch::aarch64::*;
-    let dim = row.len();
-    let chunks = dim / 4;
-    let sv = unsafe { vdupq_n_f32(scale) };
-
-    unsafe {
-        for c in 0..chunks {
-            let v = vld1q_f32(row.as_ptr().add(c * 4));
-            vst1q_f32(out.as_mut_ptr().add(c * 4), vmulq_f32(v, sv));
-        }
-        for j in (chunks * 4)..dim {
-            out[j] = row[j] * scale;
-        }
-    }
-}
-
 // ─── Norm and scale (fallback) ───────────────────────────────────────────────
 
 #[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
 fn simd_norm(row: &[f32]) -> f32 {
     row.iter().map(|x| x * x).sum::<f32>().sqrt()
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-#[inline(always)]
-fn simd_scale(row: &[f32], scale: f32, out: &mut [f32]) {
-    for j in 0..row.len() {
-        out[j] = row[j] * scale;
-    }
 }
 
 // ─── Fused quantize + scale + pack (aarch64) ────────────────────────────────

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -117,42 +117,47 @@ pub(crate) fn encode(
         dim != 0 && dim % 8 == 0,
         "encode requires dim to be a nonzero multiple of 8, got {dim}",
     );
+    // Norms only — the normalization scale rides the first rotation
+    // gather (`Rotation::apply_scaled_into`), so the unit-normalized
+    // intermediate copy of the batch is never materialized. The fused
+    // path performs the identical multiplies in the identical order, so
+    // encoded bytes are unchanged.
     let mut norms = vec![0.0f32; n];
-    // Fully overwritten by the normalize pass below before any read —
-    // zero-filling n*dim floats serially just throttles the parallel
-    // pass that immediately rewrites them.
-    let mut unit_flat = Vec::with_capacity(n * dim);
-    #[allow(clippy::uninit_vec)]
-    // SAFETY: f32 has no invalid bit patterns, and every element is
-    // written by the normalize pass (each row chunk is fully written by
-    // simd_scale) before `unit_flat` is read.
-    unsafe {
-        unit_flat.set_len(n * dim);
-    }
-
-    // Normalize. Rows are independent so Rayon splits them across cores.
+    let mut inv_norms = vec![0.0f32; n];
     norms.par_iter_mut()
-        .zip(unit_flat.par_chunks_mut(dim))
+        .zip(inv_norms.par_iter_mut())
         .enumerate()
-        .for_each(|(i, (norm, unit_row))| {
-            let row = &vectors[i * dim..(i + 1) * dim];
-            let n_val = simd_norm(row);
+        .for_each(|(i, (norm, inv))| {
+            let n_val = simd_norm(&vectors[i * dim..(i + 1) * dim]);
             *norm = n_val;
-            let inv = if n_val > 1e-10 { 1.0 / n_val } else { 0.0 };
-            simd_scale(row, inv, unit_row);
+            *inv = if n_val > 1e-10 { 1.0 / n_val } else { 0.0 };
         });
 
-    // Rotate each unit row in place via the deterministic block-Hadamard
-    // transform. Rows are independent so rayon splits them across cores;
-    // the per-row transform is reduction-free (fixed add order, no FMA),
-    // so the encoded bytes are identical regardless of how rows are
+    // Rotate each raw row into `rotated_buf` via the deterministic
+    // block-Hadamard transform, applying 1/||v|| in the first gather.
+    // Rows are independent so rayon splits them across cores; the
+    // per-row transform is reduction-free (fixed add order, no FMA), so
+    // the encoded bytes are identical regardless of how rows are
     // distributed across threads — the property the QR rotation lacked
     // (#206).
-    let mut rotated_buf = unit_flat;
+    let mut rotated_buf: Vec<f32> = Vec::with_capacity(n * dim);
+    #[allow(clippy::uninit_vec)]
+    // SAFETY: f32 has no invalid bit patterns, and every element is
+    // written by apply_scaled_into (each output row is fully written)
+    // before `rotated_buf` is read.
+    unsafe {
+        rotated_buf.set_len(n * dim);
+    }
     rotated_buf
         .par_chunks_mut(dim)
-        .for_each_init(|| vec![0.0f32; dim], |scratch, row| {
-            rotation.apply_with_scratch(row, scratch)
+        .enumerate()
+        .for_each_init(|| vec![0.0f32; dim], |scratch, (i, dst_row)| {
+            rotation.apply_scaled_into(
+                &vectors[i * dim..(i + 1) * dim],
+                inv_norms[i],
+                dst_row,
+                scratch,
+            )
         });
     let rotated: &[f32] = &rotated_buf;
 

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -233,6 +233,29 @@ pub(crate) fn encode(
     // fused per-row function. Avoids a divide per coord per vector.
     let inv_scale_tq: Vec<f32> = scale_tq.iter().map(|s| 1.0 / s).collect();
 
+    // Hoist the reconstruction operand out of the per-row loop: for a
+    // given code c and coordinate d, `centroids[c] * inv_scale_tq[d] -
+    // shift[d]` is row-independent. The table entries are computed with
+    // exactly the ops the kernel performed per element, so the
+    // accumulated inner products — and the stored scales — are
+    // bit-identical.
+    // The table costs O(2^bits * dim) to build, so it only pays once the
+    // batch is a few rows deep; below that the kernel computes the same
+    // values inline (identical ops, identical results).
+    const RECON_TABLE_MIN_ROWS: usize = 16;
+    let centroid_orig: Option<Vec<f64>> = (n >= RECON_TABLE_MIN_ROWS).then(|| {
+        let n_codes = 1usize << bit_width;
+        let mut table = vec![0.0f64; n_codes * dim];
+        for c in 0..n_codes {
+            let row = &mut table[c * dim..(c + 1) * dim];
+            for d in 0..dim {
+                row[d] =
+                    (centroids[c] as f64) * (inv_scale_tq[d] as f64) - (shift[d] as f64);
+            }
+        }
+        table
+    });
+
     let bytes_per_plane = dim / 8;
     let bytes_per_row = bit_width * bytes_per_plane;
     #[cfg(target_arch = "aarch64")]
@@ -262,7 +285,7 @@ pub(crate) fn encode(
             let rot_orig = &rotated[i * dim..(i + 1) * dim];
             *scale = fused_quantize_scale_pack(
                 rot_orig, shift, scale_tq, &inv_scale_tq,
-                boundaries, centroids, norms[i],
+                centroid_orig.as_deref(), boundaries, centroids, norms[i],
                 packed_row, dim, bit_width, bytes_per_plane,
             );
         });
@@ -430,6 +453,7 @@ fn fused_quantize_scale_pack(
     shift: &[f32],
     scale_tq: &[f32],
     inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
     boundaries: &[f32],
     centroids: &[f32],
     norm: f32,
@@ -487,13 +511,27 @@ fn fused_quantize_scale_pack(
                 vgetq_lane_u32::<3>(acc_hi) as u8,
             ];
 
-            // Inner-product reconstruction in ORIGINAL space (see doc comment).
-            for k in 0..8 {
-                let d = offset + k;
-                let centroid_in_orig =
-                    (centroids[counts[k] as usize] as f64) * (inv_scale_tq[d] as f64)
-                        - (shift[d] as f64);
-                inner += (rot_orig[d] as f64) * centroid_in_orig;
+            // Inner-product reconstruction in ORIGINAL space (see doc
+            // comment): from the hoisted per-(code, coord) table when the
+            // batch amortized building it, otherwise inline — the same
+            // ops per element, so results are bit-identical.
+            match centroid_orig {
+                Some(table) => {
+                    for k in 0..8 {
+                        let d = offset + k;
+                        inner += (rot_orig[d] as f64)
+                            * table[counts[k] as usize * dim + d];
+                    }
+                }
+                None => {
+                    for k in 0..8 {
+                        let d = offset + k;
+                        let centroid_in_orig = (centroids[counts[k] as usize] as f64)
+                            * (inv_scale_tq[d] as f64)
+                            - (shift[d] as f64);
+                        inner += (rot_orig[d] as f64) * centroid_in_orig;
+                    }
+                }
             }
 
             // Pack 8 codes into one byte per bit-plane (unchanged).
@@ -569,6 +607,7 @@ fn fused_quantize_scale_pack(
     shift: &[f32],
     scale_tq: &[f32],
     inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
     boundaries: &[f32],
     centroids: &[f32],
     norm: f32,
@@ -585,9 +624,15 @@ fn fused_quantize_scale_pack(
         for &b in boundaries {
             if calib > b { code += 1; }
         }
-        let centroid_in_orig =
-            (centroids[code as usize] as f64) * (inv_scale_tq[j] as f64)
-                - (shift[j] as f64);
+        // Same table-or-inline split as the aarch64 kernel; identical
+        // ops either way, so results are bit-identical.
+        let centroid_in_orig = match centroid_orig {
+            Some(table) => table[code as usize * dim + j],
+            None => {
+                (centroids[code as usize] as f64) * (inv_scale_tq[j] as f64)
+                    - (shift[j] as f64)
+            }
+        };
         inner += (rot_orig[j] as f64) * centroid_in_orig;
 
         let byte_pos = j / 8;

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -414,10 +414,17 @@ fn compute_tqplus_calibration(
                 // left partition — the values are identical to indexing a
                 // fully sorted array.
                 let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
-                let (left, hi_val, _) = coord.select_nth_unstable_by(hi_idx, cmp);
-                let qe_hi = *hi_val;
-                let (_, lo_val, _) = left.select_nth_unstable_by(lo_idx, cmp);
+                // Select the LOW quantile first: its partition splits
+                // off only ~5% of the data, so the second (high) select
+                // runs over the ~95% right side — total elements
+                // partitioned is the same, but the first partition's
+                // pivot walks terminate sooner. Selected values are
+                // identical to indexing a fully sorted array.
+                let (_, lo_val, right) = coord.select_nth_unstable_by(lo_idx, cmp);
                 let qe_lo = *lo_val;
+                let (_, hi_val, _) =
+                    right.select_nth_unstable_by(hi_idx - lo_idx - 1, cmp);
+                let qe_hi = *hi_val;
                 let qe_span = qe_hi - qe_lo;
                 if qe_span > 1e-6 {
                     *sc = qc_span / qe_span;

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -152,6 +152,7 @@ pub(crate) fn encode(
     centroids: &[f32],
     bit_width: usize,
     existing_calibration: Option<(&[f32], &[f32])>,
+    rotated_scratch: &mut Vec<f32>,
 ) -> (Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>) {
     // The packed layout allocates `dim / 8` bytes per bit-plane, so a dim
     // that is not a multiple of 8 has no valid layout: the tail
@@ -186,11 +187,15 @@ pub(crate) fn encode(
     // the encoded bytes are identical regardless of how rows are
     // distributed across threads — the property the QR rotation lacked
     // (#206).
-    let mut rotated_buf: Vec<f32> = Vec::with_capacity(n * dim);
+    let rotated_buf: &mut Vec<f32> = rotated_scratch;
+    rotated_buf.clear();
+    rotated_buf.reserve(n * dim);
     #[allow(clippy::uninit_vec)]
     // SAFETY: f32 has no invalid bit patterns, and every element is
     // written by apply_scaled_into (each output row is fully written)
-    // before `rotated_buf` is read.
+    // before `rotated_buf` is read. Reusing the caller's scratch keeps
+    // the allocation warm across adds instead of paying a fresh
+    // multi-MB mmap + page-fault walk per call.
     unsafe {
         rotated_buf.set_len(n * dim);
     }
@@ -205,7 +210,7 @@ pub(crate) fn encode(
                 scratch,
             )
         });
-    let rotated: &[f32] = &rotated_buf;
+    let rotated: &[f32] = rotated_buf;
 
     // TQ+ per-coord (shift, scale) — fitted to empirical quantiles of the
     // rotated batch, or reused from a previous add for consistency across

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -147,7 +147,7 @@ fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
     first_invalid_in_chunk_scalar(chunk, max_magnitude)
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
 #[inline]
 fn first_invalid_in_chunk_scalar(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
     chunk
@@ -458,10 +458,7 @@ fn compute_tqplus_calibration(
             for (c, (sh, sc)) in sh_tile.iter_mut().zip(sc_tile.iter_mut()).enumerate() {
                 let coord = &mut cols[c * n..(c + 1) * n];
                 // Only the two quantile order statistics are needed, so
-                // two O(n) selects replace a full O(n log n) sort. Select
-                // the upper quantile first, then the lower one within the
-                // left partition — the values are identical to indexing a
-                // fully sorted array.
+                // two O(n) selects replace a full O(n log n) sort.
                 let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
                 // Select the LOW quantile first: its partition splits
                 // off only ~5% of the data, so the second (high) select
@@ -907,7 +904,7 @@ fn fused_quantize_scale_pack<const BITS: usize>(
     )
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
 #[allow(clippy::too_many_arguments)]
 #[inline(always)]
 fn fused_quantize_scale_pack_scalar<const BITS: usize>(
@@ -955,4 +952,120 @@ fn fused_quantize_scale_pack_scalar<const BITS: usize>(
 
     let inner = (chains[0] + chains[1]) + (chains[2] + chains[3]);
     scale_from_inner(inner, norm)
+}
+
+#[cfg(test)]
+mod simd_identity_tests {
+    use super::*;
+    use crate::codebook;
+    use crate::rotation::Rotation;
+
+    fn pseudo_rows(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+        let mut x = seed;
+        (0..n * dim)
+            .map(|_| {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                (x as f64 / u64::MAX as f64) as f32 - 0.5
+            })
+            .collect()
+    }
+
+    /// The arch quantize kernel must reproduce the scalar kernel
+    /// bit-for-bit: identical packed codes and identical stored scales,
+    /// for every bit width, on both the inline and the hoisted-table
+    /// reconstruction paths.
+    #[test]
+    fn quantize_kernel_matches_scalar_bit_exactly() {
+        fn run<const BITS: usize>(dim: usize) {
+            let rotation = Rotation::new(dim);
+            let (boundaries, centroids) = codebook::codebook(BITS, dim);
+            // A fitted-looking calibration (non-identity) to exercise
+            // shift/scale arithmetic.
+            let shift: Vec<f32> = (0..dim).map(|d| (d as f32 * 0.001) - 0.01).collect();
+            let scale_tq: Vec<f32> = (0..dim).map(|d| 1.0 + (d as f32 * 0.0005)).collect();
+            let inv_scale_tq: Vec<f32> = scale_tq.iter().map(|s| 1.0 / s).collect();
+            let table = {
+                let n_codes = 1usize << BITS;
+                let mut t = vec![0.0f64; n_codes * dim];
+                for c in 0..n_codes {
+                    for d in 0..dim {
+                        t[c * dim + d] = (centroids[c] as f64) * (inv_scale_tq[d] as f64)
+                            - (shift[d] as f64);
+                    }
+                }
+                t
+            };
+
+            let n = 4;
+            let raw = pseudo_rows(n, dim, 0xD1536 + BITS as u64);
+            let bytes_per_plane = dim / 8;
+            let bytes_per_row = BITS * bytes_per_plane;
+            let mut scratch = vec![0.0f32; dim];
+
+            for i in 0..n {
+                let mut rot = vec![0.0f32; dim];
+                let src = &raw[i * dim..(i + 1) * dim];
+                let norm = src.iter().map(|x| x * x).sum::<f32>().sqrt();
+                rotation.apply_scaled_into(src, 1.0 / norm, &mut rot, &mut scratch);
+
+                for table_opt in [None, Some(table.as_slice())] {
+                    let mut packed_a = vec![0u8; bytes_per_row];
+                    let mut packed_b = vec![0u8; bytes_per_row];
+                    let scale_a = fused_quantize_scale_pack::<BITS>(
+                        &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
+                        &boundaries, &centroids, norm, &mut packed_a, dim,
+                        bytes_per_plane,
+                    );
+                    let scale_b = fused_quantize_scale_pack_scalar::<BITS>(
+                        &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
+                        &boundaries, &centroids, norm, &mut packed_b, dim,
+                        bytes_per_plane,
+                    );
+                    assert_eq!(
+                        packed_a, packed_b,
+                        "BITS={BITS} row {i} table={} packed bytes diverge",
+                        table_opt.is_some()
+                    );
+                    assert_eq!(
+                        scale_a.to_bits(),
+                        scale_b.to_bits(),
+                        "BITS={BITS} row {i} table={} scale diverges: {scale_a} vs {scale_b}",
+                        table_opt.is_some()
+                    );
+                }
+            }
+        }
+        run::<2>(1536);
+        run::<3>(128);
+        run::<4>(1536);
+        run::<2>(3072);
+        run::<4>(3072);
+    }
+
+    /// The vector validation predicate must agree with the scalar scan on
+    /// clean input, and report the identical first-invalid index for NaN,
+    /// +/-Inf, and over-magnitude values at every lane position.
+    #[test]
+    fn validation_matches_scalar_exactly() {
+        let n = 100;
+        let clean = pseudo_rows(1, n, 7);
+        assert_eq!(
+            first_invalid_in_chunk(&clean, 1e16),
+            first_invalid_in_chunk_scalar(&clean, 1e16)
+        );
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 1e16, -2e16] {
+            for pos in [0usize, 1, 7, 8, 15, 63, 64, 96, 99] {
+                let mut v = clean.clone();
+                v[pos] = bad;
+                assert_eq!(
+                    first_invalid_in_chunk(&v, 1e16),
+                    first_invalid_in_chunk_scalar(&v, 1e16),
+                    "bad={bad} pos={pos}"
+                );
+                assert_eq!(first_invalid_in_chunk(&v, 1e16), Some(pos));
+            }
+        }
+    }
 }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -125,8 +125,10 @@ const TQPLUS_MIN_SAMPLES: usize = 1000;
 /// quantized with the same calibration as earlier data. When `None`, fits a
 /// fresh calibration from this batch's empirical quantiles.
 ///
-/// Returns (packed_codes, scales, shift_fitted, scale_tq_fitted). The
-/// calibration pair is non-empty only when this call fitted it (i.e.
+/// Appends the packed codes and per-vector scales for this batch to
+/// `packed_out` / `scales_out` (existing contents untouched) and
+/// returns (shift_fitted, scale_tq_fitted). The calibration pair is
+/// non-empty only when this call fitted it (i.e.
 /// `existing_calibration` was `None`); on the reuse path the caller
 /// already owns the calibration and the returned pair is empty.
 ///
@@ -153,7 +155,9 @@ pub(crate) fn encode(
     bit_width: usize,
     existing_calibration: Option<(&[f32], &[f32])>,
     rotated_scratch: &mut Vec<f32>,
-) -> (Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>) {
+    packed_out: &mut Vec<u8>,
+    scales_out: &mut Vec<f32>,
+) -> (Vec<f32>, Vec<f32>) {
     // The packed layout allocates `dim / 8` bytes per bit-plane, so a dim
     // that is not a multiple of 8 has no valid layout: the tail
     // coordinates would write past the end of each plane (top plane
@@ -263,25 +267,31 @@ pub(crate) fn encode(
 
     let bytes_per_plane = dim / 8;
     let bytes_per_row = bit_width * bytes_per_plane;
+    // Append-in-place: the batch's rows land directly at the tail of the
+    // caller's buffers, so no per-call output allocation and no
+    // extend_from_slice copy afterwards.
+    let packed_old = packed_out.len();
+    let scales_old = scales_out.len();
     #[cfg(target_arch = "aarch64")]
-    let mut packed = {
+    {
         // The NEON kernel stores every byte of each packed row (one store
         // per plane per 8-coord chunk), so the zero-fill is dead work.
         // SAFETY: u8 has no invalid bit patterns, and fused_quantize_
         // scale_pack overwrites all bytes_per_row bytes of every row
-        // before `packed` is read.
-        let mut p: Vec<u8> = Vec::with_capacity(n * bytes_per_row);
+        // before the region is read.
+        packed_out.reserve(n * bytes_per_row);
         #[allow(clippy::uninit_vec)]
         unsafe {
-            p.set_len(n * bytes_per_row);
+            packed_out.set_len(packed_old + n * bytes_per_row);
         }
-        p
-    };
+    }
     // The scalar fallback ORs bits into the packed row, so it needs the
-    // zero-filled buffer.
+    // zero-filled region.
     #[cfg(not(target_arch = "aarch64"))]
-    let mut packed = vec![0u8; n * bytes_per_row];
-    let mut scales = vec![0.0f32; n];
+    packed_out.resize(packed_old + n * bytes_per_row, 0u8);
+    scales_out.resize(scales_old + n, 0.0f32);
+    let packed = &mut packed_out[packed_old..];
+    let scales = &mut scales_out[scales_old..];
 
     packed.par_chunks_mut(bytes_per_row)
         .zip(scales.par_iter_mut())
@@ -295,8 +305,7 @@ pub(crate) fn encode(
             );
         });
 
-    let (shift_out, scale_tq_out) = fitted;
-    (packed, scales, shift_out, scale_tq_out)
+    fitted
 }
 
 /// Per-coordinate TQ+ calibration. For each of the `dim` rotated coordinates,

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -52,7 +52,10 @@ const TQPLUS_MIN_SAMPLES: usize = 1000;
 /// quantized with the same calibration as earlier data. When `None`, fits a
 /// fresh calibration from this batch's empirical quantiles.
 ///
-/// Returns (packed_codes, scales, shift_used, scale_tq_used).
+/// Returns (packed_codes, scales, shift_fitted, scale_tq_fitted). The
+/// calibration pair is non-empty only when this call fitted it (i.e.
+/// `existing_calibration` was `None`); on the reuse path the caller
+/// already owns the calibration and the returned pair is empty.
 ///
 /// Crate-internal: trusts that `vectors.len() == n * dim`, that
 /// `rotation`/`boundaries`/`centroids` are correctly shaped for `dim` and
@@ -129,13 +132,23 @@ pub(crate) fn encode(
     // TQ+ per-coord (shift, scale) — fitted to empirical quantiles of the
     // rotated batch, or reused from a previous add for consistency across
     // incremental encodes.
-    let (shift, scale_tq) = match existing_calibration {
+    // Borrow an existing (frozen) calibration rather than cloning it —
+    // the warm add path hits this on every call, and the caller already
+    // owns the vectors. Freshly fitted calibration is owned here and
+    // returned; on the borrow path the returned pair is empty and the
+    // caller keeps its stored calibration unchanged.
+    let fitted: (Vec<f32>, Vec<f32>);
+    let (shift, scale_tq): (&[f32], &[f32]) = match existing_calibration {
         Some((s, sc)) => {
             assert_eq!(s.len(), dim, "existing shift length must equal dim");
             assert_eq!(sc.len(), dim, "existing scale_tq length must equal dim");
-            (s.to_vec(), sc.to_vec())
+            fitted = (Vec::new(), Vec::new());
+            (s, sc)
         }
-        None => compute_tqplus_calibration(rotated, n, dim),
+        None => {
+            fitted = compute_tqplus_calibration(rotated, n, dim);
+            (&fitted.0, &fitted.1)
+        }
     };
 
     // Precompute 1/scale_tq for the inner-product reconstruction inside the
@@ -170,13 +183,14 @@ pub(crate) fn encode(
         .for_each(|(i, (packed_row, scale))| {
             let rot_orig = &rotated[i * dim..(i + 1) * dim];
             *scale = fused_quantize_scale_pack(
-                rot_orig, &shift, &scale_tq, &inv_scale_tq,
+                rot_orig, shift, scale_tq, &inv_scale_tq,
                 boundaries, centroids, norms[i],
                 packed_row, dim, bit_width, bytes_per_plane,
             );
         });
 
-    (packed, scales, shift, scale_tq)
+    let (shift_out, scale_tq_out) = fitted;
+    (packed, scales, shift_out, scale_tq_out)
 }
 
 /// Per-coordinate TQ+ calibration. For each of the `dim` rotated coordinates,

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -346,13 +346,24 @@ fn compute_tqplus_calibration(
     // buffers (each row contributes a contiguous 4*tile-byte read). The
     // collected values per coord are identical, so the selected quantiles
     // — and every downstream encoded byte — are unchanged.
-    const CALIB_COORD_TILE: usize = 128;
+    // Tile size trades streaming passes against parallelism: each tile
+    // re-streams the whole rotated batch once, but tiles are also the
+    // unit of fan-out. Pick the largest power-of-two tile (<= 256) that
+    // still yields ~2 tiles per rayon worker; single-threaded runs get
+    // the full 256. The choice only affects scheduling — the collected
+    // values per coordinate, and every encoded byte, are identical for
+    // any tile size.
+    let workers = rayon::current_num_threads().max(1);
+    let mut tile_size = 256usize;
+    while tile_size > 32 && dim / tile_size < 2 * workers {
+        tile_size /= 2;
+    }
     shift
-        .par_chunks_mut(CALIB_COORD_TILE)
-        .zip(scale.par_chunks_mut(CALIB_COORD_TILE))
+        .par_chunks_mut(tile_size)
+        .zip(scale.par_chunks_mut(tile_size))
         .enumerate()
         .for_each(|(tile_idx, (sh_tile, sc_tile))| {
-            let d0 = tile_idx * CALIB_COORD_TILE;
+            let d0 = tile_idx * tile_size;
             let tile = sh_tile.len();
             let mut cols = vec![0.0f32; tile * n];
             for i in 0..n {

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -346,7 +346,7 @@ fn compute_tqplus_calibration(
     // buffers (each row contributes a contiguous 4*tile-byte read). The
     // collected values per coord are identical, so the selected quantiles
     // — and every downstream encoded byte — are unchanged.
-    const CALIB_COORD_TILE: usize = 64;
+    const CALIB_COORD_TILE: usize = 128;
     shift
         .par_chunks_mut(CALIB_COORD_TILE)
         .zip(scale.par_chunks_mut(CALIB_COORD_TILE))

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -33,6 +33,33 @@ use statrs::distribution::{Beta, ContinuousCDF};
 
 use crate::rotation::Rotation;
 
+/// Parallel invalid-coordinate scan backing
+/// [`crate::first_invalid_coord`]. Fixed chunks reduced by minimum flat
+/// index, so the reported (vector, coord, value) is identical to a
+/// left-to-right scan; the all-clean case (every call on the hot add
+/// path) is one streaming pass split across the current rayon pool.
+pub(crate) fn par_first_invalid_coord(
+    values: &[f32],
+    dim: usize,
+    max_magnitude: f32,
+) -> Option<(usize, usize, f32)> {
+    const VALIDATE_CHUNK: usize = 64 * 1024;
+    let first = values
+        .par_chunks(VALIDATE_CHUNK)
+        .enumerate()
+        .filter_map(|(ci, chunk)| {
+            chunk
+                .iter()
+                .position(|x| !x.is_finite() || x.abs() >= max_magnitude)
+                .map(|j| ci * VALIDATE_CHUNK + j)
+        })
+        .min()?;
+    let x = values[first];
+    let vector_index = if dim == 0 { 0 } else { first / dim };
+    let coord_index = if dim == 0 { first } else { first % dim };
+    Some((vector_index, coord_index, x))
+}
+
 /// Quantile pair used to fit per-coord `(shift, scale)`.
 const TQPLUS_P_LO: f64 = 0.05;
 const TQPLUS_P_HI: f64 = 0.95;

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -48,16 +48,62 @@ pub(crate) fn par_first_invalid_coord(
         .par_chunks(VALIDATE_CHUNK)
         .enumerate()
         .filter_map(|(ci, chunk)| {
-            chunk
-                .iter()
-                .position(|x| !x.is_finite() || x.abs() >= max_magnitude)
-                .map(|j| ci * VALIDATE_CHUNK + j)
+            first_invalid_in_chunk(chunk, max_magnitude).map(|j| ci * VALIDATE_CHUNK + j)
         })
         .min()?;
     let x = values[first];
     let vector_index = if dim == 0 { 0 } else { first / dim };
     let coord_index = if dim == 0 { first } else { first % dim };
     Some((vector_index, coord_index, x))
+}
+
+/// Position of the first invalid element in `chunk`, or `None`.
+///
+/// The predicate is `!(|x| < max_magnitude)` — identical to
+/// `!x.is_finite() || x.abs() >= max_magnitude`: NaN fails every
+/// comparison, ±Inf and over-magnitude values fail `<`. On aarch64 the
+/// all-clean fast path tests 4 lanes per `vcalt`; a failing quad falls
+/// back to a scalar scan so the reported index matches the scalar path
+/// exactly.
+#[cfg(target_arch = "aarch64")]
+#[inline]
+fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
+    use std::arch::aarch64::*;
+    let n = chunk.len();
+    let quads = n / 4;
+    unsafe {
+        let bound = vdupq_n_f32(max_magnitude);
+        for q in 0..quads {
+            let x = vld1q_f32(chunk.as_ptr().add(q * 4));
+            // Lane is all-ones iff |x| < bound (false for NaN/Inf/huge).
+            let ok = vcaltq_f32(x, bound);
+            if vminvq_u32(ok) == 0 {
+                // Some lane failed — pinpoint with the scalar predicate.
+                for j in q * 4..n {
+                    let v = chunk[j];
+                    if !(v.abs() < max_magnitude) {
+                        return Some(j);
+                    }
+                }
+                unreachable!("vector scan flagged a quad with no invalid element");
+            }
+        }
+        for j in quads * 4..n {
+            let v = chunk[j];
+            if !(v.abs() < max_magnitude) {
+                return Some(j);
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline]
+fn first_invalid_in_chunk(chunk: &[f32], max_magnitude: f32) -> Option<usize> {
+    chunk
+        .iter()
+        .position(|x| !x.is_finite() || x.abs() >= max_magnitude)
 }
 
 /// Quantile pair used to fit per-coord `(shift, scale)`.

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -128,19 +128,6 @@ pub(crate) fn encode(
         None => compute_tqplus_calibration(rotated, n, dim),
     };
 
-    // Materialize calibrated rotated values for the boundary-scan path.
-    // Memory cost: n * dim * 4 bytes (= same as `unit_flat`). At d=3072,
-    // n=100k this is 1.2 GB — still well under the rotate intermediate
-    // and encoding is one-shot, so we eat the allocation rather than
-    // recompute inline per row.
-    let mut rotated_calib = vec![0.0f32; n * dim];
-    rotated_calib.par_chunks_mut(dim).enumerate().for_each(|(i, calib_row)| {
-        let orig_row = &rotated[i * dim..(i + 1) * dim];
-        for d in 0..dim {
-            calib_row[d] = (orig_row[d] + shift[d]) * scale_tq[d];
-        }
-    });
-
     // Precompute 1/scale_tq for the inner-product reconstruction inside the
     // fused per-row function. Avoids a divide per coord per vector.
     let inv_scale_tq: Vec<f32> = scale_tq.iter().map(|s| 1.0 / s).collect();
@@ -155,9 +142,8 @@ pub(crate) fn encode(
         .enumerate()
         .for_each(|(i, (packed_row, scale))| {
             let rot_orig = &rotated[i * dim..(i + 1) * dim];
-            let rot_calib = &rotated_calib[i * dim..(i + 1) * dim];
             *scale = fused_quantize_scale_pack(
-                rot_orig, rot_calib, &shift, &inv_scale_tq,
+                rot_orig, &shift, &scale_tq, &inv_scale_tq,
                 boundaries, centroids, norms[i],
                 packed_row, dim, bit_width, bytes_per_plane,
             );
@@ -302,8 +288,8 @@ fn simd_scale(row: &[f32], scale: f32, out: &mut [f32]) {
 #[inline(always)]
 fn fused_quantize_scale_pack(
     rot_orig: &[f32],
-    rot_calib: &[f32],
     shift: &[f32],
+    scale_tq: &[f32],
     inv_scale_tq: &[f32],
     boundaries: &[f32],
     centroids: &[f32],
@@ -323,9 +309,24 @@ fn fused_quantize_scale_pack(
             let offset = c * 8;
             // Boundary scan on the CALIBRATED rotated values — TQ+ moves
             // each coord's empirical distribution onto the canonical Beta
-            // marginal that Lloyd-Max was fit against.
-            let vals_lo = vld1q_f32(rot_calib.as_ptr().add(offset));
-            let vals_hi = vld1q_f32(rot_calib.as_ptr().add(offset + 4));
+            // marginal that Lloyd-Max was fit against. Calibration is
+            // computed inline — `(x + shift) * scale_tq` per element, the
+            // same IEEE ops the old batch-materialized buffer stored — so
+            // no n*dim intermediate is allocated, written, and re-read.
+            let vals_lo = vmulq_f32(
+                vaddq_f32(
+                    vld1q_f32(rot_orig.as_ptr().add(offset)),
+                    vld1q_f32(shift.as_ptr().add(offset)),
+                ),
+                vld1q_f32(scale_tq.as_ptr().add(offset)),
+            );
+            let vals_hi = vmulq_f32(
+                vaddq_f32(
+                    vld1q_f32(rot_orig.as_ptr().add(offset + 4)),
+                    vld1q_f32(shift.as_ptr().add(offset + 4)),
+                ),
+                vld1q_f32(scale_tq.as_ptr().add(offset + 4)),
+            );
 
             let mut acc_lo = vdupq_n_u32(0);
             let mut acc_hi = vdupq_n_u32(0);
@@ -426,8 +427,8 @@ fn scale_from_inner(inner: f64, norm: f32) -> f32 {
 #[inline(always)]
 fn fused_quantize_scale_pack(
     rot_orig: &[f32],
-    rot_calib: &[f32],
     shift: &[f32],
+    scale_tq: &[f32],
     inv_scale_tq: &[f32],
     boundaries: &[f32],
     centroids: &[f32],
@@ -440,9 +441,10 @@ fn fused_quantize_scale_pack(
     let mut inner = 0.0f64;
 
     for j in 0..dim {
+        let calib = (rot_orig[j] + shift[j]) * scale_tq[j];
         let mut code = 0u8;
         for &b in boundaries {
-            if rot_calib[j] > b { code += 1; }
+            if calib > b { code += 1; }
         }
         let centroid_in_orig =
             (centroids[code as usize] as f64) * (inv_scale_tq[j] as f64)

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -200,9 +200,17 @@ fn compute_tqplus_calibration(
     shift.par_iter_mut().zip(scale.par_iter_mut()).enumerate().for_each(
         |(d, (sh, sc))| {
             let mut coord: Vec<f32> = (0..n).map(|i| rotated[i * dim + d]).collect();
-            coord.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
-            let qe_lo = coord[lo_idx];
-            let qe_hi = coord[hi_idx];
+            // Only the two quantile order statistics are needed, so two
+            // O(n) selects replace a full O(n log n) sort. Select the
+            // upper quantile first, then the lower one within the left
+            // partition — the values are identical to indexing a fully
+            // sorted array. This is the dominant first-add cost at scale
+            // (dim independent selects over n values each).
+            let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
+            let (left, hi_val, _) = coord.select_nth_unstable_by(hi_idx, cmp);
+            let qe_hi = *hi_val;
+            let (_, lo_val, _) = left.select_nth_unstable_by(lo_idx, cmp);
+            let qe_lo = *lo_val;
             let qe_span = qe_hi - qe_lo;
             if qe_span > 1e-6 {
                 *sc = qc_span / qe_span;

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -525,10 +525,33 @@ fn fused_quantize_scale_pack<const BITS: usize>(
             let mut acc_lo = vdupq_n_u32(0);
             let mut acc_hi = vdupq_n_u32(0);
 
-            for bi in 0..(1usize << BITS) - 1 {
-                let bv = vdupq_n_f32(boundaries[bi]);
-                acc_lo = vaddq_u32(acc_lo, vshrq_n_u32::<31>(vcgtq_f32(vals_lo, bv)));
-                acc_hi = vaddq_u32(acc_hi, vshrq_n_u32::<31>(vcgtq_f32(vals_hi, bv)));
+            if BITS == 4 {
+                // Two-level scan: one compare against the median boundary
+                // decides, per lane, which 7-boundary half to count.
+                // code = 8*(x > b[7]) + sum over the selected half of
+                // (x > b_k) — exactly the count the flat scan produces,
+                // since x > b[7] implies x exceeds all of b[0..=7].
+                let mid = vdupq_n_f32(boundaries[7]);
+                let m_lo = vcgtq_f32(vals_lo, mid);
+                let m_hi = vcgtq_f32(vals_hi, mid);
+                acc_lo = vshlq_n_u32::<3>(vshrq_n_u32::<31>(m_lo));
+                acc_hi = vshlq_n_u32::<3>(vshrq_n_u32::<31>(m_hi));
+                for k in 0..7 {
+                    let b_low = vdupq_n_f32(boundaries[k]);
+                    let b_high = vdupq_n_f32(boundaries[8 + k]);
+                    let bv_lo = vbslq_f32(m_lo, b_high, b_low);
+                    let bv_hi = vbslq_f32(m_hi, b_high, b_low);
+                    acc_lo =
+                        vaddq_u32(acc_lo, vshrq_n_u32::<31>(vcgtq_f32(vals_lo, bv_lo)));
+                    acc_hi =
+                        vaddq_u32(acc_hi, vshrq_n_u32::<31>(vcgtq_f32(vals_hi, bv_hi)));
+                }
+            } else {
+                for bi in 0..(1usize << BITS) - 1 {
+                    let bv = vdupq_n_f32(boundaries[bi]);
+                    acc_lo = vaddq_u32(acc_lo, vshrq_n_u32::<31>(vcgtq_f32(vals_lo, bv)));
+                    acc_hi = vaddq_u32(acc_hi, vshrq_n_u32::<31>(vcgtq_f32(vals_hi, bv)));
+                }
             }
 
             let counts: [u8; 8] = [

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -293,19 +293,59 @@ pub(crate) fn encode(
     let packed = &mut packed_out[packed_old..];
     let scales = &mut scales_out[scales_old..];
 
+    // Monomorphized per bit-width so the per-plane pack loop and the
+    // boundary scan fully unroll (bit_width is validated to {2, 3, 4}
+    // at construction). Identical operations, identical bytes.
+    match bit_width {
+        2 => quantize_batch::<2>(
+            packed, scales, rotated, shift, scale_tq, &inv_scale_tq,
+            centroid_orig.as_deref(), boundaries, centroids, &norms, dim,
+            bytes_per_row, bytes_per_plane,
+        ),
+        3 => quantize_batch::<3>(
+            packed, scales, rotated, shift, scale_tq, &inv_scale_tq,
+            centroid_orig.as_deref(), boundaries, centroids, &norms, dim,
+            bytes_per_row, bytes_per_plane,
+        ),
+        4 => quantize_batch::<4>(
+            packed, scales, rotated, shift, scale_tq, &inv_scale_tq,
+            centroid_orig.as_deref(), boundaries, centroids, &norms, dim,
+            bytes_per_row, bytes_per_plane,
+        ),
+        other => unreachable!("unsupported bit_width {other}"),
+    }
+
+    fitted
+}
+
+/// Quantize + pack the whole batch with a compile-time bit width.
+#[allow(clippy::too_many_arguments)]
+fn quantize_batch<const BITS: usize>(
+    packed: &mut [u8],
+    scales: &mut [f32],
+    rotated: &[f32],
+    shift: &[f32],
+    scale_tq: &[f32],
+    inv_scale_tq: &[f32],
+    centroid_orig: Option<&[f64]>,
+    boundaries: &[f32],
+    centroids: &[f32],
+    norms: &[f32],
+    dim: usize,
+    bytes_per_row: usize,
+    bytes_per_plane: usize,
+) {
     packed.par_chunks_mut(bytes_per_row)
         .zip(scales.par_iter_mut())
         .enumerate()
         .for_each(|(i, (packed_row, scale))| {
             let rot_orig = &rotated[i * dim..(i + 1) * dim];
-            *scale = fused_quantize_scale_pack(
-                rot_orig, shift, scale_tq, &inv_scale_tq,
-                centroid_orig.as_deref(), boundaries, centroids, norms[i],
-                packed_row, dim, bit_width, bytes_per_plane,
+            *scale = fused_quantize_scale_pack::<BITS>(
+                rot_orig, shift, scale_tq, inv_scale_tq,
+                centroid_orig, boundaries, centroids, norms[i],
+                packed_row, dim, bytes_per_plane,
             );
         });
-
-    fitted
 }
 
 /// Per-coordinate TQ+ calibration. For each of the `dim` rotated coordinates,
@@ -446,7 +486,7 @@ fn simd_norm(row: &[f32]) -> f32 {
 /// ```
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
-fn fused_quantize_scale_pack(
+fn fused_quantize_scale_pack<const BITS: usize>(
     rot_orig: &[f32],
     shift: &[f32],
     scale_tq: &[f32],
@@ -457,7 +497,6 @@ fn fused_quantize_scale_pack(
     norm: f32,
     packed_row: &mut [u8],
     dim: usize,
-    bits: usize,
     bytes_per_plane: usize,
 ) -> f32 {
     use std::arch::aarch64::*;
@@ -492,8 +531,8 @@ fn fused_quantize_scale_pack(
             let mut acc_lo = vdupq_n_u32(0);
             let mut acc_hi = vdupq_n_u32(0);
 
-            for &b in boundaries {
-                let bv = vdupq_n_f32(b);
+            for bi in 0..(1usize << BITS) - 1 {
+                let bv = vdupq_n_f32(boundaries[bi]);
                 acc_lo = vaddq_u32(acc_lo, vshrq_n_u32::<31>(vcgtq_f32(vals_lo, bv)));
                 acc_hi = vaddq_u32(acc_hi, vshrq_n_u32::<31>(vcgtq_f32(vals_hi, bv)));
             }
@@ -537,7 +576,7 @@ fn fused_quantize_scale_pack(
             let weights: [u8; 8] = [128, 64, 32, 16, 8, 4, 2, 1];
             let wv = vld1_u8(weights.as_ptr());
 
-            for p in 0..bits {
+            for p in 0..BITS {
                 let mask = vdup_n_u8(1u8 << p);
                 let hit = vcgt_u8(vand_u8(codes_vec, mask), vdup_n_u8(0));
                 packed_row[p * bytes_per_plane + offset / 8] = vaddv_u8(vand_u8(hit, wv));
@@ -600,7 +639,7 @@ fn scale_from_inner(inner: f64, norm: f32) -> f32 {
 
 #[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
-fn fused_quantize_scale_pack(
+fn fused_quantize_scale_pack<const BITS: usize>(
     rot_orig: &[f32],
     shift: &[f32],
     scale_tq: &[f32],
@@ -611,7 +650,6 @@ fn fused_quantize_scale_pack(
     norm: f32,
     packed_row: &mut [u8],
     dim: usize,
-    bits: usize,
     bytes_per_plane: usize,
 ) -> f32 {
     let mut inner = 0.0f64;
@@ -619,8 +657,8 @@ fn fused_quantize_scale_pack(
     for j in 0..dim {
         let calib = (rot_orig[j] + shift[j]) * scale_tq[j];
         let mut code = 0u8;
-        for &b in boundaries {
-            if calib > b { code += 1; }
+        for bi in 0..(1usize << BITS) - 1 {
+            if calib > boundaries[bi] { code += 1; }
         }
         // Same table-or-inline split as the aarch64 kernel; identical
         // ops either way, so results are bit-identical.
@@ -635,7 +673,7 @@ fn fused_quantize_scale_pack(
 
         let byte_pos = j / 8;
         let bit_pos = 7 - (j % 8);
-        for p in 0..bits {
+        for p in 0..BITS {
             if code & (1 << p) != 0 {
                 packed_row[p * bytes_per_plane + byte_pos] |= 1 << bit_pos;
             }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -88,7 +88,17 @@ pub(crate) fn encode(
         "encode requires dim to be a nonzero multiple of 8, got {dim}",
     );
     let mut norms = vec![0.0f32; n];
-    let mut unit_flat = vec![0.0f32; n * dim];
+    // Fully overwritten by the normalize pass below before any read —
+    // zero-filling n*dim floats serially just throttles the parallel
+    // pass that immediately rewrites them.
+    let mut unit_flat = Vec::with_capacity(n * dim);
+    #[allow(clippy::uninit_vec)]
+    // SAFETY: f32 has no invalid bit patterns, and every element is
+    // written by the normalize pass (each row chunk is fully written by
+    // simd_scale) before `unit_flat` is read.
+    unsafe {
+        unit_flat.set_len(n * dim);
+    }
 
     // Normalize. Rows are independent so Rayon splits them across cores.
     norms.par_iter_mut()
@@ -134,6 +144,23 @@ pub(crate) fn encode(
 
     let bytes_per_plane = dim / 8;
     let bytes_per_row = bit_width * bytes_per_plane;
+    #[cfg(target_arch = "aarch64")]
+    let mut packed = {
+        // The NEON kernel stores every byte of each packed row (one store
+        // per plane per 8-coord chunk), so the zero-fill is dead work.
+        // SAFETY: u8 has no invalid bit patterns, and fused_quantize_
+        // scale_pack overwrites all bytes_per_row bytes of every row
+        // before `packed` is read.
+        let mut p: Vec<u8> = Vec::with_capacity(n * bytes_per_row);
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            p.set_len(n * bytes_per_row);
+        }
+        p
+    };
+    // The scalar fallback ORs bits into the packed row, so it needs the
+    // zero-filled buffer.
+    #[cfg(not(target_arch = "aarch64"))]
     let mut packed = vec![0u8; n * bytes_per_row];
     let mut scales = vec![0.0f32; n];
 

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -384,11 +384,11 @@ fn compute_tqplus_calibration(
     // re-streams the whole rotated batch once, but tiles are also the
     // unit of fan-out. Pick the largest power-of-two tile (<= 256) that
     // still yields ~2 tiles per rayon worker; single-threaded runs get
-    // the full 256. The choice only affects scheduling — the collected
+    // the full 512. The choice only affects scheduling — the collected
     // values per coordinate, and every encoded byte, are identical for
     // any tile size.
     let workers = rayon::current_num_threads().max(1);
-    let mut tile_size = 256usize;
+    let mut tile_size = 512usize;
     while tile_size > 32 && dim / tile_size < 2 * workers {
         tile_size /= 2;
     }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -384,11 +384,11 @@ fn compute_tqplus_calibration(
     // re-streams the whole rotated batch once, but tiles are also the
     // unit of fan-out. Pick the largest power-of-two tile (<= 256) that
     // still yields ~2 tiles per rayon worker; single-threaded runs get
-    // the full 512. The choice only affects scheduling — the collected
+    // the full 768. The choice only affects scheduling — the collected
     // values per coordinate, and every encoded byte, are identical for
     // any tile size.
     let workers = rayon::current_num_threads().max(1);
-    let mut tile_size = 512usize;
+    let mut tile_size = 768usize;
     while tile_size > 32 && dim / tile_size < 2 * workers {
         tile_size /= 2;
     }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -174,15 +174,6 @@ pub(crate) fn encode(
     // path performs the identical multiplies in the identical order, so
     // encoded bytes are unchanged.
     let mut norms = vec![0.0f32; n];
-    let mut inv_norms = vec![0.0f32; n];
-    norms.par_iter_mut()
-        .zip(inv_norms.par_iter_mut())
-        .enumerate()
-        .for_each(|(i, (norm, inv))| {
-            let n_val = simd_norm(&vectors[i * dim..(i + 1) * dim]);
-            *norm = n_val;
-            *inv = if n_val > 1e-10 { 1.0 / n_val } else { 0.0 };
-        });
 
     // Rotate each raw row into `rotated_buf` via the deterministic
     // block-Hadamard transform, applying 1/||v|| in the first gather.
@@ -203,16 +194,19 @@ pub(crate) fn encode(
     unsafe {
         rotated_buf.set_len(n * dim);
     }
+    // The norm is computed in the same per-row task as the rotation —
+    // the row is already in cache, so the separate full-batch norms
+    // pass disappears. Same per-row operations, identical bytes.
     rotated_buf
         .par_chunks_mut(dim)
+        .zip(norms.par_iter_mut())
         .enumerate()
-        .for_each_init(|| vec![0.0f32; dim], |scratch, (i, dst_row)| {
-            rotation.apply_scaled_into(
-                &vectors[i * dim..(i + 1) * dim],
-                inv_norms[i],
-                dst_row,
-                scratch,
-            )
+        .for_each_init(|| vec![0.0f32; dim], |scratch, (i, (dst_row, norm))| {
+            let src = &vectors[i * dim..(i + 1) * dim];
+            let n_val = simd_norm(src);
+            *norm = n_val;
+            let inv = if n_val > 1e-10 { 1.0 / n_val } else { 0.0 };
+            rotation.apply_scaled_into(src, inv, dst_row, scratch)
         });
     let rotated: &[f32] = rotated_buf;
 

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -502,8 +502,16 @@ fn fused_quantize_scale_pack<const BITS: usize>(
 ) -> f32 {
     use std::arch::aarch64::*;
 
-    let mut inner = 0.0f64;
     let chunks = dim / 8;
+    // Four fixed accumulation chains (two f64x2 registers): term j joins
+    // chain j % 4; final combine ((a0 + a1) + (b0 + b1)). Deterministic,
+    // mirrored exactly by the scalar fallback.
+    let mut acc_a;
+    let mut acc_b;
+    unsafe {
+        acc_a = vdupq_n_f64(0.0);
+        acc_b = vdupq_n_f64(0.0);
+    }
 
     unsafe {
         for c in 0..chunks {
@@ -576,11 +584,12 @@ fn fused_quantize_scale_pack<const BITS: usize>(
             // comment): from the hoisted per-(code, coord) table when the
             // batch amortized building it, otherwise inline — the same
             // ops per element, so results are bit-identical.
+            let mut terms = [0.0f64; 8];
             match centroid_orig {
                 Some(table) => {
                     for k in 0..8 {
                         let d = offset + k;
-                        inner += (rot_orig[d] as f64)
+                        terms[k] = (rot_orig[d] as f64)
                             * table[counts[k] as usize * dim + d];
                     }
                 }
@@ -590,10 +599,14 @@ fn fused_quantize_scale_pack<const BITS: usize>(
                         let centroid_in_orig = (centroids[counts[k] as usize] as f64)
                             * (inv_scale_tq[d] as f64)
                             - (shift[d] as f64);
-                        inner += (rot_orig[d] as f64) * centroid_in_orig;
+                        terms[k] = (rot_orig[d] as f64) * centroid_in_orig;
                     }
                 }
             }
+            acc_a = vaddq_f64(acc_a, vld1q_f64(terms.as_ptr()));
+            acc_b = vaddq_f64(acc_b, vld1q_f64(terms.as_ptr().add(2)));
+            acc_a = vaddq_f64(acc_a, vld1q_f64(terms.as_ptr().add(4)));
+            acc_b = vaddq_f64(acc_b, vld1q_f64(terms.as_ptr().add(6)));
 
             // Pack 8 codes into one byte per bit-plane (unchanged).
             let codes_vec = vld1_u8(counts.as_ptr());
@@ -611,6 +624,10 @@ fn fused_quantize_scale_pack<const BITS: usize>(
         // truncates, so tail coordinates have no bytes to land in; see #117.)
     }
 
+    let inner = unsafe {
+        (vgetq_lane_f64::<0>(acc_a) + vgetq_lane_f64::<1>(acc_a))
+            + (vgetq_lane_f64::<0>(acc_b) + vgetq_lane_f64::<1>(acc_b))
+    };
     scale_from_inner(inner, norm)
 }
 
@@ -676,7 +693,9 @@ fn fused_quantize_scale_pack<const BITS: usize>(
     dim: usize,
     bytes_per_plane: usize,
 ) -> f32 {
-    let mut inner = 0.0f64;
+    // Four fixed chains mirroring the aarch64 kernel (chain j % 4;
+    // combine ((c0 + c1) + (c2 + c3))).
+    let mut chains = [0.0f64; 4];
 
     for j in 0..dim {
         let calib = (rot_orig[j] + shift[j]) * scale_tq[j];
@@ -693,7 +712,7 @@ fn fused_quantize_scale_pack<const BITS: usize>(
                     - (shift[j] as f64)
             }
         };
-        inner += (rot_orig[j] as f64) * centroid_in_orig;
+        chains[j % 4] += (rot_orig[j] as f64) * centroid_in_orig;
 
         let byte_pos = j / 8;
         let bit_pos = 7 - (j % 8);
@@ -704,5 +723,6 @@ fn fused_quantize_scale_pack<const BITS: usize>(
         }
     }
 
+    let inner = (chains[0] + chains[1]) + (chains[2] + chains[3]);
     scale_from_inner(inner, norm)
 }

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -41,8 +41,13 @@ use std::hash::{BuildHasherDefault, Hasher};
 /// Multiply-shift hasher for the external-id maps. Ids are caller-chosen
 /// u64s, not attacker-controlled protocol input, so SipHash's HashDoS
 /// resistance buys nothing here while costing a measurable slice of the
-/// O(1) remove path. Fibonacci multiply-shift gives full avalanche on the
-/// high bits (which hashbrown uses for bucket selection) in one multiply.
+/// O(1) remove path. Fibonacci multiply-shift mixes the input into both
+/// halves of the hash in one multiply — hashbrown derives the bucket
+/// index from the low bits and its 7-bit control tags from the top bits,
+/// and the multiply feeds entropy to both. Note the "not attacker
+/// controlled" premise is an application assumption: the hash is
+/// trivially invertible, so a service that lets untrusted callers choose
+/// ids inherits O(n) bucket-collision behavior on this map.
 #[derive(Default)]
 pub(crate) struct IdHasher(u64);
 

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -36,6 +36,39 @@
 //!   pass over the returned slot indices.
 
 use std::collections::HashMap;
+use std::hash::{BuildHasherDefault, Hasher};
+
+/// Multiply-shift hasher for the external-id maps. Ids are caller-chosen
+/// u64s, not attacker-controlled protocol input, so SipHash's HashDoS
+/// resistance buys nothing here while costing a measurable slice of the
+/// O(1) remove path. Fibonacci multiply-shift gives full avalanche on the
+/// high bits (which hashbrown uses for bucket selection) in one multiply.
+#[derive(Default)]
+pub(crate) struct IdHasher(u64);
+
+impl Hasher for IdHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        // Only u64 keys are ever hashed by the id maps; this fallback
+        // keeps the impl total for completeness.
+        for &b in bytes {
+            self.0 = (self.0 ^ b as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        }
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+}
+
+/// `BuildHasher` for [`IdHasher`]-keyed maps.
+pub(crate) type IdBuildHasher = BuildHasherDefault<IdHasher>;
 use std::path::Path;
 
 use crate::io;
@@ -49,7 +82,7 @@ pub struct IdMapIndex {
     /// currently stored in slot `i` of `inner`.
     slot_to_id: Vec<u64>,
     /// external id → slot. Kept in sync with `slot_to_id`.
-    id_to_slot: HashMap<u64, usize>,
+    id_to_slot: HashMap<u64, usize, IdBuildHasher>,
 }
 
 impl IdMapIndex {
@@ -60,7 +93,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: TurboQuantIndex::new(dim, bit_width)?,
             slot_to_id: Vec::new(),
-            id_to_slot: HashMap::new(),
+            id_to_slot: HashMap::default(),
         })
     }
 
@@ -71,7 +104,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: TurboQuantIndex::new_lazy(bit_width)?,
             slot_to_id: Vec::new(),
-            id_to_slot: HashMap::new(),
+            id_to_slot: HashMap::default(),
         })
     }
 
@@ -128,8 +161,8 @@ impl IdMapIndex {
         // Validate all ids up-front so a partial failure is impossible.
         // Reject both ids already in the index and duplicates within
         // this call.
-        let mut seen_this_call: std::collections::HashSet<u64> =
-            std::collections::HashSet::with_capacity(n);
+        let mut seen_this_call: std::collections::HashSet<u64, IdBuildHasher> =
+            std::collections::HashSet::with_capacity_and_hasher(n, IdBuildHasher::default());
         for &id in ids {
             if self.id_to_slot.contains_key(&id) || !seen_this_call.insert(id) {
                 return Err(AddError::IdAlreadyPresent(id));
@@ -363,7 +396,7 @@ impl IdMapIndex {
             dim_opt, bit_width, n_vectors, packed_codes, scales, tqplus_shift, tqplus_scale,
         )
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-        let id_to_slot: HashMap<u64, usize> = slot_to_id
+        let id_to_slot: HashMap<u64, usize, IdBuildHasher> = slot_to_id
             .iter()
             .enumerate()
             .map(|(slot, &id)| (id, slot))

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -167,6 +167,7 @@ mod encode_pipeline {
 
         let (packed, scales, _, _) = encode(
             &vectors, n, dim, &rotation, &boundaries, &centroids, 3, None,
+            &mut Vec::new(),
         );
 
         let bytes_per_row = 3 * (dim / 8);
@@ -185,6 +186,7 @@ mod encode_pipeline {
 
             let (packed, scales, _, _) = encode(
                 &vectors, n, dim, &rotation, &boundaries, &centroids, bit_width, None,
+                &mut Vec::new(),
             );
 
             let bytes_per_row = bit_width * (dim / 8);
@@ -208,7 +210,7 @@ mod encode_pipeline {
         let vectors = make_vectors(n, dim, 0);
 
         let (_, scales, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
+            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
 
         for i in 0..n {
             let row = &vectors[i * dim..(i + 1) * dim];
@@ -254,9 +256,9 @@ mod encode_pipeline {
         let vectors = make_vectors(n, dim, 0);
 
         let (p1, s1, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
+            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
         let (p2, s2, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
+            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
 
         assert_eq!(p1, p2);
         assert_eq!(s1, s2);
@@ -270,7 +272,7 @@ mod encode_pipeline {
         let zeros = vec![0.0f32; dim];
 
         let (packed, scales, _, _) =
-            encode(&zeros, 1, dim, &rotation, &boundaries, &centroids, 4, None);
+            encode(&zeros, 1, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
 
         assert_eq!(scales[0], 0.0);
         assert!(scales[0].is_finite());
@@ -585,6 +587,7 @@ mod core_encode_hardening {
         let (boundaries, centroids) = codebook(4, dim);
         let (_, _, shift, scale_tq) = encode(
             &vectors, n, dim, &rotation, &boundaries, &centroids, 4, None,
+            &mut Vec::new(),
         );
 
         let mut ood = vec![0.0f32; dim];
@@ -592,6 +595,7 @@ mod core_encode_hardening {
         let (_, scales, _, _) = encode(
             &ood, 1, dim, &rotation, &boundaries, &centroids, 4,
             Some((&shift, &scale_tq)),
+            &mut Vec::new(),
         );
         assert!(
             scales[0].abs() < 10.0,
@@ -603,6 +607,7 @@ mod core_encode_hardening {
         let (_, zero_scales, _, _) = encode(
             &zero, 1, dim, &rotation, &boundaries, &centroids, 4,
             Some((&shift, &scale_tq)),
+            &mut Vec::new(),
         );
         assert_eq!(zero_scales[0], 0.0, "zero vector must keep scale 0");
 
@@ -611,6 +616,7 @@ mod core_encode_hardening {
         let (_, nan_scales, _, _) = encode(
             &nan_vec, 1, dim, &rotation, &boundaries, &centroids, 4,
             Some((&shift, &scale_tq)),
+            &mut Vec::new(),
         );
         assert_eq!(
             nan_scales[0], 0.0,
@@ -636,6 +642,7 @@ mod core_encode_hardening {
         let (boundaries, centroids) = codebook(4, dim);
         let (_, _, shift, scale_tq) = encode(
             &cluster, n, dim, &rotation, &boundaries, &centroids, 4, None,
+            &mut Vec::new(),
         );
         let steps = 720;
         let mut sweep = vec![0.0f32; steps * dim];
@@ -647,6 +654,7 @@ mod core_encode_hardening {
         let (_, sweep_scales, _, _) = encode(
             &sweep, steps, dim, &rotation, &boundaries, &centroids, 4,
             Some((&shift, &scale_tq)),
+            &mut Vec::new(),
         );
         for (t, &s) in sweep_scales.iter().enumerate() {
             assert!(
@@ -699,6 +707,7 @@ mod core_encode_hardening {
         let vectors = vec![0.25f32; n * dim];
         let _ = encode(
             &vectors, n, dim, &rotation, &boundaries, &centroids, 2, None,
+            &mut Vec::new(),
         );
     }
 

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -141,6 +141,27 @@ mod codebook_correctness {
 mod encode_pipeline {
     use crate::codebook::codebook;
     use crate::encode::encode;
+    /// Test shim preserving the old owned-return encode signature.
+    #[allow(clippy::too_many_arguments)]
+    fn encode_owned(
+        vectors: &[f32],
+        n: usize,
+        dim: usize,
+        rotation: &crate::rotation::Rotation,
+        boundaries: &[f32],
+        centroids: &[f32],
+        bit_width: usize,
+        existing: Option<(&[f32], &[f32])>,
+    ) -> (Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>) {
+        let mut packed = Vec::new();
+        let mut scales = Vec::new();
+        let (shift, scale_tq) = crate::encode::encode(
+            vectors, n, dim, rotation, boundaries, centroids, bit_width, existing,
+            &mut Vec::new(), &mut packed, &mut scales,
+        );
+        (packed, scales, shift, scale_tq)
+    }
+
     use crate::rotation::Rotation;
 
     fn make_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
@@ -165,9 +186,8 @@ mod encode_pipeline {
         let (boundaries, centroids) = codebook(3, dim);
         let vectors = make_vectors(n, dim, 0);
 
-        let (packed, scales, _, _) = encode(
-            &vectors, n, dim, &rotation, &boundaries, &centroids, 3, None,
-            &mut Vec::new(),
+        let (packed, scales, _, _) = encode_owned(
+            &vectors, n, dim, &rotation, &boundaries, &centroids, 3, None
         );
 
         let bytes_per_row = 3 * (dim / 8);
@@ -184,9 +204,8 @@ mod encode_pipeline {
             let (boundaries, centroids) = codebook(bit_width, dim);
             let vectors = make_vectors(n, dim, 0);
 
-            let (packed, scales, _, _) = encode(
-                &vectors, n, dim, &rotation, &boundaries, &centroids, bit_width, None,
-                &mut Vec::new(),
+            let (packed, scales, _, _) = encode_owned(
+                &vectors, n, dim, &rotation, &boundaries, &centroids, bit_width, None
             );
 
             let bytes_per_row = bit_width * (dim / 8);
@@ -210,7 +229,7 @@ mod encode_pipeline {
         let vectors = make_vectors(n, dim, 0);
 
         let (_, scales, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
+            encode_owned(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
 
         for i in 0..n {
             let row = &vectors[i * dim..(i + 1) * dim];
@@ -256,9 +275,9 @@ mod encode_pipeline {
         let vectors = make_vectors(n, dim, 0);
 
         let (p1, s1, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
+            encode_owned(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
         let (p2, s2, _, _) =
-            encode(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
+            encode_owned(&vectors, n, dim, &rotation, &boundaries, &centroids, 4, None);
 
         assert_eq!(p1, p2);
         assert_eq!(s1, s2);
@@ -272,7 +291,7 @@ mod encode_pipeline {
         let zeros = vec![0.0f32; dim];
 
         let (packed, scales, _, _) =
-            encode(&zeros, 1, dim, &rotation, &boundaries, &centroids, 4, None, &mut Vec::new());
+            encode_owned(&zeros, 1, dim, &rotation, &boundaries, &centroids, 4, None);
 
         assert_eq!(scales[0], 0.0);
         assert!(scales[0].is_finite());
@@ -518,6 +537,27 @@ mod core_encode_hardening {
 
     use crate::codebook::codebook;
     use crate::encode::encode;
+    /// Test shim preserving the old owned-return encode signature.
+    #[allow(clippy::too_many_arguments)]
+    fn encode_owned(
+        vectors: &[f32],
+        n: usize,
+        dim: usize,
+        rotation: &crate::rotation::Rotation,
+        boundaries: &[f32],
+        centroids: &[f32],
+        bit_width: usize,
+        existing: Option<(&[f32], &[f32])>,
+    ) -> (Vec<u8>, Vec<f32>, Vec<f32>, Vec<f32>) {
+        let mut packed = Vec::new();
+        let mut scales = Vec::new();
+        let (shift, scale_tq) = crate::encode::encode(
+            vectors, n, dim, rotation, boundaries, centroids, bit_width, existing,
+            &mut Vec::new(), &mut packed, &mut scales,
+        );
+        (packed, scales, shift, scale_tq)
+    }
+
     use crate::rotation::Rotation;
     use crate::{AddError, IdMapIndex, TurboQuantIndex};
 
@@ -585,17 +625,15 @@ mod core_encode_hardening {
 
         let rotation = Rotation::new(dim);
         let (boundaries, centroids) = codebook(4, dim);
-        let (_, _, shift, scale_tq) = encode(
-            &vectors, n, dim, &rotation, &boundaries, &centroids, 4, None,
-            &mut Vec::new(),
+        let (_, _, shift, scale_tq) = encode_owned(
+            &vectors, n, dim, &rotation, &boundaries, &centroids, 4, None
         );
 
         let mut ood = vec![0.0f32; dim];
         ood[0] = -1.0;
-        let (_, scales, _, _) = encode(
+        let (_, scales, _, _) = encode_owned(
             &ood, 1, dim, &rotation, &boundaries, &centroids, 4,
-            Some((&shift, &scale_tq)),
-            &mut Vec::new(),
+            Some((&shift, &scale_tq))
         );
         assert!(
             scales[0].abs() < 10.0,
@@ -604,19 +642,17 @@ mod core_encode_hardening {
         );
 
         let zero = vec![0.0f32; dim];
-        let (_, zero_scales, _, _) = encode(
+        let (_, zero_scales, _, _) = encode_owned(
             &zero, 1, dim, &rotation, &boundaries, &centroids, 4,
-            Some((&shift, &scale_tq)),
-            &mut Vec::new(),
+            Some((&shift, &scale_tq))
         );
         assert_eq!(zero_scales[0], 0.0, "zero vector must keep scale 0");
 
         let mut nan_vec = vec![0.5f32; dim];
         nan_vec[3] = f32::NAN;
-        let (_, nan_scales, _, _) = encode(
+        let (_, nan_scales, _, _) = encode_owned(
             &nan_vec, 1, dim, &rotation, &boundaries, &centroids, 4,
-            Some((&shift, &scale_tq)),
-            &mut Vec::new(),
+            Some((&shift, &scale_tq))
         );
         assert_eq!(
             nan_scales[0], 0.0,
@@ -640,9 +676,8 @@ mod core_encode_hardening {
 
         let rotation = Rotation::new(dim);
         let (boundaries, centroids) = codebook(4, dim);
-        let (_, _, shift, scale_tq) = encode(
-            &cluster, n, dim, &rotation, &boundaries, &centroids, 4, None,
-            &mut Vec::new(),
+        let (_, _, shift, scale_tq) = encode_owned(
+            &cluster, n, dim, &rotation, &boundaries, &centroids, 4, None
         );
         let steps = 720;
         let mut sweep = vec![0.0f32; steps * dim];
@@ -651,10 +686,9 @@ mod core_encode_hardening {
             row[0] = theta.cos();
             row[1] = theta.sin();
         }
-        let (_, sweep_scales, _, _) = encode(
+        let (_, sweep_scales, _, _) = encode_owned(
             &sweep, steps, dim, &rotation, &boundaries, &centroids, 4,
-            Some((&shift, &scale_tq)),
-            &mut Vec::new(),
+            Some((&shift, &scale_tq))
         );
         for (t, &s) in sweep_scales.iter().enumerate() {
             assert!(
@@ -705,9 +739,8 @@ mod core_encode_hardening {
         let rotation = Rotation::new(8);
         let (boundaries, centroids) = codebook(2, dim);
         let vectors = vec![0.25f32; n * dim];
-        let _ = encode(
-            &vectors, n, dim, &rotation, &boundaries, &centroids, 2, None,
-            &mut Vec::new(),
+        let _ = encode_owned(
+            &vectors, n, dim, &rotation, &boundaries, &centroids, 2, None
         );
     }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -65,6 +65,8 @@ pub use id_map::IdMapIndex;
 use std::path::Path;
 use std::sync::OnceLock;
 
+use rayon::prelude::*;
+
 const BLOCK: usize = 32;
 
 /// Upper bound on vector dimensionality. The block-Hadamard rotation and
@@ -100,14 +102,25 @@ const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 ///     +Inf, `scale[i] = Inf` gets stored, slot incorrectly wins
 ///     top-k against every query.
 pub fn first_invalid_coord(values: &[f32], dim: usize) -> Option<(usize, usize, f32)> {
-    for (i, x) in values.iter().enumerate() {
-        if !x.is_finite() || x.abs() >= MAX_INPUT_MAGNITUDE {
-            let vector_index = if dim == 0 { 0 } else { i / dim };
-            let coord_index = if dim == 0 { i } else { i % dim };
-            return Some((vector_index, coord_index, *x));
-        }
-    }
-    None
+    // Parallel scan in fixed chunks, reduced by minimum flat index — the
+    // reported (vector, coord, value) is identical to a left-to-right
+    // scan. The all-clean case (every call on the hot add path) does one
+    // streaming pass split across cores; a chunk stops at its first hit.
+    const VALIDATE_CHUNK: usize = 64 * 1024;
+    let first = values
+        .par_chunks(VALIDATE_CHUNK)
+        .enumerate()
+        .filter_map(|(ci, chunk)| {
+            chunk
+                .iter()
+                .position(|x| !x.is_finite() || x.abs() >= MAX_INPUT_MAGNITUDE)
+                .map(|j| ci * VALIDATE_CHUNK + j)
+        })
+        .min()?;
+    let x = values[first];
+    let vector_index = if dim == 0 { 0 } else { first / dim };
+    let coord_index = if dim == 0 { first } else { first % dim };
+    Some((vector_index, coord_index, x))
 }
 
 /// SIMD-blocked cache derived from `packed_codes`.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -339,10 +339,13 @@ impl TurboQuantIndex {
         } else {
             Some((self.tqplus_shift.as_slice(), self.tqplus_scale.as_slice()))
         };
-        // Take the scratch out of self so it can be borrowed mutably
-        // alongside the shared cache borrows above.
+        // Take the scratch and output buffers out of self so they can be
+        // borrowed mutably alongside the shared cache borrows above;
+        // encode appends the new rows directly at their tails.
         let mut scratch = std::mem::take(&mut self.encode_scratch);
-        let (packed, scales, shift, scale_tq) = encode::encode(
+        let mut packed_codes = std::mem::take(&mut self.packed_codes);
+        let mut scales_buf = std::mem::take(&mut self.scales);
+        let (shift, scale_tq) = encode::encode(
             vectors,
             n,
             dim,
@@ -352,19 +355,18 @@ impl TurboQuantIndex {
             self.bit_width,
             existing,
             &mut scratch,
+            &mut packed_codes,
+            &mut scales_buf,
         );
         self.encode_scratch = scratch;
+        self.packed_codes = packed_codes;
+        self.scales = scales_buf;
 
         if self.n_vectors == 0 {
-            self.packed_codes = packed;
-            self.scales = scales;
             self.tqplus_shift = shift;
             self.tqplus_scale = scale_tq;
-        } else {
-            self.packed_codes.extend_from_slice(&packed);
-            self.scales.extend_from_slice(&scales);
-            // tqplus_shift/scale unchanged — locked by the first add.
         }
+        // else: tqplus_shift/scale unchanged — locked by the first add.
         self.n_vectors += n;
 
         // Invalidate the blocked cache — it was derived from the old

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -65,8 +65,6 @@ pub use id_map::IdMapIndex;
 use std::path::Path;
 use std::sync::OnceLock;
 
-use rayon::prelude::*;
-
 const BLOCK: usize = 32;
 
 /// Upper bound on vector dimensionality. The block-Hadamard rotation and
@@ -102,25 +100,10 @@ const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 ///     +Inf, `scale[i] = Inf` gets stored, slot incorrectly wins
 ///     top-k against every query.
 pub fn first_invalid_coord(values: &[f32], dim: usize) -> Option<(usize, usize, f32)> {
-    // Parallel scan in fixed chunks, reduced by minimum flat index — the
-    // reported (vector, coord, value) is identical to a left-to-right
-    // scan. The all-clean case (every call on the hot add path) does one
-    // streaming pass split across cores; a chunk stops at its first hit.
-    const VALIDATE_CHUNK: usize = 64 * 1024;
-    let first = values
-        .par_chunks(VALIDATE_CHUNK)
-        .enumerate()
-        .filter_map(|(ci, chunk)| {
-            chunk
-                .iter()
-                .position(|x| !x.is_finite() || x.abs() >= MAX_INPUT_MAGNITUDE)
-                .map(|j| ci * VALIDATE_CHUNK + j)
-        })
-        .min()?;
-    let x = values[first];
-    let vector_index = if dim == 0 { 0 } else { first / dim };
-    let coord_index = if dim == 0 { first } else { first % dim };
-    Some((vector_index, coord_index, x))
+    // The parallel scan lives in encode.rs — one of the audited rayon
+    // chokepoint files (fork safety, issue #147); binding entry points
+    // reach it inside `with_pool`.
+    encode::par_first_invalid_coord(values, dim, MAX_INPUT_MAGNITUDE)
 }
 
 /// SIMD-blocked cache derived from `packed_codes`.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -345,19 +345,48 @@ impl TurboQuantIndex {
         let mut scratch = std::mem::take(&mut self.encode_scratch);
         let mut packed_codes = std::mem::take(&mut self.packed_codes);
         let mut scales_buf = std::mem::take(&mut self.scales);
-        let (shift, scale_tq) = encode::encode(
-            vectors,
-            n,
-            dim,
-            rotation,
-            boundaries,
-            centroids,
-            self.bit_width,
-            existing,
-            &mut scratch,
-            &mut packed_codes,
-            &mut scales_buf,
-        );
+        // Unwind guard: encode appends to the taken buffers, so a panic
+        // inside it (kernel invariant assert, rayon worker panic) must
+        // not leave `self` with emptied buffers while n_vectors still
+        // counts the old rows. On unwind, truncate back to the pre-call
+        // lengths (encode never touches the existing prefix) and restore
+        // the buffers before propagating.
+        let packed_len_before = packed_codes.len();
+        let scales_len_before = scales_buf.len();
+        let bit_width = self.bit_width;
+        let encode_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            encode::encode(
+                vectors,
+                n,
+                dim,
+                rotation,
+                boundaries,
+                centroids,
+                bit_width,
+                existing,
+                &mut scratch,
+                &mut packed_codes,
+                &mut scales_buf,
+            )
+        }));
+        let (shift, scale_tq) = match encode_result {
+            Ok(pair) => pair,
+            Err(panic) => {
+                packed_codes.truncate(packed_len_before);
+                scales_buf.truncate(scales_len_before);
+                self.packed_codes = packed_codes;
+                self.scales = scales_buf;
+                self.encode_scratch = scratch;
+                std::panic::resume_unwind(panic);
+            }
+        };
+        // Keep the scratch warm for same-size adds, but don't let a
+        // one-time huge bulk load pin its full rotated-batch capacity
+        // for the index lifetime: shrink when the buffer is far larger
+        // than this call needed.
+        if scratch.capacity() > 4 * n * dim {
+            scratch.shrink_to(n * dim);
+        }
         self.encode_scratch = scratch;
         self.packed_codes = packed_codes;
         self.scales = scales_buf;

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -159,6 +159,12 @@ pub struct TurboQuantIndex {
     boundaries: OnceLock<Vec<f32>>,
     centroids: OnceLock<Vec<f32>>,
     blocked: OnceLock<BlockedCache>,
+
+    /// Reusable encode scratch (the rotated-batch buffer). Purely
+    /// derived state: never serialized, contents meaningless between
+    /// calls — kept only so repeated adds reuse one allocation instead
+    /// of paying a fresh multi-MB mmap + page-fault walk per call.
+    encode_scratch: Vec<f32>,
 }
 
 /// Top-`k` results for a batch of queries, as returned by
@@ -235,6 +241,7 @@ impl TurboQuantIndex {
             boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
+            encode_scratch: Vec::new(),
         })
     }
 
@@ -260,6 +267,7 @@ impl TurboQuantIndex {
             boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
+            encode_scratch: Vec::new(),
         })
     }
 
@@ -331,6 +339,9 @@ impl TurboQuantIndex {
         } else {
             Some((self.tqplus_shift.as_slice(), self.tqplus_scale.as_slice()))
         };
+        // Take the scratch out of self so it can be borrowed mutably
+        // alongside the shared cache borrows above.
+        let mut scratch = std::mem::take(&mut self.encode_scratch);
         let (packed, scales, shift, scale_tq) = encode::encode(
             vectors,
             n,
@@ -340,7 +351,9 @@ impl TurboQuantIndex {
             centroids,
             self.bit_width,
             existing,
+            &mut scratch,
         );
+        self.encode_scratch = scratch;
 
         if self.n_vectors == 0 {
             self.packed_codes = packed;
@@ -956,6 +969,7 @@ impl TurboQuantIndex {
             boundaries: OnceLock::new(),
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
+            encode_scratch: Vec::new(),
         })
     }
 

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -109,6 +109,12 @@ pub struct Rotation {
     /// Per-round global permutations, `K` permutations each of length
     /// `dim` (`perm[i]` is the source coordinate for output slot `i`).
     perms: Vec<Vec<u32>>,
+    /// Round-1 signs pre-scattered to source positions:
+    /// `signs_pre[perms[1][i]] == signs[1][i]`. Lets the round-1 sign
+    /// multiply ride the (vectorized) round-0 output scale pass instead
+    /// of the scalar gather; the multiply order per element is
+    /// unchanged, so the output is bit-identical.
+    signs1_pre: Vec<f32>,
 }
 
 impl Rotation {
@@ -132,7 +138,12 @@ impl Rotation {
             perms.push(fisher_yates(dim, &mut rng));
         }
 
-        Self { dim, block, inv_sqrt_block, signs, perms }
+        let mut signs1_pre = vec![1.0f32; dim];
+        for (i, &p) in perms[1].iter().enumerate() {
+            signs1_pre[p as usize] = signs[1][i];
+        }
+
+        Self { dim, block, inv_sqrt_block, signs, perms, signs1_pre }
     }
 
     /// Vector dimensionality this rotation is built for.
@@ -197,14 +208,17 @@ impl Rotation {
             *d = (src[p as usize] * inv) * s;
         }
         wht(scratch);
+        // Apply round 1's sign at the source positions (see
+        // `signs1_pre`): `(x * 1/sqrtB) * sign` happens in the same
+        // order as the gather-side multiply it replaces, so the round-1
+        // output is bit-identical while its gather becomes a pure move.
+        for (x, &sg) in scratch.iter_mut().zip(self.signs1_pre.iter()) {
+            *x *= sg;
+        }
 
-        // Round 1: scratch -> dst.
-        for ((d, &p), &s) in dst
-            .iter_mut()
-            .zip(self.perms[1].iter())
-            .zip(self.signs[1].iter())
-        {
-            *d = scratch[p as usize] * s;
+        // Round 1: scratch -> dst (sign already applied above).
+        for (d, &p) in dst.iter_mut().zip(self.perms[1].iter()) {
+            *d = scratch[p as usize];
         }
         wht(dst);
     }

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -440,9 +440,115 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     }
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    // Runtime dispatch: AVX2 executes the identical per-element adds,
+    // subtracts, and multiplies 8 (or 4) lanes at a time — butterflies
+    // within a stage touch disjoint elements, so results are
+    // bit-identical to the scalar loop (the same property the NEON path
+    // relies on). is_x86_feature_detected caches after the first call.
+    if std::arch::is_x86_feature_detected!("avx2") {
+        unsafe { wht_block_avx2(blk, block, inv_sqrt_block) }
+    } else {
+        wht_block_scalar(blk, block, inv_sqrt_block)
+    }
+}
+
+/// AVX2 Walsh-Hadamard: stage pairs (j, j+len) processed 8-wide for
+/// len >= 8, 4-wide (SSE) for len == 4, and via in-register shuffles for
+/// len 1 and 2 — every output is the same (a ± b) with the same f32
+/// rounding as the scalar butterfly.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn wht_block_avx2(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    use std::arch::x86_64::*;
+    debug_assert!(block >= 8 && block.is_power_of_two());
+    let p = blk.as_mut_ptr();
+
+    // Stage len=1: adjacent pairs, resolved with SSE shuffles per 4
+    // floats: [a0 b0 a1 b1] -> sums [a0+b0, a1+b1], diffs [a0-b0, a1-b1],
+    // re-interleaved.
+    let mut j = 0;
+    while j < block {
+        let v = _mm_loadu_ps(p.add(j)); // [a0 b0 a1 b1]
+        let a = _mm_shuffle_ps::<0b10_10_00_00>(v, v); // [a0 a0 a1 a1]
+        let b = _mm_shuffle_ps::<0b11_11_01_01>(v, v); // [b0 b0 b1 b1]
+        let s = _mm_add_ps(a, b);
+        let d = _mm_sub_ps(a, b);
+        // out = [s0 d0 s1 d1]: take lanes (s0, d1?) — blend s/d on odd lanes.
+        let out = _mm_blend_ps::<0b1010>(s, d);
+        _mm_storeu_ps(p.add(j), out);
+        j += 4;
+    }
+
+    // Stage len=2: per 8 floats [a0 a1 b0 b1 | a2 a3 b2 b3].
+    let mut j = 0;
+    while j < block {
+        let lo = _mm_loadu_ps(p.add(j)); // [a0 a1 b0 b1]
+        let hi = _mm_loadu_ps(p.add(j + 4)); // [a2 a3 b2 b3]
+        let a = _mm_movelh_ps(lo, hi); // [a0 a1 a2 a3]
+        let b = _mm_movehl_ps(hi, lo); // [b0 b1 b2 b3]
+        let s = _mm_add_ps(a, b);
+        let d = _mm_sub_ps(a, b);
+        _mm_storeu_ps(p.add(j), _mm_movelh_ps(s, d)); // [s0 s1 d0 d1]
+        _mm_storeu_ps(p.add(j + 4), _mm_movehl_ps(d, s)); // [s2 s3 d2 d3]
+        j += 8;
+    }
+
+    // Stage len=4: disjoint 4-float operand groups.
+    if block > 4 {
+        let len = 4;
+        let mut i = 0;
+        while i < block {
+            let a = _mm_loadu_ps(p.add(i));
+            let b = _mm_loadu_ps(p.add(i + len));
+            _mm_storeu_ps(p.add(i), _mm_add_ps(a, b));
+            _mm_storeu_ps(p.add(i + len), _mm_sub_ps(a, b));
+            i += 2 * len;
+        }
+    }
+
+    // Stages len >= 8: 8-wide.
+    let mut len = 8;
+    while len < block {
+        let mut i = 0;
+        while i < block {
+            let mut j = i;
+            while j < i + len {
+                let a = _mm256_loadu_ps(p.add(j));
+                let b = _mm256_loadu_ps(p.add(j + len));
+                _mm256_storeu_ps(p.add(j), _mm256_add_ps(a, b));
+                _mm256_storeu_ps(p.add(j + len), _mm256_sub_ps(a, b));
+                j += 8;
+            }
+            i += 2 * len;
+        }
+        len <<= 1;
+    }
+
+    // Orthonormalization scale.
+    let sv = _mm256_set1_ps(inv_sqrt_block);
+    let mut j = 0;
+    while j + 8 <= block {
+        _mm256_storeu_ps(p.add(j), _mm256_mul_ps(_mm256_loadu_ps(p.add(j)), sv));
+        j += 8;
+    }
+    while j < block {
+        *p.add(j) *= inv_sqrt_block;
+        j += 1;
+    }
+}
+
+#[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
+#[inline(always)]
+fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    wht_block_scalar(blk, block, inv_sqrt_block)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline(always)]
+fn wht_block_scalar(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     let mut len = 1;
     while len < block {
         let mut i = 0;

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -154,6 +154,61 @@ impl Rotation {
         self.apply_with_scratch(row, &mut scratch);
     }
 
+    /// Rotate `src` scaled by `inv` into `dst`, leaving `src` untouched.
+    ///
+    /// Computes exactly what `apply_with_scratch` would produce for a row
+    /// pre-scaled by `inv`: the first round's gather multiplies
+    /// `(src[perm[i]] * inv) * sign[i]` — the same two multiplies, in the
+    /// same order, as a separate scale pass followed by the fused
+    /// gather — so the output is bit-identical while the pre-scaled
+    /// intermediate row never has to be materialized.
+    ///
+    /// Panics if any of `src`, `dst`, or `scratch` is not `dim` long.
+    pub fn apply_scaled_into(
+        &self,
+        src: &[f32],
+        inv: f32,
+        dst: &mut [f32],
+        scratch: &mut [f32],
+    ) {
+        assert_eq!(src.len(), self.dim, "rotation input row must have length dim");
+        assert_eq!(dst.len(), self.dim, "rotation output row must have length dim");
+        assert_eq!(scratch.len(), self.dim, "rotation scratch must have length dim");
+        let dim = self.dim;
+        let block = self.block;
+
+        // Round 0 gathers src -> scratch (applying `inv`), round 1
+        // gathers scratch -> dst; K = 2 keeps the result in `dst`.
+        const _: () = assert!(K == 2, "buffer schedule below is written for K = 2");
+        let wht = |buf: &mut [f32]| {
+            let mut offset = 0;
+            while offset < dim {
+                wht_block(&mut buf[offset..offset + block], block, self.inv_sqrt_block);
+                offset += block;
+            }
+        };
+
+        // Round 0: fused scale + sign in the gather.
+        for ((d, &p), &s) in scratch
+            .iter_mut()
+            .zip(self.perms[0].iter())
+            .zip(self.signs[0].iter())
+        {
+            *d = (src[p as usize] * inv) * s;
+        }
+        wht(scratch);
+
+        // Round 1: scratch -> dst.
+        for ((d, &p), &s) in dst
+            .iter_mut()
+            .zip(self.perms[1].iter())
+            .zip(self.signs[1].iter())
+        {
+            *d = scratch[p as usize] * s;
+        }
+        wht(dst);
+    }
+
     /// [`Self::apply`] with a caller-provided scratch buffer, for hot loops
     /// that rotate many rows (encode, query batches) — reusing one scratch
     /// per rayon worker avoids an allocation per row. The scratch is fully

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -294,34 +294,69 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     let p = blk.as_mut_ptr();
 
     unsafe {
-        // Stage len=1: pairs are adjacent. vld2q deinterleaves 8 floats
-        // into a = evens, b = odds; store back interleaved.
+        // Stages len=1 and len=2, fused: each 8-float group is fully
+        // resolved in registers. Layout per group: [a0 a1 b0 b1 a2 a3
+        // b2 b3] after the len=1 view; the arithmetic below evaluates
+        // the same (a±b) then (·±·) expression trees, with the same f32
+        // roundings, as two sequential passes.
         let mut j = 0;
         while j < block {
+            // len=1: adjacent pairs.
             let ab = vld2q_f32(p.add(j));
-            let s = vaddq_f32(ab.0, ab.1);
-            let d = vsubq_f32(ab.0, ab.1);
-            vst2q_f32(p.add(j), float32x4x2_t(s, d));
+            let s1 = vaddq_f32(ab.0, ab.1); // sums at even slots
+            let d1 = vsubq_f32(ab.0, ab.1); // diffs at odd slots
+            // After len=1 the block is [s0 d0 s1 d1 s2 d2 s3 d3] in
+            // memory order; len=2 pairs slots (k, k+2):
+            //   (s0,d0) with (s1,d1) and (s2,d2) with (s3,d3).
+            // s1/d1 registers hold [s0 s1 s2 s3] / [d0 d1 d2 d3].
+            // len=2 pairs slot k with k+2, i.e. (s0,d0) with (s1,d1)
+            // and (s2,d2) with (s3,d3). Interleave the s/d registers so
+            // each len=2 operand pair sits in matching lanes:
+            let s_even = vtrn1q_f32(s1, d1); // [s0 d0 s2 d2]
+            let s_odd  = vtrn2q_f32(s1, d1); // [s1 d1 s3 d3]
+            let sum2 = vaddq_f32(s_even, s_odd);  // [s0+s1 d0+d1 s2+s3 d2+d3]
+            let dif2 = vsubq_f32(s_even, s_odd);  // [s0-s1 d0-d1 s2-s3 d2-d3]
+            // Memory order after len=2 stage:
+            //   j..j+4  = [s0+s1, d0+d1, s0-s1, d0-d1]
+            //   j+4..j+8= [s2+s3, d2+d3, s2-s3, d2-d3]
+            let out0 = vcombine_f32(vget_low_f32(sum2), vget_low_f32(dif2));
+            let out1 = vcombine_f32(vget_high_f32(sum2), vget_high_f32(dif2));
+            vst1q_f32(p.add(j), out0);
+            vst1q_f32(p.add(j + 4), out1);
             j += 8;
         }
 
-        // Stage len=2: layout per 8 floats is [a0 a1 b0 b1 a2 a3 b2 b3].
-        let mut j = 0;
-        while j < block {
-            let q0 = vld1q_f32(p.add(j)); // [a0 a1 b0 b1]
-            let q1 = vld1q_f32(p.add(j + 4)); // [a2 a3 b2 b3]
-            let a = vcombine_f32(vget_low_f32(q0), vget_low_f32(q1));
-            let b = vcombine_f32(vget_high_f32(q0), vget_high_f32(q1));
-            let s = vaddq_f32(a, b);
-            let d = vsubq_f32(a, b);
-            vst1q_f32(p.add(j), vcombine_f32(vget_low_f32(s), vget_low_f32(d)));
-            vst1q_f32(p.add(j + 4), vcombine_f32(vget_high_f32(s), vget_high_f32(d)));
-            j += 8;
-        }
-
-        // Stages len >= 4: operand pairs are 4-aligned and disjoint.
+        // Stages len >= 4, fused in radix-4 pairs where possible. The
+        // fused pass computes (a±b)±(c±d) — the identical expression
+        // trees, in the identical f32 rounding order, as the two
+        // sequential stages it replaces.
         let mut len = 4;
-        while len < block {
+        while 2 * len < block {
+            let quad = 4 * len;
+            let mut i = 0;
+            while i < block {
+                let mut j = i;
+                while j < i + len {
+                    let a = vld1q_f32(p.add(j));
+                    let b = vld1q_f32(p.add(j + len));
+                    let c = vld1q_f32(p.add(j + 2 * len));
+                    let d = vld1q_f32(p.add(j + 3 * len));
+                    let apb = vaddq_f32(a, b);
+                    let amb = vsubq_f32(a, b);
+                    let cpd = vaddq_f32(c, d);
+                    let cmd = vsubq_f32(c, d);
+                    vst1q_f32(p.add(j), vaddq_f32(apb, cpd));
+                    vst1q_f32(p.add(j + len), vaddq_f32(amb, cmd));
+                    vst1q_f32(p.add(j + 2 * len), vsubq_f32(apb, cpd));
+                    vst1q_f32(p.add(j + 3 * len), vsubq_f32(amb, cmd));
+                    j += 4;
+                }
+                i += quad;
+            }
+            len <<= 2;
+        }
+        // Odd stage left over when the stage count from len=4 up is odd.
+        if len < block {
             let mut i = 0;
             while i < block {
                 let mut j = i;
@@ -334,7 +369,6 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
                 }
                 i += 2 * len;
             }
-            len <<= 1;
         }
 
         // Orthonormalization scale.

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -196,29 +196,111 @@ impl Rotation {
             //    orthonormal. `√B` may be inexact in f32 (e.g. √8), but the
             //    scale is a fixed constant so the result is still
             //    deterministic.
+            //
+            //    The SIMD path below performs exactly the same adds,
+            //    subtracts, and multiplies on the same operand pairs —
+            //    butterflies within a stage are independent, so lane-
+            //    parallel execution cannot reassociate anything and the
+            //    output stays bit-identical to the scalar path (pinned by
+            //    the golden-bytes tests in tests/rotation_determinism.rs).
             let mut offset = 0;
             while offset < dim {
                 let blk = &mut row[offset..offset + block];
-                let mut len = 1;
-                while len < block {
-                    let mut i = 0;
-                    while i < block {
-                        for j in i..i + len {
-                            let a = blk[j];
-                            let b = blk[j + len];
-                            blk[j] = a + b;
-                            blk[j + len] = a - b;
-                        }
-                        i += 2 * len;
-                    }
-                    len <<= 1;
-                }
-                for x in blk.iter_mut() {
-                    *x *= self.inv_sqrt_block;
-                }
+                wht_block(blk, block, self.inv_sqrt_block);
                 offset += block;
             }
         }
+    }
+}
+
+/// Unnormalized Walsh-Hadamard butterfly over one `block`-length slice,
+/// followed by the `1/√B` orthonormalization scale.
+///
+/// Scalar reference semantics: for each stage `len = 1, 2, 4, …, B/2`,
+/// each pair `(blk[j], blk[j+len])` becomes `(a+b, a-b)`. The aarch64
+/// path executes the identical operations 4 lanes at a time; butterflies
+/// within a stage touch disjoint elements, so the results are
+/// bit-identical to the scalar loop.
+#[cfg(target_arch = "aarch64")]
+#[inline(always)]
+fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    use std::arch::aarch64::*;
+    debug_assert!(block >= 8 && block.is_power_of_two());
+    let p = blk.as_mut_ptr();
+
+    unsafe {
+        // Stage len=1: pairs are adjacent. vld2q deinterleaves 8 floats
+        // into a = evens, b = odds; store back interleaved.
+        let mut j = 0;
+        while j < block {
+            let ab = vld2q_f32(p.add(j));
+            let s = vaddq_f32(ab.0, ab.1);
+            let d = vsubq_f32(ab.0, ab.1);
+            vst2q_f32(p.add(j), float32x4x2_t(s, d));
+            j += 8;
+        }
+
+        // Stage len=2: layout per 8 floats is [a0 a1 b0 b1 a2 a3 b2 b3].
+        let mut j = 0;
+        while j < block {
+            let q0 = vld1q_f32(p.add(j)); // [a0 a1 b0 b1]
+            let q1 = vld1q_f32(p.add(j + 4)); // [a2 a3 b2 b3]
+            let a = vcombine_f32(vget_low_f32(q0), vget_low_f32(q1));
+            let b = vcombine_f32(vget_high_f32(q0), vget_high_f32(q1));
+            let s = vaddq_f32(a, b);
+            let d = vsubq_f32(a, b);
+            vst1q_f32(p.add(j), vcombine_f32(vget_low_f32(s), vget_low_f32(d)));
+            vst1q_f32(p.add(j + 4), vcombine_f32(vget_high_f32(s), vget_high_f32(d)));
+            j += 8;
+        }
+
+        // Stages len >= 4: operand pairs are 4-aligned and disjoint.
+        let mut len = 4;
+        while len < block {
+            let mut i = 0;
+            while i < block {
+                let mut j = i;
+                while j < i + len {
+                    let a = vld1q_f32(p.add(j));
+                    let b = vld1q_f32(p.add(j + len));
+                    vst1q_f32(p.add(j), vaddq_f32(a, b));
+                    vst1q_f32(p.add(j + len), vsubq_f32(a, b));
+                    j += 4;
+                }
+                i += 2 * len;
+            }
+            len <<= 1;
+        }
+
+        // Orthonormalization scale.
+        let sv = vdupq_n_f32(inv_sqrt_block);
+        let mut j = 0;
+        while j < block {
+            vst1q_f32(p.add(j), vmulq_f32(vld1q_f32(p.add(j)), sv));
+            j += 4;
+        }
+    }
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+#[inline(always)]
+fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    let mut len = 1;
+    while len < block {
+        let mut i = 0;
+        while i < block {
+            for j in i..i + len {
+                let a = blk[j];
+                let b = blk[j + len];
+                blk[j] = a + b;
+                blk[j + len] = a - b;
+            }
+            i += 2 * len;
+        }
+        len <<= 1;
+    }
+    for x in blk.iter_mut() {
+        *x *= inv_sqrt_block;
     }
 }
 

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -546,7 +546,7 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     wht_block_scalar(blk, block, inv_sqrt_block)
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg_attr(target_arch = "aarch64", allow(dead_code))]
 #[inline(always)]
 fn wht_block_scalar(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     let mut len = 1;
@@ -599,6 +599,56 @@ mod tests {
     }
 
     #[test]
+    fn wht_simd_matches_scalar_bit_exactly() {
+        // The format contract requires the SIMD butterfly to reproduce
+        // the scalar expression trees bit-for-bit. Enforce it directly,
+        // on every architecture, for every block-size regime the stage
+        // scheduler has (8 = min block, 16/128/1024 = radix-4 tail,
+        // 32/64/256/512 = other radix-8/leftover mixes).
+        for block in [8usize, 16, 32, 64, 128, 256, 512, 1024] {
+            let inv = 1.0 / (block as f32).sqrt();
+            // Deterministic pseudo-random input.
+            let mut x = 0x9E3779B97F4A7C15u64;
+            let mut buf: Vec<f32> = (0..block)
+                .map(|_| {
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    (x as f64 / u64::MAX as f64) as f32 - 0.5
+                })
+                .collect();
+            let mut expect = buf.clone();
+            wht_block_scalar(&mut expect, block, inv);
+            wht_block(&mut buf, block, inv);
+            for (i, (a, b)) in buf.iter().zip(expect.iter()).enumerate() {
+                assert_eq!(
+                    a.to_bits(),
+                    b.to_bits(),
+                    "block {block} lane {i}: SIMD {a} != scalar {b}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn golden_rotation_dim128() {
+        // Pins the dim=128 rotation output (block = 128, the radix-4
+        // tail branch) against frozen bytes. Input: e_0.
+        let rot = Rotation::new(128);
+        let mut row = vec![0.0f32; 128];
+        row[0] = 1.0;
+        rot.apply(&mut row);
+        // Frozen fingerprint: bit-pattern XOR-fold and first four lanes.
+        let fold = row.iter().fold(0u32, |acc, v| acc.rotate_left(1) ^ v.to_bits());
+        let head: Vec<u32> = row[..4].iter().map(|v| v.to_bits()).collect();
+        assert_eq!(
+            (fold, head[0], head[1], head[2], head[3]),
+            GOLDEN_DIM128,
+            "dim=128 rotation output drifted from the frozen v5 bytes",
+        );
+    }
+
+    #[test]
     fn preserves_norm_and_is_deterministic() {
         for &dim in &[8usize, 200, 768, 1000, 1536] {
             let rot = Rotation::new(dim);
@@ -626,3 +676,9 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+/// Frozen golden fingerprint for `golden_rotation_dim128` — generated
+/// once from the v5 rotation; must never change.
+const GOLDEN_DIM128: (u32, u32, u32, u32, u32) =
+    (186507913, 1033895935, 3175088127, 1027604479, 3162505217);

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -167,8 +167,19 @@ impl Rotation {
         let dim = self.dim;
         let block = self.block;
 
+        // The two buffers ping-pong: each round's permutation gathers from
+        // one buffer into the other, and the sign flip + Walsh-Hadamard run
+        // in the destination — no copy back. K = 2 (even), so the final
+        // round lands the result in `row` where callers expect it.
+        const _: () = assert!(K % 2 == 0, "ping-pong ends in `row` only for even K");
+        let (mut input, mut output): (&mut [f32], &mut [f32]) = (row, scratch);
+
         for round in 0..K {
-            // 1. Global permutation FIRST. A permutation precedes *every*
+
+            // 1. Global permutation FIRST, with the sign flip fused into
+            //    the gather (`out[i] = in[perm[i]] * sign[i]` — the same
+            //    multiply the separate pass performed, so values are
+            //    bit-identical). A permutation precedes *every*
             //    Walsh-Hadamard, including round 1, so a B-block is never
             //    formed from contiguous input coordinates. This makes the
             //    transform order-invariant: importance-ordered embeddings
@@ -179,15 +190,11 @@ impl Rotation {
             //    i.e. `8·odd`) dims. Permuting first scatters those
             //    coordinates across blocks.
             let perm = &self.perms[round];
-            for (dst, &src) in scratch.iter_mut().zip(perm.iter()) {
-                *dst = row[src as usize];
-            }
-            row.copy_from_slice(&scratch);
-
-            // 2. Sign flip.
             let sign_row = &self.signs[round];
-            for (x, &s) in row.iter_mut().zip(sign_row.iter()) {
-                *x *= s;
+            for ((dst, &src), &s) in
+                output.iter_mut().zip(perm.iter()).zip(sign_row.iter())
+            {
+                *dst = input[src as usize] * s;
             }
 
             // 3. Normalized Walsh-Hadamard per B-block. The butterfly is
@@ -205,10 +212,13 @@ impl Rotation {
             //    the golden-bytes tests in tests/rotation_determinism.rs).
             let mut offset = 0;
             while offset < dim {
-                let blk = &mut row[offset..offset + block];
+                let blk = &mut output[offset..offset + block];
                 wht_block(blk, block, self.inv_sqrt_block);
                 offset += block;
             }
+
+            // This round's output feeds the next round's gather.
+            std::mem::swap(&mut input, &mut output);
         }
     }
 }

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -340,12 +340,57 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
             j += 8;
         }
 
-        // Stages len >= 4, fused in radix-4 pairs where possible. The
-        // fused pass computes (a±b)±(c±d) — the identical expression
-        // trees, in the identical f32 rounding order, as the two
+        // Stages len >= 4: radix-8 passes (three stages each) while at
+        // least three stages remain, then a radix-4 pass if two remain.
+        // Every output is the identical (((a±b)±(c±d))±((e±f)±(g±h)))
+        // expression tree, with the same f32 roundings, as the
         // sequential stages it replaces.
         let mut len = 4;
-        while 2 * len < block {
+        while 4 * len < block {
+            let oct = 8 * len;
+            let mut i = 0;
+            while i < block {
+                let mut j = i;
+                while j < i + len {
+                    let a = vld1q_f32(p.add(j));
+                    let b = vld1q_f32(p.add(j + len));
+                    let c = vld1q_f32(p.add(j + 2 * len));
+                    let d = vld1q_f32(p.add(j + 3 * len));
+                    let e = vld1q_f32(p.add(j + 4 * len));
+                    let f = vld1q_f32(p.add(j + 5 * len));
+                    let g = vld1q_f32(p.add(j + 6 * len));
+                    let h = vld1q_f32(p.add(j + 7 * len));
+                    let apb = vaddq_f32(a, b);
+                    let amb = vsubq_f32(a, b);
+                    let cpd = vaddq_f32(c, d);
+                    let cmd = vsubq_f32(c, d);
+                    let epf = vaddq_f32(e, f);
+                    let emf = vsubq_f32(e, f);
+                    let gph = vaddq_f32(g, h);
+                    let gmh = vsubq_f32(g, h);
+                    let s0 = vaddq_f32(apb, cpd);
+                    let s1 = vaddq_f32(amb, cmd);
+                    let s2 = vsubq_f32(apb, cpd);
+                    let s3 = vsubq_f32(amb, cmd);
+                    let s4 = vaddq_f32(epf, gph);
+                    let s5 = vaddq_f32(emf, gmh);
+                    let s6 = vsubq_f32(epf, gph);
+                    let s7 = vsubq_f32(emf, gmh);
+                    vst1q_f32(p.add(j), vaddq_f32(s0, s4));
+                    vst1q_f32(p.add(j + len), vaddq_f32(s1, s5));
+                    vst1q_f32(p.add(j + 2 * len), vaddq_f32(s2, s6));
+                    vst1q_f32(p.add(j + 3 * len), vaddq_f32(s3, s7));
+                    vst1q_f32(p.add(j + 4 * len), vsubq_f32(s0, s4));
+                    vst1q_f32(p.add(j + 5 * len), vsubq_f32(s1, s5));
+                    vst1q_f32(p.add(j + 6 * len), vsubq_f32(s2, s6));
+                    vst1q_f32(p.add(j + 7 * len), vsubq_f32(s3, s7));
+                    j += 4;
+                }
+                i += oct;
+            }
+            len <<= 3;
+        }
+        if 2 * len < block {
             let quad = 4 * len;
             let mut i = 0;
             while i < block {


### PR DESCRIPTION
## Summary
Hill-climb of turbovec insertion and removal performance (34 accepted optimizations from ~100 tested hypotheses; loop terminated at the specified 20 consecutive non-improving hypotheses), an AVX2 port of the optimized kernels to x86_64, fully regenerated official benchmark results + diagrams on both architectures, and fixes for all findings from the adversarial review.

## Results (quoted verbatim from the committed `benchmarks/results/*.json`)

**ARM (Apple M3 Max), d=1536 2-bit — vs pre-branch baseline:**

| Metric | Before | After | Δ | FAISS PQFastScan |
|---|---|---|---|---|
| ST cold bulk insert | 29.5k vec/s | **136,253** | 4.6× | 75,374 |
| MT cold bulk insert | 207k vec/s | **800,353** | 3.9× | 590,899 |
| ST warm append | 65.3k vec/s | **274,401** | 4.2× | — |
| MT warm append | 280k vec/s | **1,719,814** | 6.1× | — |
| Single add | 15.4 µs | **5.14 µs** | 3.0× | — |
| IdMap remove / swap_remove (ST) | 0.20 / 0.17 µs | **0.150 / 0.127 µs** | −25% | — |

turbovec leads FAISS on bulk insert in **every** arm config (both dims, both bit-widths, ST and MT).

**x86 (Sapphire Rapids c3-standard-8), d=1536 2-bit — vs stale pre-branch results:**

| Metric | Before | After | Δ | FAISS |
|---|---|---|---|---|
| Single add | 256.5 µs | **23.28 µs** | 11× | — |
| ST cold bulk | 10.6k vec/s | **29,532** | 2.8× | 27,754 |
| MT cold bulk | 32.1k vec/s | **138,721** | 4.3× | 147,617 |
| MT warm append | 42.4k vec/s | **209,043** | 4.9× | — |
| IdMap remove ST | 0.41 µs | **0.305 µs** | −26% | — |

x86 vs FAISS: ahead on 2-bit ST bulk at both dims, within 3–6% on 2-bit MT, behind on 4-bit (FAISS's AVX-512 edge — see follow-ups). Kernels verified natively on the instance (19 Rust suites) and on CI's x86 runners.

## Adversarial review — all findings addressed
1. **GIL stalls under contention** → O(1) removes use a try-write fast path with a detached wait under contention; the add snapshot copy falls back to a bounded serial copy when the rayon pool is busy. Uncontended numbers unchanged (spot-checked).
2. **Scratch retention** → per-index scratch/snapshot buffers shrink when capacity exceeds 4× the current batch's need.
3. **Unwind safety** → `add` restores its taken buffers on encode panic (index left intact).
4. **Coverage** → new bit-exact SIMD-vs-scalar identity tests (WHT all block regimes incl. radix-4 tail; quantize kernel, bit widths 2/3/4, both reconstruction paths; validation predicate per lane), scalar kernels now compiled on every arch so the tests enforce on both arm and x86 CI, plus a frozen dim=128 rotation golden pinning the radix-4 tail.
5. **Minor** → stale comment removed, id-hasher rationale corrected + attacker-controlled-ids caveat documented, CHANGELOG entries added (including the scale drift), PR tables above now quote committed JSONs verbatim, stale rebase note dropped.

## Review notes
- **Maintainer sign-off needed:** the four-chain f64 accumulation shifts stored per-vector scales (empirically ~1 ULP) vs earlier v5 builds for newly encoded vectors — packed codes unchanged, deterministic, identical across scalar/NEON/AVX2 (verified by the review and now enforced by identity tests), previously written files load byte-identical. Recorded in the CHANGELOG.
- Encode output is otherwise bit-identical throughout; rotation golden-bytes tests pass at every commit.
- All 19 core suites + full Python suite green; rebased on current main.

## Follow-ups (not in this PR)
AVX-512 specialization (expected to close the x86 4-bit gap) · batched `remove_many(ids)` API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)