### PR TITLE
ci: trigger Claude via @q-turbovec-bot instead of @claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,22 +15,22 @@ permissions: {}
 jobs:
   claude:
     # Only the repo owner and the turbovec-bot machine account may invoke
-    # @claude — the OAuth token spends subscription usage, and this workflow
-    # runs project code (cargo build/test) on trigger, so this guard is
-    # load-bearing for security. Pinned to immutable numeric actor IDs
+    # @q-turbovec-bot — the OAuth token spends subscription usage, and this
+    # workflow runs project code (cargo build/test) on trigger, so this guard
+    # is load-bearing for security. Pinned to immutable numeric actor IDs
     # (RyanCodrai = 10856497, turbovec-bot = 309383466) rather than logins,
     # which can be renamed/reclaimed. turbovec-bot is allowed so a Claude run
-    # can @claude-mention follow-up work (e.g. request a review of its own
-    # PR) and spawn a fresh agent; its PAT-authored comments do fire this
-    # workflow, so keep the agent instructed to mention @claude at most once
-    # per run to bound chained invocations.
+    # can @q-turbovec-bot-mention follow-up work (e.g. request a review of its
+    # own PR) and spawn a fresh agent; its PAT-authored comments do fire this
+    # workflow, so keep the agent instructed to mention @q-turbovec-bot at
+    # most once per run to bound chained invocations.
     if: |
       contains(fromJSON('["10856497", "309383466"]'), github.actor_id) &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@q-turbovec-bot')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@q-turbovec-bot')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@q-turbovec-bot')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@q-turbovec-bot') || contains(github.event.issue.title, '@q-turbovec-bot')))
       )
     runs-on: ubuntu-latest
     # Write scopes so Claude can push branches, open PRs, and comment —
@@ -81,6 +81,9 @@ jobs:
           # its own identity, contributor-level, and not in CODEOWNERS — so it
           # can't approve, and merges to main stay gated on the owner's review.
           github_token: ${{ secrets.CLAUDE_BOT_TOKEN }}
+          # The action's own mention-detection defaults to "@claude"; keep it
+          # in sync with the actor-guard trigger above.
+          trigger_phrase: "@q-turbovec-bot"
           # Full local-parity toolset: arbitrary shell (build/test/gh/etc.),
           # file edits, and web access. Safe because this workflow is
           # owner-only (see the actor guard above) — do NOT widen the guard


### PR DESCRIPTION
Renames the mention trigger for the Claude workflow from `@claude` to `@q-turbovec-bot`.

- Updates all four event guards in the job `if` condition
- Sets `trigger_phrase: "@q-turbovec-bot"` on claude-code-action, whose built-in mention detection defaults to `@claude` (without this the job would start and no-op)
- Updates comments; the two-ID actor guard is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)