### PR TITLE
perf: cold-load hill-climb — 4.1x faster x86, 3.8x faster ARM (file → first search)

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -429,7 +429,13 @@ impl TurboQuantIndex {
                     )));
                 }
             }
-            with_pool_if(nq > 1, || {
+            // Pool nq=1 too once the index is large enough for the core's
+            // block-parallel single-query path — running that inline
+            // would inject parallel work into the global sentinel
+            // registry (the #147 invariant). Small-index nq=1 stays
+            // inline; a pooled-but-serial masked search only costs the
+            // install handoff.
+            with_pool_if(nq > 1 || inner.len() >= 32 * turbovec_core::search::SINGLE_QUERY_PARALLEL_MIN_BLOCKS, || {
                 inner.search_with_mask(&q_owned, k, mask_owned.as_deref())
             })
         })?;
@@ -809,7 +815,9 @@ impl IdMapIndex {
                     )));
                 }
             }
-            let (scores, ids) = with_pool_if(nq > 1, || {
+            // See search: nq=1 on a large index must run pooled for the
+            // core's block-parallel single-query path.
+            let (scores, ids) = with_pool_if(nq > 1 || inner.len() >= 32 * turbovec_core::search::SINGLE_QUERY_PARALLEL_MIN_BLOCKS, || {
                 inner.search_with_allowlist(&q_owned, k, allow_owned.as_deref())
             })?;
             Ok((scores, ids, inner.len()))

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -435,7 +435,7 @@ impl TurboQuantIndex {
             // registry (the #147 invariant). Small-index nq=1 stays
             // inline; a pooled-but-serial masked search only costs the
             // install handoff.
-            with_pool_if(nq > 1 || inner.len() >= 32 * turbovec_core::search::SINGLE_QUERY_PARALLEL_MIN_BLOCKS, || {
+            with_pool_if(nq > 1 || turbovec_core::search::single_query_parallelizes(inner.len()), || {
                 inner.search_with_mask(&q_owned, k, mask_owned.as_deref())
             })
         })?;
@@ -817,7 +817,7 @@ impl IdMapIndex {
             }
             // See search: nq=1 on a large index must run pooled for the
             // core's block-parallel single-query path.
-            let (scores, ids) = with_pool_if(nq > 1 || inner.len() >= 32 * turbovec_core::search::SINGLE_QUERY_PARALLEL_MIN_BLOCKS, || {
+            let (scores, ids) = with_pool_if(nq > 1 || turbovec_core::search::single_query_parallelizes(inner.len()), || {
                 inner.search_with_allowlist(&q_owned, k, allow_owned.as_deref())
             })?;
             Ok((scores, ids, inner.len()))

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -86,8 +86,11 @@ pub struct IdMapIndex {
     /// slot → external id. `slot_to_id[i]` is the id of the vector
     /// currently stored in slot `i` of `inner`.
     slot_to_id: Vec<u64>,
-    /// external id → slot. Kept in sync with `slot_to_id`.
-    id_to_slot: HashMap<u64, usize, IdBuildHasher>,
+    /// external id → slot. Kept in sync with `slot_to_id`. Built lazily
+    /// after a load (cold start — load + search — never consults it;
+    /// duplicate-id validation happens at load via a sort instead), and
+    /// eagerly on every other path.
+    id_to_slot: std::sync::OnceLock<HashMap<u64, usize, IdBuildHasher>>,
 }
 
 impl IdMapIndex {
@@ -98,7 +101,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: TurboQuantIndex::new(dim, bit_width)?,
             slot_to_id: Vec::new(),
-            id_to_slot: HashMap::default(),
+            id_to_slot: std::sync::OnceLock::from(HashMap::default()),
         })
     }
 
@@ -109,8 +112,25 @@ impl IdMapIndex {
         Ok(Self {
             inner: TurboQuantIndex::new_lazy(bit_width)?,
             slot_to_id: Vec::new(),
-            id_to_slot: HashMap::default(),
+            id_to_slot: std::sync::OnceLock::from(HashMap::default()),
         })
+    }
+
+    /// The id → slot map, built from `slot_to_id` on first use after a
+    /// load. Loads validated id uniqueness, so the sizes always agree.
+    fn ids(&self) -> &HashMap<u64, usize, IdBuildHasher> {
+        self.id_to_slot.get_or_init(|| {
+            self.slot_to_id
+                .iter()
+                .enumerate()
+                .map(|(slot, &id)| (id, slot))
+                .collect()
+        })
+    }
+
+    fn ids_mut(&mut self) -> &mut HashMap<u64, usize, IdBuildHasher> {
+        self.ids();
+        self.id_to_slot.get_mut().expect("ids just materialized")
     }
 
     /// Add `n = vectors.len() / dim` vectors with the given external ids.
@@ -169,7 +189,7 @@ impl IdMapIndex {
         let mut seen_this_call: std::collections::HashSet<u64, IdBuildHasher> =
             std::collections::HashSet::with_capacity_and_hasher(n, IdBuildHasher::default());
         for &id in ids {
-            if self.id_to_slot.contains_key(&id) || !seen_this_call.insert(id) {
+            if self.ids().contains_key(&id) || !seen_this_call.insert(id) {
                 return Err(AddError::IdAlreadyPresent(id));
             }
         }
@@ -183,10 +203,10 @@ impl IdMapIndex {
         let base_slot = self.inner.len();
         self.inner.add_2d(vectors, dim)?;
 
-        self.id_to_slot.reserve(n);
+        self.ids_mut().reserve(n);
         self.slot_to_id.reserve(n);
         for (i, &id) in ids.iter().enumerate() {
-            self.id_to_slot.insert(id, base_slot + i);
+            self.ids_mut().insert(id, base_slot + i);
         }
         self.slot_to_id.extend_from_slice(ids);
 
@@ -198,7 +218,7 @@ impl IdMapIndex {
     /// Returns `true` if the id was present and removed, `false`
     /// otherwise. O(1) via the inner [`TurboQuantIndex::swap_remove`].
     pub fn remove(&mut self, id: u64) -> bool {
-        let Some(slot) = self.id_to_slot.remove(&id) else {
+        let Some(slot) = self.ids_mut().remove(&id) else {
             return false;
         };
         let last = self.slot_to_id.len() - 1;
@@ -211,7 +231,7 @@ impl IdMapIndex {
             let moved_id = self.slot_to_id[last];
             self.slot_to_id[slot] = moved_id;
             // The previously-last id now lives at `slot`.
-            self.id_to_slot.insert(moved_id, slot);
+            self.ids_mut().insert(moved_id, slot);
         }
         self.slot_to_id.pop();
 
@@ -255,7 +275,7 @@ impl IdMapIndex {
             assert!(!ids.is_empty(), "allowlist is empty");
             let mut mask = vec![false; self.inner.len()];
             for &id in ids {
-                let slot = match self.id_to_slot.get(&id) {
+                let slot = match self.ids().get(&id) {
                     Some(&s) => s,
                     None => panic!("id {id} in allowlist is not present in index"),
                 };
@@ -284,7 +304,7 @@ impl IdMapIndex {
 
     /// True if the index currently contains a vector with this id.
     pub fn contains(&self, id: u64) -> bool {
-        self.id_to_slot.contains_key(&id)
+        self.ids().contains_key(&id)
     }
 
     pub fn len(&self) -> usize {
@@ -410,14 +430,13 @@ impl IdMapIndex {
         let inner = TurboQuantIndex::from_loaded((
             bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale,
         ))?;
-        let id_to_slot: HashMap<u64, usize, IdBuildHasher> = slot_to_id
-            .iter()
-            .enumerate()
-            .map(|(slot, &id)| (id, slot))
-            .collect();
         // Reject corrupt payloads where the id table contains duplicates —
-        // this would desync the two tables.
-        if id_to_slot.len() != slot_to_id.len() {
+        // this would desync the two tables. Validated with a sort (cheap,
+        // cache-friendly) so the id → slot map itself can build lazily:
+        // the cold-start path (load + search) never consults it.
+        let mut sorted = slot_to_id.clone();
+        sorted.sort_unstable();
+        if sorted.windows(2).any(|w| w[0] == w[1]) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "duplicate ids in .tvim file",
@@ -426,7 +445,7 @@ impl IdMapIndex {
         Ok(Self {
             inner,
             slot_to_id,
-            id_to_slot,
+            id_to_slot: std::sync::OnceLock::new(),
         })
     }
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -784,6 +784,20 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
 /// section straight into its final home (no intermediate whole-file
 /// buffer, no extraction copy).
 fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>> {
+    read_range_parallel_transform(f, range_off, len, None)
+}
+
+/// [`read_range_parallel`] with an optional in-place transform fused
+/// into the read: each thread reads its span in L2-sized sub-chunks
+/// (256 KB, a 32-byte-block multiple) and transforms each sub-chunk
+/// immediately, while its lines are still resident — the transform's
+/// separate cold memory pass disappears.
+fn read_range_parallel_transform(
+    f: &File,
+    range_off: u64,
+    len: u64,
+    transform: Option<fn(&mut [u8])>,
+) -> io::Result<Vec<u8>> {
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
     const CHUNK_MIN: usize = 8 * 1024 * 1024;
@@ -794,6 +808,9 @@ fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>
         // `take` would read from the descriptor's current position).
         buf.resize(len_usize, 0);
         read_exact_at(f, &mut buf, range_off)?;
+        if let Some(t) = transform {
+            t(&mut buf);
+        }
         return Ok(buf);
     }
     // One even chunk per thread, one positioned read each — fewer,
@@ -818,7 +835,26 @@ fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>
                 // thread via read_exact_at.
                 let chunk =
                     unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = read_exact_at(f, chunk, range_off + off as u64) {
+                let res = match transform {
+                    None => read_exact_at(f, chunk, range_off + off as u64),
+                    Some(t) => {
+                        const SUB: usize = 256 * 1024;
+                        let mut r = Ok(());
+                        let mut sub_off = 0usize;
+                        while sub_off < chunk.len() {
+                            let sub_len = SUB.min(chunk.len() - sub_off);
+                            let sub = &mut chunk[sub_off..sub_off + sub_len];
+                            r = read_exact_at(f, sub, range_off + (off + sub_off) as u64);
+                            if r.is_err() {
+                                break;
+                            }
+                            t(sub);
+                            sub_off += sub_len;
+                        }
+                        r
+                    }
+                };
+                if let Err(e) = res {
                     *err.lock().expect("err lock") = Some(e);
                     break;
                 }
@@ -877,10 +913,13 @@ fn try_load_v6_fast(
                 format!("truncated file: expected {blocked_bytes} code bytes"),
             )
         })?;
-    let codes_seq = read_range_parallel(f, codes_start, blocked_bytes as u64)?;
-    // In-place native transform on just-faulted (warm) pages; identity
+    // Native transform fused into the read at L2 granularity; identity
     // on non-x86, where the stored layout is already native.
-    let codes = crate::pack::seq_into_native(codes_seq);
+    #[cfg(target_arch = "x86_64")]
+    let transform: Option<fn(&mut [u8])> = Some(crate::pack::interleave_chunk_x86);
+    #[cfg(not(target_arch = "x86_64"))]
+    let transform: Option<fn(&mut [u8])> = None;
+    let codes = read_range_parallel_transform(f, codes_start, blocked_bytes as u64, transform)?;
     // Tail: scales + TQ+ (+ id table for .tvim) — small.
     let tail_len = (cap - codes_end) as usize;
     let mut tail = vec![0u8; tail_len];

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,8 +170,21 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_from_capped(&mut r, cap)
+    // aarch64: parallel positioned whole-file read (page-cache reads
+    // parallelize near-linearly there and the M-series load is
+    // read-bound — measured ~2.3x). x86: the streamed capped read wins —
+    // measured: parallel pread gains nothing on common virtualized page
+    // caches while the extra per-section copy costs ~6 ms on 79 MB.
+    #[cfg(target_arch = "aarch64")]
+    {
+        let buf = read_file_parallel(&f, cap)?;
+        load_from_capped(&mut &buf[..], cap)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut r = BufReader::new(f);
+        load_from_capped(&mut r, cap)
+    }
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -307,8 +320,17 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_id_map_from_capped(&mut r, cap)
+    // See `load` for the per-architecture read strategy rationale.
+    #[cfg(target_arch = "aarch64")]
+    {
+        let buf = read_file_parallel(&f, cap)?;
+        load_id_map_from_capped(&mut &buf[..], cap)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut r = BufReader::new(f);
+        load_id_map_from_capped(&mut r, cap)
+    }
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -728,6 +750,61 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// on a `take`-limited reader grows the buffer only to the bytes actually
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
+/// Read a whole file of known length with positioned reads across scoped
+/// threads (aarch64 path loads only — see the call sites for the
+/// measured rationale). The buffer is allocated uninitialized and every
+/// byte is written by exactly one positioned read before `set_len`
+/// exposes it (on any error the Vec drops with len 0, so uninitialized
+/// bytes are never readable). Scoped `std::thread` (not rayon) keeps
+/// this outside the fork-safety pool machinery. Small files read
+/// serially.
+#[cfg(target_arch = "aarch64")]
+fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
+    use std::os::unix::fs::FileExt;
+    let len_usize = usize::try_from(len)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
+    const CHUNK: usize = 8 * 1024 * 1024;
+    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let mut buf: Vec<u8> = Vec::with_capacity(len_usize);
+    if len_usize < 2 * CHUNK || n_threads < 2 {
+        let mut r = f;
+        r.take(len).read_to_end(&mut buf)?;
+        return Ok(buf);
+    }
+    let n_chunks = len_usize.div_ceil(CHUNK);
+    let base = buf.spare_capacity_mut().as_mut_ptr() as usize;
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
+    std::thread::scope(|s| {
+        for _ in 0..n_threads.min(n_chunks) {
+            s.spawn(|| loop {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if i >= n_chunks {
+                    break;
+                }
+                let off = i * CHUNK;
+                let this = CHUNK.min(len_usize - off);
+                // SAFETY: chunks are disjoint [off, off+this) views of the
+                // allocation; each is written (never read) by exactly one
+                // thread via read_exact_at.
+                let chunk =
+                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
+                if let Err(e) = f.read_exact_at(chunk, off as u64) {
+                    *err.lock().expect("err lock") = Some(e);
+                    break;
+                }
+            });
+        }
+    });
+    if let Some(e) = err.into_inner().expect("err lock") {
+        return Err(e);
+    }
+    // SAFETY: every byte in 0..len was filled by a successful
+    // read_exact_at (any failure returned above).
+    unsafe { buf.set_len(len_usize) };
+    Ok(buf)
+}
+
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
     read_exact_vec_capped(r, n, 0)
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -164,27 +164,15 @@ pub fn write_to<W: Write>(
 /// because the v5 rotation break changed every encoded byte. Files
 /// with empty TQ+ are treated as identity calibration.
 pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
+    let path = path.as_ref();
     let f = File::open(path)?;
     // The file's real length caps section preallocation: a section can
     // pre-reserve its declared size only when the bytes provably exist,
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    // aarch64: parallel positioned whole-file read (page-cache reads
-    // parallelize near-linearly there and the M-series load is
-    // read-bound — measured ~2.3x). x86: the streamed capped read wins —
-    // measured: parallel pread gains nothing on common virtualized page
-    // caches while the extra per-section copy costs ~6 ms on 79 MB.
-    #[cfg(target_arch = "aarch64")]
-    {
-        let buf = read_file_parallel(&f, cap)?;
-        load_from_capped(&mut &buf[..], cap)
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        let mut r = BufReader::new(f);
-        load_from_capped(&mut r, cap)
-    }
+    let buf = read_file_parallel(path, &f, cap)?;
+    load_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -317,20 +305,12 @@ pub fn write_id_map_to<W: Write>(
 pub fn load_id_map(
     path: impl AsRef<Path>,
 ) -> io::Result<(usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
+    let path = path.as_ref();
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    // See `load` for the per-architecture read strategy rationale.
-    #[cfg(target_arch = "aarch64")]
-    {
-        let buf = read_file_parallel(&f, cap)?;
-        load_id_map_from_capped(&mut &buf[..], cap)
-    }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        let mut r = BufReader::new(f);
-        load_id_map_from_capped(&mut r, cap)
-    }
+    let buf = read_file_parallel(path, &f, cap)?;
+    load_id_map_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -751,16 +731,16 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
 /// Read a whole file of known length with positioned reads across scoped
-/// threads (aarch64 path loads only — see the call sites for the
-/// measured rationale). The buffer is allocated uninitialized and every
-/// byte is written by exactly one positioned read before `set_len`
-/// exposes it (on any error the Vec drops with len 0, so uninitialized
-/// bytes are never readable). Scoped `std::thread` (not rayon) keeps
-/// this outside the fork-safety pool machinery. Small files read
-/// serially.
-#[cfg(target_arch = "aarch64")]
-fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
-    use std::os::unix::fs::FileExt;
+/// threads, each on its OWN file handle — a shared descriptor's per-fd
+/// locking serializes concurrent preads on common virtualized page
+/// caches (measured 21.5 → 3.8 ms for 79 MB on a KVM guest; near-linear
+/// on Apple Silicon either way). The buffer is allocated uninitialized
+/// and every byte is written by exactly one positioned read before
+/// `set_len` exposes it (on any error the Vec drops with len 0, so
+/// uninitialized bytes are never readable). Scoped `std::thread` (not
+/// rayon) keeps this outside the fork-safety pool machinery. Small
+/// files read serially through the already-open handle.
+fn read_file_parallel(path: &Path, f: &File, len: u64) -> io::Result<Vec<u8>> {
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
     const CHUNK: usize = 8 * 1024 * 1024;
@@ -777,7 +757,9 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
     let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
     std::thread::scope(|s| {
         for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| loop {
+            s.spawn(|| {
+                let own_fd = File::open(path);
+                loop {
                 let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if i >= n_chunks {
                     break;
@@ -789,9 +771,14 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
                 // thread via read_exact_at.
                 let chunk =
                     unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = f.read_exact_at(chunk, off as u64) {
+                if let Err(e) = own_fd
+                    .as_ref()
+                    .map_err(clone_io_err)
+                    .and_then(|fd| read_exact_at(fd, chunk, off as u64))
+                {
                     *err.lock().expect("err lock") = Some(e);
                     break;
+                }
                 }
             });
         }
@@ -803,6 +790,32 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
     // read_exact_at (any failure returned above).
     unsafe { buf.set_len(len_usize) };
     Ok(buf)
+}
+
+#[cfg(unix)]
+fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.read_exact_at(buf, off)
+}
+
+#[cfg(windows)]
+fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        let n = f.seek_read(buf, off)?;
+        if n == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
+        }
+        buf = &mut buf[n..];
+        off += n as u64;
+    }
+    Ok(())
+}
+
+/// Clone-shape an io::Error for use inside the reader threads (io::Error
+/// itself is not Clone; kind + text is all we need).
+fn clone_io_err(e: &io::Error) -> io::Error {
+    io::Error::new(e.kind(), e.to_string())
 }
 
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,8 +170,8 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_from_capped(&mut r, cap)
+    let buf = read_file_parallel(&f, cap)?;
+    load_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -307,8 +307,8 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_id_map_from_capped(&mut r, cap)
+    let buf = read_file_parallel(&f, cap)?;
+    load_id_map_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -728,6 +728,79 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// on a `take`-limited reader grows the buffer only to the bytes actually
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
+/// Read a whole file of known length with positioned reads across scoped
+/// threads — page-cache reads parallelize near-linearly and dominate
+/// large cold loads. The buffer is allocated uninitialized and every
+/// byte is written by exactly one positioned read before `set_len`
+/// exposes it (on any error the Vec drops with len 0, so uninitialized
+/// bytes are never readable). Scoped `std::thread` (not rayon) keeps
+/// this path outside the fork-safety pool machinery. Small files read
+/// serially through the capped reader.
+fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
+    let len_usize = usize::try_from(len)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
+    const CHUNK: usize = 8 * 1024 * 1024;
+    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    let mut buf: Vec<u8> = Vec::with_capacity(len_usize);
+    if len_usize < 2 * CHUNK || n_threads < 2 {
+        let mut r = f;
+        r.take(len).read_to_end(&mut buf)?;
+        return Ok(buf);
+    }
+    let n_chunks = len_usize.div_ceil(CHUNK);
+    let base = buf.spare_capacity_mut().as_mut_ptr() as usize;
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
+    std::thread::scope(|s| {
+        for _ in 0..n_threads.min(n_chunks) {
+            s.spawn(|| loop {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if i >= n_chunks {
+                    break;
+                }
+                let off = i * CHUNK;
+                let this = CHUNK.min(len_usize - off);
+                // SAFETY: chunks are disjoint [off, off+this) views of the
+                // allocation; each is written (never read) by exactly one
+                // thread via read_exact_at.
+                let chunk =
+                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
+                if let Err(e) = read_exact_at(f, chunk, off as u64) {
+                    *err.lock().expect("err lock") = Some(e);
+                    break;
+                }
+            });
+        }
+    });
+    if let Some(e) = err.into_inner().expect("err lock") {
+        return Err(e);
+    }
+    // SAFETY: every byte in 0..len was filled by a successful
+    // read_exact_at (any failure returned above).
+    unsafe { buf.set_len(len_usize) };
+    Ok(buf)
+}
+
+#[cfg(unix)]
+fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.read_exact_at(buf, off)
+}
+
+#[cfg(windows)]
+fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        let n = f.seek_read(buf, off)?;
+        if n == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
+        }
+        buf = &mut buf[n..];
+        off += n as u64;
+    }
+    Ok(())
+}
+
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
     read_exact_vec_capped(r, n, 0)
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -164,15 +164,27 @@ pub fn write_to<W: Write>(
 /// because the v5 rotation break changed every encoded byte. Files
 /// with empty TQ+ are treated as identity calibration.
 pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
-    let path = path.as_ref();
     let f = File::open(path)?;
     // The file's real length caps section preallocation: a section can
     // pre-reserve its declared size only when the bytes provably exist,
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(path, &f, cap)?;
-    load_from_capped(&mut &buf[..], cap)
+    // aarch64: parallel positioned whole-file read (page-cache reads
+    // parallelize near-linearly there and the M-series load is
+    // read-bound — measured ~2.3x). x86: the streamed capped read wins —
+    // measured: parallel pread gains nothing on common virtualized page
+    // caches while the extra per-section copy costs ~6 ms on 79 MB.
+    #[cfg(target_arch = "aarch64")]
+    {
+        let buf = read_file_parallel(&f, cap)?;
+        load_from_capped(&mut &buf[..], cap)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut r = BufReader::new(f);
+        load_from_capped(&mut r, cap)
+    }
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -305,12 +317,20 @@ pub fn write_id_map_to<W: Write>(
 pub fn load_id_map(
     path: impl AsRef<Path>,
 ) -> io::Result<(usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
-    let path = path.as_ref();
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(path, &f, cap)?;
-    load_id_map_from_capped(&mut &buf[..], cap)
+    // See `load` for the per-architecture read strategy rationale.
+    #[cfg(target_arch = "aarch64")]
+    {
+        let buf = read_file_parallel(&f, cap)?;
+        load_id_map_from_capped(&mut &buf[..], cap)
+    }
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        let mut r = BufReader::new(f);
+        load_id_map_from_capped(&mut r, cap)
+    }
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -731,16 +751,16 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
 /// Read a whole file of known length with positioned reads across scoped
-/// threads, each on its OWN file handle — a shared descriptor's per-fd
-/// locking serializes concurrent preads on common virtualized page
-/// caches (measured 21.5 → 3.8 ms for 79 MB on a KVM guest; near-linear
-/// on Apple Silicon either way). The buffer is allocated uninitialized
-/// and every byte is written by exactly one positioned read before
-/// `set_len` exposes it (on any error the Vec drops with len 0, so
-/// uninitialized bytes are never readable). Scoped `std::thread` (not
-/// rayon) keeps this outside the fork-safety pool machinery. Small
-/// files read serially through the already-open handle.
-fn read_file_parallel(path: &Path, f: &File, len: u64) -> io::Result<Vec<u8>> {
+/// threads (aarch64 path loads only — see the call sites for the
+/// measured rationale). The buffer is allocated uninitialized and every
+/// byte is written by exactly one positioned read before `set_len`
+/// exposes it (on any error the Vec drops with len 0, so uninitialized
+/// bytes are never readable). Scoped `std::thread` (not rayon) keeps
+/// this outside the fork-safety pool machinery. Small files read
+/// serially.
+#[cfg(target_arch = "aarch64")]
+fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
+    use std::os::unix::fs::FileExt;
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
     const CHUNK: usize = 8 * 1024 * 1024;
@@ -757,9 +777,7 @@ fn read_file_parallel(path: &Path, f: &File, len: u64) -> io::Result<Vec<u8>> {
     let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
     std::thread::scope(|s| {
         for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| {
-                let own_fd = File::open(path);
-                loop {
+            s.spawn(|| loop {
                 let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if i >= n_chunks {
                     break;
@@ -771,14 +789,9 @@ fn read_file_parallel(path: &Path, f: &File, len: u64) -> io::Result<Vec<u8>> {
                 // thread via read_exact_at.
                 let chunk =
                     unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = own_fd
-                    .as_ref()
-                    .map_err(clone_io_err)
-                    .and_then(|fd| read_exact_at(fd, chunk, off as u64))
-                {
+                if let Err(e) = f.read_exact_at(chunk, off as u64) {
                     *err.lock().expect("err lock") = Some(e);
                     break;
-                }
                 }
             });
         }
@@ -790,32 +803,6 @@ fn read_file_parallel(path: &Path, f: &File, len: u64) -> io::Result<Vec<u8>> {
     // read_exact_at (any failure returned above).
     unsafe { buf.set_len(len_usize) };
     Ok(buf)
-}
-
-#[cfg(unix)]
-fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
-    use std::os::unix::fs::FileExt;
-    f.read_exact_at(buf, off)
-}
-
-#[cfg(windows)]
-fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
-    use std::os::windows::fs::FileExt;
-    while !buf.is_empty() {
-        let n = f.seek_read(buf, off)?;
-        if n == 0 {
-            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
-        }
-        buf = &mut buf[n..];
-        off += n as u64;
-    }
-    Ok(())
-}
-
-/// Clone-shape an io::Error for use inside the reader threads (io::Error
-/// itself is not Clone; kind + text is all we need).
-fn clone_io_err(e: &io::Error) -> io::Error {
-    io::Error::new(e.kind(), e.to_string())
 }
 
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,8 +170,8 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(&f, cap)?;
-    load_from_capped(&mut &buf[..], cap)
+    let mut r = BufReader::new(f);
+    load_from_capped(&mut r, cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -307,8 +307,8 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(&f, cap)?;
-    load_id_map_from_capped(&mut &buf[..], cap)
+    let mut r = BufReader::new(f);
+    load_id_map_from_capped(&mut r, cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -728,79 +728,6 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// on a `take`-limited reader grows the buffer only to the bytes actually
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
-/// Read a whole file of known length with positioned reads across scoped
-/// threads — page-cache reads parallelize near-linearly and dominate
-/// large cold loads. The buffer is allocated uninitialized and every
-/// byte is written by exactly one positioned read before `set_len`
-/// exposes it (on any error the Vec drops with len 0, so uninitialized
-/// bytes are never readable). Scoped `std::thread` (not rayon) keeps
-/// this path outside the fork-safety pool machinery. Small files read
-/// serially through the capped reader.
-fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
-    let len_usize = usize::try_from(len)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
-    const CHUNK: usize = 8 * 1024 * 1024;
-    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
-    let mut buf: Vec<u8> = Vec::with_capacity(len_usize);
-    if len_usize < 2 * CHUNK || n_threads < 2 {
-        let mut r = f;
-        r.take(len).read_to_end(&mut buf)?;
-        return Ok(buf);
-    }
-    let n_chunks = len_usize.div_ceil(CHUNK);
-    let base = buf.spare_capacity_mut().as_mut_ptr() as usize;
-    let next = std::sync::atomic::AtomicUsize::new(0);
-    let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
-    std::thread::scope(|s| {
-        for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| loop {
-                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                if i >= n_chunks {
-                    break;
-                }
-                let off = i * CHUNK;
-                let this = CHUNK.min(len_usize - off);
-                // SAFETY: chunks are disjoint [off, off+this) views of the
-                // allocation; each is written (never read) by exactly one
-                // thread via read_exact_at.
-                let chunk =
-                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = read_exact_at(f, chunk, off as u64) {
-                    *err.lock().expect("err lock") = Some(e);
-                    break;
-                }
-            });
-        }
-    });
-    if let Some(e) = err.into_inner().expect("err lock") {
-        return Err(e);
-    }
-    // SAFETY: every byte in 0..len was filled by a successful
-    // read_exact_at (any failure returned above).
-    unsafe { buf.set_len(len_usize) };
-    Ok(buf)
-}
-
-#[cfg(unix)]
-fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
-    use std::os::unix::fs::FileExt;
-    f.read_exact_at(buf, off)
-}
-
-#[cfg(windows)]
-fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
-    use std::os::windows::fs::FileExt;
-    while !buf.is_empty() {
-        let n = f.seek_read(buf, off)?;
-        if n == 0 {
-            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
-        }
-        buf = &mut buf[n..];
-        off += n as u64;
-    }
-    Ok(())
-}
-
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
     read_exact_vec_capped(r, n, 0)
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,21 +170,16 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    // aarch64: parallel positioned whole-file read (page-cache reads
-    // parallelize near-linearly there and the M-series load is
-    // read-bound — measured ~2.3x). x86: the streamed capped read wins —
-    // measured: parallel pread gains nothing on common virtualized page
-    // caches while the extra per-section copy costs ~6 ms on 79 MB.
-    #[cfg(target_arch = "aarch64")]
-    {
-        let buf = read_file_parallel(&f, cap)?;
-        load_from_capped(&mut &buf[..], cap)
+    // Parallel whole-file read (scoped threads; both architectures —
+    // measured 20.5 → 7.7 ms on a KVM guest, ~2.3x on Apple Silicon),
+    // then v6 sections parse from the in-memory buffer with the one big
+    // section extracted by a parallel fault+copy. v5 files parse from
+    // the same buffer through the generic path.
+    let buf = read_file_parallel(&f, cap)?;
+    if let Some(core) = try_parse_v6_fast(&buf, TV_MAGIC)? {
+        return Ok(core.0);
     }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        let mut r = BufReader::new(f);
-        load_from_capped(&mut r, cap)
-    }
+    load_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -320,17 +315,24 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    // See `load` for the per-architecture read strategy rationale.
-    #[cfg(target_arch = "aarch64")]
-    {
-        let buf = read_file_parallel(&f, cap)?;
-        load_id_map_from_capped(&mut &buf[..], cap)
+    // See `load` — parallel read + fast v6 parse.
+    let buf = read_file_parallel(&f, cap)?;
+    if let Some((core, rest)) = try_parse_v6_fast(&buf, TVIM_MAGIC)? {
+        let (bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale) = core;
+        let mut r = rest;
+        let id_bytes = n_vectors
+            .checked_mul(8)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "id table size overflows usize"))?;
+        let raw = read_exact_vec_capped(&mut r, id_bytes, cap)?;
+        let slot_to_id: Vec<u64> = raw
+            .chunks_exact(8)
+            .map(|b| u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
+            .collect();
+        return Ok((
+            bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale, slot_to_id,
+        ));
     }
-    #[cfg(not(target_arch = "aarch64"))]
-    {
-        let mut r = BufReader::new(f);
-        load_id_map_from_capped(&mut r, cap)
-    }
+    load_id_map_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -511,12 +513,30 @@ fn read_core_v6<R: Read>(r: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
     let n_levels = 1usize << bit_width;
     let boundaries = read_f32_array(r, n_levels - 1)?;
     let centroids = read_f32_array(r, n_levels)?;
+    validate_codebook(n_vectors, &boundaries, &centroids)?;
+    let blocked_bytes = v6_blocked_len(bit_width, dim, n_vectors)?;
+    let blocked = read_exact_vec_capped(r, blocked_bytes, alloc_cap)?;
+    let scales = read_scales_validated(r, n_vectors)?;
+    let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(r, dim)?;
+    Ok((
+        bit_width,
+        dim,
+        n_vectors,
+        CodePayload::BlockedSeq { codes: blocked, boundaries, centroids },
+        scales,
+        tqplus_shift,
+        tqplus_scale,
+    ))
+}
+
+/// Codebook value validation shared by the streamed and fast v6 loaders.
+fn validate_codebook(n_vectors: usize, boundaries: &[f32], centroids: &[f32]) -> io::Result<()> {
     // Codebook value validation (skipped for an empty index, whose
     // codebook is an ignored all-zero placeholder): search uses these to
     // decode every score, so a non-finite or out-of-support value would
     // silently poison results. |v| <= 1 is the quantizer's support.
     if n_vectors > 0 {
-        for (name, vals) in [("boundaries", &boundaries), ("centroids", &centroids)] {
+        for (name, vals) in [("boundaries", boundaries), ("centroids", centroids)] {
             if let Some((i, &v)) = vals
                 .iter()
                 .enumerate()
@@ -541,37 +561,25 @@ fn read_core_v6<R: Read>(r: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
             ));
         }
     }
-    let blocked_bytes = if dim == 0 {
-        0
-    } else {
-        // Checked: dim/n_vectors are attacker-controlled.
-        let codes_per_byte = 8 / bit_width;
-        let n_byte_groups = dim / codes_per_byte;
-        let n_blocks = n_vectors
-            .checked_add(crate::BLOCK - 1)
-            .map(|x| x / crate::BLOCK)
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "block count overflows usize")
-            })?;
-        n_blocks
-            .checked_mul(n_byte_groups)
-            .and_then(|x| x.checked_mul(crate::BLOCK))
-            .ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidData, "blocked code size overflows usize")
-            })?
-    };
-    let blocked = read_exact_vec_capped(r, blocked_bytes, alloc_cap)?;
-    let scales = read_scales_validated(r, n_vectors)?;
-    let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(r, dim)?;
-    Ok((
-        bit_width,
-        dim,
-        n_vectors,
-        CodePayload::BlockedSeq { codes: blocked, boundaries, centroids },
-        scales,
-        tqplus_shift,
-        tqplus_scale,
-    ))
+    Ok(())
+}
+
+/// The v6 blocked-payload length for a validated header, with checked
+/// arithmetic (dim/n_vectors are attacker-controlled).
+fn v6_blocked_len(bit_width: usize, dim: usize, n_vectors: usize) -> io::Result<usize> {
+    if dim == 0 {
+        return Ok(0);
+    }
+    let codes_per_byte = 8 / bit_width;
+    let n_byte_groups = dim / codes_per_byte;
+    let n_blocks = n_vectors
+        .checked_add(crate::BLOCK - 1)
+        .map(|x| x / crate::BLOCK)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "block count overflows usize"))?;
+    n_blocks
+        .checked_mul(n_byte_groups)
+        .and_then(|x| x.checked_mul(crate::BLOCK))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "blocked code size overflows usize"))
 }
 
 /// v5: header (`bit_width` u8 + `dim` u32 + `n_vectors` u64) + codes +
@@ -758,9 +766,7 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// bytes are never readable). Scoped `std::thread` (not rayon) keeps
 /// this outside the fork-safety pool machinery. Small files read
 /// serially.
-#[cfg(target_arch = "aarch64")]
 fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
-    use std::os::unix::fs::FileExt;
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
     const CHUNK: usize = 8 * 1024 * 1024;
@@ -789,7 +795,7 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
                 // thread via read_exact_at.
                 let chunk =
                     unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = f.read_exact_at(chunk, off as u64) {
+                if let Err(e) = read_exact_at(f, chunk, off as u64) {
                     *err.lock().expect("err lock") = Some(e);
                     break;
                 }
@@ -803,6 +809,112 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
     // read_exact_at (any failure returned above).
     unsafe { buf.set_len(len_usize) };
     Ok(buf)
+}
+
+/// Fast v6 parse from a whole-file buffer: identical sections, headers
+/// and validators as the streamed reader (`read_core_v6`), with the one
+/// large section — the blocked codes — extracted by [`parallel_copy_out`]
+/// so its page-fault + copy cost spreads across threads instead of
+/// crawling single-threaded (measured 21.7 → ~3 ms on 77 MB). Returns
+/// `Ok(None)` for anything that is not a well-formed v6 magic+version
+/// prefix — the caller falls back to the generic reader, which produces
+/// the canonical error messages.
+#[allow(clippy::type_complexity)]
+fn try_parse_v6_fast<'a>(
+    buf: &'a [u8],
+    magic: &[u8; 4],
+) -> io::Result<Option<(CoreLoad, &'a [u8])>> {
+    if buf.len() < 5 || &buf[0..4] != magic || buf[4] != 6 {
+        return Ok(None);
+    }
+    let mut r: &[u8] = &buf[5..];
+    let (bit_width, dim, n_vectors) = read_v5_header(&mut r)?;
+    let n_levels = 1usize << bit_width;
+    let boundaries = read_f32_array(&mut r, n_levels - 1)?;
+    let centroids = read_f32_array(&mut r, n_levels)?;
+    validate_codebook(n_vectors, &boundaries, &centroids)?;
+    let blocked_bytes = v6_blocked_len(bit_width, dim, n_vectors)?;
+    if r.len() < blocked_bytes {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            format!("truncated file: expected {blocked_bytes} bytes, got {}", r.len()),
+        ));
+    }
+    let codes = parallel_copy_out(&r[..blocked_bytes]);
+    r = &r[blocked_bytes..];
+    let scales = read_scales_validated(&mut r, n_vectors)?;
+    let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(&mut r, dim)?;
+    Ok(Some((
+        (
+            bit_width,
+            dim,
+            n_vectors,
+            CodePayload::BlockedSeq { codes, boundaries, centroids },
+            scales,
+            tqplus_shift,
+            tqplus_scale,
+        ),
+        r,
+    )))
+}
+
+/// Copy a large slice into a fresh exact-size buffer with the work — and
+/// the destination page faults, which dominate on fresh allocations —
+/// spread across scoped threads. Small inputs copy serially.
+fn parallel_copy_out(src: &[u8]) -> Vec<u8> {
+    const CHUNK: usize = 8 * 1024 * 1024;
+    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    if src.len() < 2 * CHUNK || n_threads < 2 {
+        return src.to_vec();
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(src.len());
+    let n_chunks = src.len().div_ceil(CHUNK);
+    let base = out.spare_capacity_mut().as_mut_ptr() as usize;
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    std::thread::scope(|s| {
+        for _ in 0..n_threads.min(n_chunks) {
+            s.spawn(|| loop {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if i >= n_chunks {
+                    break;
+                }
+                let off = i * CHUNK;
+                let this = CHUNK.min(src.len() - off);
+                // SAFETY: disjoint [off, off+this) chunks, each written by
+                // exactly one thread.
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        src.as_ptr().add(off),
+                        (base + off) as *mut u8,
+                        this,
+                    );
+                }
+            });
+        }
+    });
+    // SAFETY: every byte in 0..len was written above.
+    unsafe { out.set_len(src.len()) };
+    out
+}
+
+#[cfg(unix)]
+fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.read_exact_at(buf, off)
+}
+
+#[cfg(windows)]
+fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        let n = f.seek_read(buf, off)?;
+        if n == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
+        }
+        buf = &mut buf[n..];
+        off += n as u64;
+    }
+    Ok(())
 }
 
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,8 +170,8 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(&f, cap)?;
-    load_from_capped(&mut &buf[..], cap)
+    let mut r = BufReader::new(f);
+    load_from_capped(&mut r, cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -307,8 +307,8 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let buf = read_file_parallel(&f, cap)?;
-    load_id_map_from_capped(&mut &buf[..], cap)
+    let mut r = BufReader::new(f);
+    load_id_map_from_capped(&mut r, cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -728,73 +728,6 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// on a `take`-limited reader grows the buffer only to the bytes actually
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
-/// Read a whole file of known length with positioned reads across scoped
-/// threads — page-cache reads parallelize near-linearly, and the copy is
-/// the dominant cold-load cost for large indexes. Scoped `std::thread`
-/// (not rayon) keeps this path outside the fork-safety pool machinery:
-/// threads are created and joined within the call. Small files read
-/// serially.
-fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
-    let len_usize = usize::try_from(len)
-        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
-    const CHUNK: usize = 8 * 1024 * 1024;
-    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
-    if len_usize < 2 * CHUNK || n_threads < 2 {
-        let mut buf = Vec::with_capacity(len_usize);
-        let mut r = f;
-        r.take(len).read_to_end(&mut buf)?;
-        return Ok(buf);
-    }
-    let mut buf = vec![0u8; len_usize];
-    let n_chunks = len_usize.div_ceil(CHUNK);
-    let next = std::sync::atomic::AtomicUsize::new(0);
-    let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
-    // Disjoint chunk views handed to workers via chunks_mut.
-    let chunks: Vec<(usize, &mut [u8])> = buf.chunks_mut(CHUNK).enumerate().collect();
-    let chunks = std::sync::Mutex::new(chunks.into_iter().map(Some).collect::<Vec<_>>());
-    std::thread::scope(|s| {
-        for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| loop {
-                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                if i >= n_chunks {
-                    break;
-                }
-                let taken = chunks.lock().expect("chunk list lock")[i].take();
-                let Some((idx, chunk)) = taken else { break };
-                let off = (idx * CHUNK) as u64;
-                if let Err(e) = read_exact_at(f, chunk, off) {
-                    *err.lock().expect("err lock") = Some(e);
-                    break;
-                }
-            });
-        }
-    });
-    if let Some(e) = err.into_inner().expect("err lock") {
-        return Err(e);
-    }
-    Ok(buf)
-}
-
-#[cfg(unix)]
-fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
-    use std::os::unix::fs::FileExt;
-    f.read_exact_at(buf, off)
-}
-
-#[cfg(windows)]
-fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
-    use std::os::windows::fs::FileExt;
-    while !buf.is_empty() {
-        let n = f.seek_read(buf, off)?;
-        if n == 0 {
-            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
-        }
-        buf = &mut buf[n..];
-        off += n as u64;
-    }
-    Ok(())
-}
-
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
     read_exact_vec_capped(r, n, 0)
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -786,17 +786,21 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
 fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>> {
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
-    const CHUNK: usize = 8 * 1024 * 1024;
+    const CHUNK_MIN: usize = 8 * 1024 * 1024;
     let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
     let mut buf: Vec<u8> = Vec::with_capacity(len_usize);
-    if len_usize < 2 * CHUNK || n_threads < 2 {
+    if len_usize < 2 * CHUNK_MIN || n_threads < 2 {
         // Positioned serial read — must honor `range_off` (a plain
         // `take` would read from the descriptor's current position).
         buf.resize(len_usize, 0);
         read_exact_at(f, &mut buf, range_off)?;
         return Ok(buf);
     }
-    let n_chunks = len_usize.div_ceil(CHUNK);
+    // One even chunk per thread, one positioned read each — fewer,
+    // larger syscalls measure faster than a fine-grained work queue on
+    // both target platforms.
+    let chunk = len_usize.div_ceil(n_threads).max(CHUNK_MIN).next_multiple_of(4096);
+    let n_chunks = len_usize.div_ceil(chunk);
     let base = buf.spare_capacity_mut().as_mut_ptr() as usize;
     let next = std::sync::atomic::AtomicUsize::new(0);
     let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
@@ -807,8 +811,8 @@ fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>
                 if i >= n_chunks {
                     break;
                 }
-                let off = i * CHUNK;
-                let this = CHUNK.min(len_usize - off);
+                let off = i * chunk;
+                let this = chunk.min(len_usize - off);
                 // SAFETY: chunks are disjoint [off, off+this) views of the
                 // allocation; each is written (never read) by exactly one
                 // thread via read_exact_at.

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -57,7 +57,7 @@
 //! file" cleanly.
 
 use std::fs::File;
-use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::io::{self, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
 const TV_MAGIC: &[u8; 4] = b"TVPI";
@@ -179,15 +179,15 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    // Parallel whole-file read (scoped threads; both architectures —
-    // measured 20.5 → 7.7 ms on a KVM guest, ~2.3x on Apple Silicon),
-    // then v6 sections parse from the in-memory buffer with the one big
-    // section extracted by a parallel fault+copy. v5 files parse from
-    // the same buffer through the generic path.
-    let buf = read_file_parallel(&f, cap)?;
-    if let Some(core) = try_parse_v6_fast(&buf, TV_MAGIC)? {
-        return Ok(core.0);
+    // Fast v6 path: sections read straight from the file — the fixed
+    // header offset lets the codes section parallel-pread directly into
+    // its final buffer (no intermediate copy), then transform in place
+    // on warm pages. v5/malformed files fall back to the generic
+    // streamed reader for canonical errors.
+    if let Some((core, _tail)) = try_load_v6_fast(&f, cap, TV_MAGIC)? {
+        return Ok(core);
     }
+    let buf = read_file_parallel(&f, cap)?;
     load_from_capped(&mut &buf[..], cap)
 }
 
@@ -324,11 +324,10 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    // See `load` — parallel read + fast v6 parse.
-    let buf = read_file_parallel(&f, cap)?;
-    if let Some((core, rest)) = try_parse_v6_fast(&buf, TVIM_MAGIC)? {
+    // See `load` — direct-to-destination fast v6 path.
+    if let Some((core, tail)) = try_load_v6_fast(&f, cap, TVIM_MAGIC)? {
         let (bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale) = core;
-        let mut r = rest;
+        let mut r = &tail[..];
         let id_bytes = n_vectors
             .checked_mul(8)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "id table size overflows usize"))?;
@@ -341,6 +340,7 @@ pub fn load_id_map(
             bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale, slot_to_id,
         ));
     }
+    let buf = read_file_parallel(&f, cap)?;
     load_id_map_from_capped(&mut &buf[..], cap)
 }
 
@@ -776,14 +776,24 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// this outside the fork-safety pool machinery. Small files read
 /// serially.
 fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
+    read_range_parallel(f, 0, len)
+}
+
+/// Positioned parallel read of `[off, off+len)` into a fresh exact-size
+/// buffer — the offset form lets the fast v6 loader read the codes
+/// section straight into its final home (no intermediate whole-file
+/// buffer, no extraction copy).
+fn read_range_parallel(f: &File, range_off: u64, len: u64) -> io::Result<Vec<u8>> {
     let len_usize = usize::try_from(len)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
     const CHUNK: usize = 8 * 1024 * 1024;
     let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
     let mut buf: Vec<u8> = Vec::with_capacity(len_usize);
     if len_usize < 2 * CHUNK || n_threads < 2 {
-        let mut r = f;
-        r.take(len).read_to_end(&mut buf)?;
+        // Positioned serial read — must honor `range_off` (a plain
+        // `take` would read from the descriptor's current position).
+        buf.resize(len_usize, 0);
+        read_exact_at(f, &mut buf, range_off)?;
         return Ok(buf);
     }
     let n_chunks = len_usize.div_ceil(CHUNK);
@@ -804,7 +814,7 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
                 // thread via read_exact_at.
                 let chunk =
                     unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                if let Err(e) = read_exact_at(f, chunk, off as u64) {
+                if let Err(e) = read_exact_at(f, chunk, range_off + off as u64) {
                     *err.lock().expect("err lock") = Some(e);
                     break;
                 }
@@ -820,39 +830,61 @@ fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Fast v6 parse from a whole-file buffer: identical sections, headers
-/// and validators as the streamed reader (`read_core_v6`), with the one
-/// large section — the blocked codes — extracted by [`parallel_copy_out`]
-/// so its page-fault + copy cost spreads across threads instead of
-/// crawling single-threaded (measured 21.7 → ~3 ms on 77 MB). Returns
-/// `Ok(None)` for anything that is not a well-formed v6 magic+version
-/// prefix — the caller falls back to the generic reader, which produces
-/// the canonical error messages.
+/// Fast v6 loader: reads sections straight from the file. The prefix
+/// (magic + version + header + codebook — 142 bytes at 4-bit, bounded by
+/// PREFIX_MAX) is read serially and parsed with the same validators as
+/// the streamed reader; the codes section is then parallel-pread into
+/// its exact final buffer and transformed to the native layout in place
+/// (pages just faulted by the read, so the transform runs warm); the
+/// small tail (scales + TQ+ [+ id table]) is read serially and returned
+/// for the caller to finish. Returns `Ok(None)` for anything that is
+/// not a well-formed v6 magic+version prefix — callers fall back to the
+/// generic reader, which produces the canonical error messages.
 #[allow(clippy::type_complexity)]
-fn try_parse_v6_fast<'a>(
-    buf: &'a [u8],
+fn try_load_v6_fast(
+    f: &File,
+    cap: u64,
     magic: &[u8; 4],
-) -> io::Result<Option<(CoreLoad, &'a [u8])>> {
-    if buf.len() < 5 || &buf[0..4] != magic || buf[4] != 6 {
+) -> io::Result<Option<(CoreLoad, Vec<u8>)>> {
+    const PREFIX_MAX: usize = 4096;
+    let prefix_len = (cap as usize).min(PREFIX_MAX);
+    if prefix_len < 5 {
         return Ok(None);
     }
-    let mut r: &[u8] = &buf[5..];
+    let mut prefix = vec![0u8; prefix_len];
+    read_exact_at(f, &mut prefix, 0)?;
+    if &prefix[0..4] != magic || prefix[4] != 6 {
+        return Ok(None);
+    }
+    let mut r: &[u8] = &prefix[5..];
     let (bit_width, dim, n_vectors) = read_v5_header(&mut r)?;
     let n_levels = 1usize << bit_width;
     let boundaries = read_f32_array(&mut r, n_levels - 1)?;
     let centroids = read_f32_array(&mut r, n_levels)?;
     validate_codebook(n_vectors, &boundaries, &centroids)?;
     let blocked_bytes = v6_blocked_len(bit_width, dim, n_vectors)?;
-    if r.len() < blocked_bytes {
-        return Err(io::Error::new(
-            io::ErrorKind::UnexpectedEof,
-            format!("truncated file: expected {blocked_bytes} bytes, got {}", r.len()),
-        ));
-    }
-    let codes = parallel_extract_native(&r[..blocked_bytes]);
-    r = &r[blocked_bytes..];
-    let scales = read_scales_validated(&mut r, n_vectors)?;
-    let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(&mut r, dim)?;
+    let codes_start = (prefix_len - r.len()) as u64;
+    let codes_end = codes_start
+        .checked_add(blocked_bytes as u64)
+        .filter(|&e| e <= cap)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                format!("truncated file: expected {blocked_bytes} code bytes"),
+            )
+        })?;
+    let codes_seq = read_range_parallel(f, codes_start, blocked_bytes as u64)?;
+    // In-place native transform on just-faulted (warm) pages; identity
+    // on non-x86, where the stored layout is already native.
+    let codes = crate::pack::seq_into_native(codes_seq);
+    // Tail: scales + TQ+ (+ id table for .tvim) — small.
+    let tail_len = (cap - codes_end) as usize;
+    let mut tail = vec![0u8; tail_len];
+    read_exact_at(f, &mut tail, codes_end)?;
+    let mut tr: &[u8] = &tail[..];
+    let scales = read_scales_validated(&mut tr, n_vectors)?;
+    let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(&mut tr, dim)?;
+    let rest = tr.to_vec();
     Ok(Some((
         (
             bit_width,
@@ -863,48 +895,8 @@ fn try_parse_v6_fast<'a>(
             tqplus_shift,
             tqplus_scale,
         ),
-        r,
+        rest,
     )))
-}
-
-/// Extract a large blocked-codes slice into a fresh exact-size buffer in
-/// the platform's native kernel layout, one fused pass: the copy, the
-/// destination page faults (which dominate on fresh allocations), and
-/// the x86 nibble interleave all spread across scoped threads. Small
-/// inputs extract serially.
-fn parallel_extract_native(src: &[u8]) -> Vec<u8> {
-    const CHUNK: usize = 8 * 1024 * 1024;
-    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
-    if src.len() < 2 * CHUNK || n_threads < 2 {
-        let mut out = vec![0u8; src.len()];
-        crate::pack::extract_native_chunk(src, &mut out);
-        return out;
-    }
-    let mut out: Vec<u8> = Vec::with_capacity(src.len());
-    let n_chunks = src.len().div_ceil(CHUNK);
-    let base = out.spare_capacity_mut().as_mut_ptr() as usize;
-    let next = std::sync::atomic::AtomicUsize::new(0);
-    std::thread::scope(|s| {
-        for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| loop {
-                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                if i >= n_chunks {
-                    break;
-                }
-                let off = i * CHUNK;
-                let this = CHUNK.min(src.len() - off);
-                // SAFETY: disjoint [off, off+this) chunks, each written by
-                // exactly one thread; the raw view is only written through
-                // extract_native_chunk.
-                let dst =
-                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
-                crate::pack::extract_native_chunk(&src[off..off + this], dst);
-            });
-        }
-    });
-    // SAFETY: every byte in 0..len was written above.
-    unsafe { out.set_len(src.len()) };
-    out
 }
 
 #[cfg(unix)]

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -170,8 +170,8 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     // so a tiny file declaring a huge payload still cannot drive a large
     // allocation (same posture as the capped incremental read).
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_from_capped(&mut r, cap)
+    let buf = read_file_parallel(&f, cap)?;
+    load_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -307,8 +307,8 @@ pub fn load_id_map(
     let f = File::open(path)?;
     // See `load` for the allocation-cap rationale.
     let cap = f.metadata()?.len();
-    let mut r = BufReader::new(f);
-    load_id_map_from_capped(&mut r, cap)
+    let buf = read_file_parallel(&f, cap)?;
+    load_id_map_from_capped(&mut &buf[..], cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -728,6 +728,73 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// on a `take`-limited reader grows the buffer only to the bytes actually
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
+/// Read a whole file of known length with positioned reads across scoped
+/// threads — page-cache reads parallelize near-linearly, and the copy is
+/// the dominant cold-load cost for large indexes. Scoped `std::thread`
+/// (not rayon) keeps this path outside the fork-safety pool machinery:
+/// threads are created and joined within the call. Small files read
+/// serially.
+fn read_file_parallel(f: &File, len: u64) -> io::Result<Vec<u8>> {
+    let len_usize = usize::try_from(len)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
+    const CHUNK: usize = 8 * 1024 * 1024;
+    let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+    if len_usize < 2 * CHUNK || n_threads < 2 {
+        let mut buf = Vec::with_capacity(len_usize);
+        let mut r = f;
+        r.take(len).read_to_end(&mut buf)?;
+        return Ok(buf);
+    }
+    let mut buf = vec![0u8; len_usize];
+    let n_chunks = len_usize.div_ceil(CHUNK);
+    let next = std::sync::atomic::AtomicUsize::new(0);
+    let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
+    // Disjoint chunk views handed to workers via chunks_mut.
+    let chunks: Vec<(usize, &mut [u8])> = buf.chunks_mut(CHUNK).enumerate().collect();
+    let chunks = std::sync::Mutex::new(chunks.into_iter().map(Some).collect::<Vec<_>>());
+    std::thread::scope(|s| {
+        for _ in 0..n_threads.min(n_chunks) {
+            s.spawn(|| loop {
+                let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                if i >= n_chunks {
+                    break;
+                }
+                let taken = chunks.lock().expect("chunk list lock")[i].take();
+                let Some((idx, chunk)) = taken else { break };
+                let off = (idx * CHUNK) as u64;
+                if let Err(e) = read_exact_at(f, chunk, off) {
+                    *err.lock().expect("err lock") = Some(e);
+                    break;
+                }
+            });
+        }
+    });
+    if let Some(e) = err.into_inner().expect("err lock") {
+        return Err(e);
+    }
+    Ok(buf)
+}
+
+#[cfg(unix)]
+fn read_exact_at(f: &File, buf: &mut [u8], off: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.read_exact_at(buf, off)
+}
+
+#[cfg(windows)]
+fn read_exact_at(f: &File, mut buf: &mut [u8], mut off: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        let n = f.seek_read(buf, off)?;
+        if n == 0 {
+            return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated file"));
+        }
+        buf = &mut buf[n..];
+        off += n as u64;
+    }
+    Ok(())
+}
+
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
     read_exact_vec_capped(r, n, 0)
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -164,8 +164,14 @@ pub fn write_to<W: Write>(
 /// because the v5 rotation break changed every encoded byte. Files
 /// with empty TQ+ are treated as identity calibration.
 pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
-    let mut f = BufReader::new(File::open(path)?);
-    load_from(&mut f)
+    let f = File::open(path)?;
+    // The file's real length caps section preallocation: a section can
+    // pre-reserve its declared size only when the bytes provably exist,
+    // so a tiny file declaring a huge payload still cannot drive a large
+    // allocation (same posture as the capped incremental read).
+    let cap = f.metadata()?.len();
+    let mut r = BufReader::new(f);
+    load_from_capped(&mut r, cap)
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -173,6 +179,12 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
 /// (structural checks, value-level float validation), so a byte slice
 /// and the file it came from load — or fail — identically.
 pub fn load_from<R: Read>(f: &mut R) -> io::Result<CoreLoad> {
+    load_from_capped(f, 0)
+}
+
+/// [`load_from`] with a preallocation cap from a trusted source (the
+/// real file length for path loads; `0` = never preallocate).
+fn load_from_capped<R: Read>(f: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
     let mut magic = [0u8; 4];
     f.read_exact(&mut magic)?;
     if &magic != TV_MAGIC {
@@ -190,7 +202,7 @@ pub fn load_from<R: Read>(f: &mut R) -> io::Result<CoreLoad> {
     }
     let mut version = [0u8; 1];
     f.read_exact(&mut version)?;
-    read_core_versioned(f, version[0], TV_VERSION, ".tv")
+    read_core_versioned(f, version[0], TV_VERSION, ".tv", alloc_cap)
 }
 
 /// Error for an index written in a pre-v5 format (versions 1 through 4).
@@ -292,8 +304,11 @@ pub fn write_id_map_to<W: Write>(
 pub fn load_id_map(
     path: impl AsRef<Path>,
 ) -> io::Result<(usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
-    let mut f = BufReader::new(File::open(path)?);
-    load_id_map_from(&mut f)
+    let f = File::open(path)?;
+    // See `load` for the allocation-cap rationale.
+    let cap = f.metadata()?.len();
+    let mut r = BufReader::new(f);
+    load_id_map_from_capped(&mut r, cap)
 }
 
 /// `.tvim` load from any [`Read`] source — the in-memory counterpart of
@@ -303,6 +318,16 @@ pub fn load_id_map(
 #[allow(clippy::type_complexity)]
 pub fn load_id_map_from<R: Read>(
     f: &mut R,
+) -> io::Result<(usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
+    load_id_map_from_capped(f, 0)
+}
+
+/// [`load_id_map_from`] with a trusted preallocation cap (see
+/// [`load_from_capped`]).
+#[allow(clippy::type_complexity)]
+fn load_id_map_from_capped<R: Read>(
+    f: &mut R,
+    alloc_cap: u64,
 ) -> io::Result<(usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>, Vec<u64>)> {
     let mut magic = [0u8; 4];
     f.read_exact(&mut magic)?;
@@ -315,7 +340,7 @@ pub fn load_id_map_from<R: Read>(
     let mut version = [0u8; 1];
     f.read_exact(&mut version)?;
     let (bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale) =
-        read_core_versioned(f, version[0], TVIM_VERSION, ".tvim")?;
+        read_core_versioned(f, version[0], TVIM_VERSION, ".tvim", alloc_cap)?;
 
     // Read the slot_to_id table via the capped reader rather than
     // `Vec::with_capacity(n_vectors)` — `n_vectors` is attacker-controlled and
@@ -323,7 +348,7 @@ pub fn load_id_map_from<R: Read>(
     let id_bytes = n_vectors
         .checked_mul(8)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "id table size overflows usize"))?;
-    let raw = read_exact_vec(f, id_bytes)?;
+    let raw = read_exact_vec_capped(f, id_bytes, alloc_cap)?;
     let slot_to_id: Vec<u64> = raw
         .chunks_exact(8)
         .map(|b| u64::from_le_bytes([b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]]))
@@ -440,9 +465,10 @@ fn read_core_versioned<R: Read>(
     version: u8,
     expected: u8,
     label: &str,
+    alloc_cap: u64,
 ) -> io::Result<CoreLoad> {
     match version {
-        6 => read_core_v6(r),
+        6 => read_core_v6(r, alloc_cap),
         5 => read_core_v5(r),
         1..=4 => Err(incompatible_version_error(version, label)),
         _ => Err(io::Error::new(
@@ -458,7 +484,7 @@ fn read_core_versioned<R: Read>(
 /// v6: identical header and trailer to v5, but the code payload is the
 /// arch-neutral sequential blocked layout (see [`CodePayload`]); its
 /// length is the padded blocked size, not the packed row size.
-fn read_core_v6<R: Read>(r: &mut R) -> io::Result<CoreLoad> {
+fn read_core_v6<R: Read>(r: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
     let (bit_width, dim, n_vectors) = read_v5_header(r)?;
     let n_levels = 1usize << bit_width;
     let boundaries = read_f32_array(r, n_levels - 1)?;
@@ -512,7 +538,7 @@ fn read_core_v6<R: Read>(r: &mut R) -> io::Result<CoreLoad> {
                 io::Error::new(io::ErrorKind::InvalidData, "blocked code size overflows usize")
             })?
     };
-    let blocked = read_exact_vec(r, blocked_bytes)?;
+    let blocked = read_exact_vec_capped(r, blocked_bytes, alloc_cap)?;
     let scales = read_scales_validated(r, n_vectors)?;
     let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(r, dim)?;
     Ok((
@@ -703,7 +729,21 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
 fn read_exact_vec<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<u8>> {
-    let mut buf = Vec::new();
+    read_exact_vec_capped(r, n, 0)
+}
+
+/// [`read_exact_vec`] with a trusted allocation cap: when the declared
+/// section size provably fits the source (`n <= alloc_cap`, where the
+/// cap comes from real file metadata), pre-reserve it exactly — the
+/// capped `read_to_end` then fills spare capacity with no zero-fill and
+/// no growth-doubling copies. Otherwise fall back to the incremental
+/// read, which never trusts `n` for allocation.
+fn read_exact_vec_capped<R: Read>(r: &mut R, n: usize, alloc_cap: u64) -> io::Result<Vec<u8>> {
+    let mut buf = if (n as u64) <= alloc_cap {
+        Vec::with_capacity(n)
+    } else {
+        Vec::new()
+    };
     let read = r.take(n as u64).read_to_end(&mut buf)?;
     if read != n {
         return Err(io::Error::new(

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -92,6 +92,15 @@ pub enum CodePayload {
         boundaries: Vec<f32>,
         centroids: Vec<f32>,
     },
+    /// Codes already in the *native* kernel layout for this platform —
+    /// produced by the fast path loader, whose extraction pass fuses the
+    /// platform transform into the copy. Byte-identical to `BlockedSeq`
+    /// on non-x86 (the stored layout is native there).
+    BlockedNative {
+        codes: Vec<u8>,
+        boundaries: Vec<f32>,
+        centroids: Vec<f32>,
+    },
 }
 
 /// Core payload — what a fully-deserialized index needs.
@@ -840,7 +849,7 @@ fn try_parse_v6_fast<'a>(
             format!("truncated file: expected {blocked_bytes} bytes, got {}", r.len()),
         ));
     }
-    let codes = parallel_copy_out(&r[..blocked_bytes]);
+    let codes = parallel_extract_native(&r[..blocked_bytes]);
     r = &r[blocked_bytes..];
     let scales = read_scales_validated(&mut r, n_vectors)?;
     let (tqplus_shift, tqplus_scale) = read_tqplus_trailer(&mut r, dim)?;
@@ -849,7 +858,7 @@ fn try_parse_v6_fast<'a>(
             bit_width,
             dim,
             n_vectors,
-            CodePayload::BlockedSeq { codes, boundaries, centroids },
+            CodePayload::BlockedNative { codes, boundaries, centroids },
             scales,
             tqplus_shift,
             tqplus_scale,
@@ -858,14 +867,18 @@ fn try_parse_v6_fast<'a>(
     )))
 }
 
-/// Copy a large slice into a fresh exact-size buffer with the work — and
-/// the destination page faults, which dominate on fresh allocations —
-/// spread across scoped threads. Small inputs copy serially.
-fn parallel_copy_out(src: &[u8]) -> Vec<u8> {
+/// Extract a large blocked-codes slice into a fresh exact-size buffer in
+/// the platform's native kernel layout, one fused pass: the copy, the
+/// destination page faults (which dominate on fresh allocations), and
+/// the x86 nibble interleave all spread across scoped threads. Small
+/// inputs extract serially.
+fn parallel_extract_native(src: &[u8]) -> Vec<u8> {
     const CHUNK: usize = 8 * 1024 * 1024;
     let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
     if src.len() < 2 * CHUNK || n_threads < 2 {
-        return src.to_vec();
+        let mut out = vec![0u8; src.len()];
+        crate::pack::extract_native_chunk(src, &mut out);
+        return out;
     }
     let mut out: Vec<u8> = Vec::with_capacity(src.len());
     let n_chunks = src.len().div_ceil(CHUNK);
@@ -881,14 +894,11 @@ fn parallel_copy_out(src: &[u8]) -> Vec<u8> {
                 let off = i * CHUNK;
                 let this = CHUNK.min(src.len() - off);
                 // SAFETY: disjoint [off, off+this) chunks, each written by
-                // exactly one thread.
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        src.as_ptr().add(off),
-                        (base + off) as *mut u8,
-                        this,
-                    );
-                }
+                // exactly one thread; the raw view is only written through
+                // extract_native_chunk.
+                let dst =
+                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
+                crate::pack::extract_native_chunk(&src[off..off + this], dst);
             });
         }
     });

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -768,8 +768,9 @@ fn read_scales_validated<R: Read>(r: &mut R, n_vectors: usize) -> io::Result<Vec
 /// present, so we never reserve the attacker's claimed size before confirming
 /// the data exists. The length check then rejects a truncated file cleanly.
 /// Read a whole file of known length with positioned reads across scoped
-/// threads (aarch64 path loads only — see the call sites for the
-/// measured rationale). The buffer is allocated uninitialized and every
+/// threads — the generic-fallback whole-file form of
+/// [`read_range_parallel`], used when the fast v6 path declines. The
+/// buffer is allocated uninitialized and every
 /// byte is written by exactly one positioned read before `set_len`
 /// exposes it (on any error the Vec drops with len 0, so uninitialized
 /// bytes are never readable). Scoped `std::thread` (not rayon) keeps
@@ -818,12 +819,23 @@ fn read_range_parallel_transform(
     // both target platforms.
     let chunk = len_usize.div_ceil(n_threads).max(CHUNK_MIN).next_multiple_of(4096);
     let n_chunks = len_usize.div_ceil(chunk);
-    let base = buf.spare_capacity_mut().as_mut_ptr() as usize;
+    // Pointer wrapper carrying real provenance across the thread
+    // boundary (an integer round-trip would fail strict-provenance
+    // tooling like Miri).
+    #[derive(Clone, Copy)]
+    struct BasePtr(*mut u8);
+    unsafe impl Send for BasePtr {}
+    unsafe impl Sync for BasePtr {}
+    let base = BasePtr(buf.spare_capacity_mut().as_mut_ptr() as *mut u8);
     let next = std::sync::atomic::AtomicUsize::new(0);
     let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
     std::thread::scope(|s| {
         for _ in 0..n_threads.min(n_chunks) {
-            s.spawn(|| loop {
+            s.spawn(|| {
+                // Capture the wrapper whole (2021 field-precise capture
+                // would otherwise grab the raw pointer field directly).
+                let base = base;
+                loop {
                 let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 if i >= n_chunks {
                     break;
@@ -834,7 +846,7 @@ fn read_range_parallel_transform(
                 // allocation; each is written (never read) by exactly one
                 // thread via read_exact_at.
                 let chunk =
-                    unsafe { std::slice::from_raw_parts_mut((base + off) as *mut u8, this) };
+                    unsafe { std::slice::from_raw_parts_mut(base.0.add(off), this) };
                 let res = match transform {
                     None => read_exact_at(f, chunk, range_off + off as u64),
                     Some(t) => {
@@ -857,6 +869,7 @@ fn read_range_parallel_transform(
                 if let Err(e) = res {
                     *err.lock().expect("err lock") = Some(e);
                     break;
+                }
                 }
             });
         }
@@ -887,7 +900,9 @@ fn try_load_v6_fast(
     magic: &[u8; 4],
 ) -> io::Result<Option<(CoreLoad, Vec<u8>)>> {
     const PREFIX_MAX: usize = 4096;
-    let prefix_len = (cap as usize).min(PREFIX_MAX);
+    let cap_usize = usize::try_from(cap)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "file too large for this platform"))?;
+    let prefix_len = cap_usize.min(PREFIX_MAX);
     if prefix_len < 5 {
         return Ok(None);
     }
@@ -910,7 +925,10 @@ fn try_load_v6_fast(
         .ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::UnexpectedEof,
-                format!("truncated file: expected {blocked_bytes} code bytes"),
+                format!(
+                    "truncated file: expected {blocked_bytes} bytes, got {}",
+                    cap.saturating_sub(codes_start)
+                ),
             )
         })?;
     // Native transform fused into the read at L2 granularity; identity
@@ -921,7 +939,7 @@ fn try_load_v6_fast(
     let transform: Option<fn(&mut [u8])> = None;
     let codes = read_range_parallel_transform(f, codes_start, blocked_bytes as u64, transform)?;
     // Tail: scales + TQ+ (+ id table for .tvim) — small.
-    let tail_len = (cap - codes_end) as usize;
+    let tail_len = cap_usize - codes_end as usize;
     let mut tail = vec![0u8; tail_len];
     read_exact_at(f, &mut tail, codes_end)?;
     let mut tr: &[u8] = &tail[..];

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -864,6 +864,48 @@ impl TurboQuantIndex {
             // reconstruction. Validation: the io layer checked the
             // payload length against the header geometry; scales length
             // is checked here as from_parts would.
+            io::CodePayload::BlockedNative { codes, boundaries, centroids } => {
+                if scales.len() != n_vectors {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "scales length {} does not match n_vectors {n_vectors}",
+                            scales.len()
+                        ),
+                    ));
+                }
+                let blocked = OnceLock::new();
+                let boundaries_lock = OnceLock::new();
+                let centroids_lock = OnceLock::new();
+                if let Some(d) = dim_opt {
+                    if n_vectors > 0 {
+                        let (n_blocks, _, _) = pack::blocked_geometry(n_vectors, bit_width, d);
+                        // Already the native kernel layout — no transform.
+                        let _ = blocked.set(BlockedCache { data: codes, n_blocks });
+                        let _ = boundaries_lock.set(boundaries);
+                        let _ = centroids_lock.set(centroids);
+                    }
+                }
+                let packed_codes = if n_vectors == 0 {
+                    OnceLock::from(Vec::new())
+                } else {
+                    OnceLock::new()
+                };
+                Ok(Self {
+                    dim: dim_opt,
+                    bit_width,
+                    n_vectors,
+                    packed_codes,
+                    scales,
+                    tqplus_shift,
+                    tqplus_scale,
+                    encode_scratch: Vec::new(),
+                    rotation: OnceLock::new(),
+                    boundaries: boundaries_lock,
+                    centroids: centroids_lock,
+                    blocked,
+                })
+            }
             io::CodePayload::BlockedSeq { codes: seq, boundaries, centroids } => {
                 if scales.len() != n_vectors {
                     return Err(std::io::Error::new(

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -267,6 +267,63 @@ pub(crate) fn seq_into_native(seq: Vec<u8>) -> Vec<u8> {
     }
 }
 
+/// Extract a chunk into the *native* search layout in one pass: on x86
+/// this fuses the perm0 nibble interleave into the copy (out-of-place,
+/// from the read buffer into the fresh destination), elsewhere the
+/// native layout IS the stored layout and this is a plain copy. Chunk
+/// lengths must be equal multiples of `BLOCK`.
+pub(crate) fn extract_native_chunk(src: &[u8], dst: &mut [u8]) {
+    debug_assert_eq!(src.len(), dst.len());
+    debug_assert_eq!(src.len() % BLOCK, 0);
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("ssse3") {
+            // SAFETY: gated on runtime SSSE3 detection.
+            unsafe { interleave_chunk_ssse3_out(src, dst) };
+        } else {
+            for (s, o) in src.chunks_exact(BLOCK).zip(dst.chunks_exact_mut(BLOCK)) {
+                for j in 0..16 {
+                    let ba = s[PERM0[j]];
+                    let bb = s[PERM0[j] + 16];
+                    o[j] = (ba >> 4) | (bb & 0xF0);
+                    o[16 + j] = (ba & 0x0F) | ((bb & 0x0F) << 4);
+                }
+            }
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    dst.copy_from_slice(src);
+}
+
+/// SAFETY: caller ensures SSSE3; lens are equal multiples of BLOCK.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "ssse3")]
+unsafe fn interleave_chunk_ssse3_out(seq: &[u8], out: &mut [u8]) {
+    use std::arch::x86_64::*;
+    let perm: [u8; 16] = std::array::from_fn(|j| PERM0[j] as u8);
+    let permv = _mm_loadu_si128(perm.as_ptr() as *const __m128i);
+    let lo_mask = _mm_set1_epi8(0x0Fu8 as i8);
+    let hi_mask = _mm_set1_epi8(0xF0u8 as i8);
+    let n = seq.len() / BLOCK;
+    for i in 0..n {
+        let s = seq.as_ptr().add(i * BLOCK);
+        if (i + 128) * BLOCK < seq.len() {
+            _mm_prefetch(seq.as_ptr().add((i + 128) * BLOCK) as *const i8, _MM_HINT_T0);
+        }
+        let o = out.as_mut_ptr().add(i * BLOCK);
+        let lo16 = _mm_loadu_si128(s as *const __m128i);
+        let hi16 = _mm_loadu_si128(s.add(16) as *const __m128i);
+        let a = _mm_shuffle_epi8(lo16, permv);
+        let b = _mm_shuffle_epi8(hi16, permv);
+        let a_hi = _mm_and_si128(_mm_srli_epi16(a, 4), lo_mask);
+        let out_hi = _mm_or_si128(a_hi, _mm_and_si128(b, hi_mask));
+        let b_lo4 = _mm_and_si128(b, lo_mask);
+        let out_lo = _mm_or_si128(_mm_and_si128(a, lo_mask), _mm_slli_epi16(b_lo4, 4));
+        _mm_storeu_si128(o as *mut __m128i, out_hi);
+        _mm_storeu_si128(o.add(16) as *mut __m128i, out_lo);
+    }
+}
+
 /// Native search layout → sequential blocked layout — [`seq_into_native`]'s
 /// inverse. Lets the write path serialize a warm in-memory blocked cache
 /// without a full O(n·dim) repack from bit-planes.

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -365,7 +365,7 @@ fn interleave_blocks_x86_in_place(buf: &mut [u8]) {
 }
 
 #[cfg(target_arch = "x86_64")]
-fn interleave_chunk_x86(buf: &mut [u8]) {
+pub(crate) fn interleave_chunk_x86(buf: &mut [u8]) {
     if is_x86_feature_detected!("ssse3") {
         // SAFETY: gated on runtime SSSE3 detection.
         unsafe { interleave_chunk_ssse3(buf) }

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -267,63 +267,6 @@ pub(crate) fn seq_into_native(seq: Vec<u8>) -> Vec<u8> {
     }
 }
 
-/// Extract a chunk into the *native* search layout in one pass: on x86
-/// this fuses the perm0 nibble interleave into the copy (out-of-place,
-/// from the read buffer into the fresh destination), elsewhere the
-/// native layout IS the stored layout and this is a plain copy. Chunk
-/// lengths must be equal multiples of `BLOCK`.
-pub(crate) fn extract_native_chunk(src: &[u8], dst: &mut [u8]) {
-    debug_assert_eq!(src.len(), dst.len());
-    debug_assert_eq!(src.len() % BLOCK, 0);
-    #[cfg(target_arch = "x86_64")]
-    {
-        if is_x86_feature_detected!("ssse3") {
-            // SAFETY: gated on runtime SSSE3 detection.
-            unsafe { interleave_chunk_ssse3_out(src, dst) };
-        } else {
-            for (s, o) in src.chunks_exact(BLOCK).zip(dst.chunks_exact_mut(BLOCK)) {
-                for j in 0..16 {
-                    let ba = s[PERM0[j]];
-                    let bb = s[PERM0[j] + 16];
-                    o[j] = (ba >> 4) | (bb & 0xF0);
-                    o[16 + j] = (ba & 0x0F) | ((bb & 0x0F) << 4);
-                }
-            }
-        }
-    }
-    #[cfg(not(target_arch = "x86_64"))]
-    dst.copy_from_slice(src);
-}
-
-/// SAFETY: caller ensures SSSE3; lens are equal multiples of BLOCK.
-#[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "ssse3")]
-unsafe fn interleave_chunk_ssse3_out(seq: &[u8], out: &mut [u8]) {
-    use std::arch::x86_64::*;
-    let perm: [u8; 16] = std::array::from_fn(|j| PERM0[j] as u8);
-    let permv = _mm_loadu_si128(perm.as_ptr() as *const __m128i);
-    let lo_mask = _mm_set1_epi8(0x0Fu8 as i8);
-    let hi_mask = _mm_set1_epi8(0xF0u8 as i8);
-    let n = seq.len() / BLOCK;
-    for i in 0..n {
-        let s = seq.as_ptr().add(i * BLOCK);
-        if (i + 128) * BLOCK < seq.len() {
-            _mm_prefetch(seq.as_ptr().add((i + 128) * BLOCK) as *const i8, _MM_HINT_T0);
-        }
-        let o = out.as_mut_ptr().add(i * BLOCK);
-        let lo16 = _mm_loadu_si128(s as *const __m128i);
-        let hi16 = _mm_loadu_si128(s.add(16) as *const __m128i);
-        let a = _mm_shuffle_epi8(lo16, permv);
-        let b = _mm_shuffle_epi8(hi16, permv);
-        let a_hi = _mm_and_si128(_mm_srli_epi16(a, 4), lo_mask);
-        let out_hi = _mm_or_si128(a_hi, _mm_and_si128(b, hi_mask));
-        let b_lo4 = _mm_and_si128(b, lo_mask);
-        let out_lo = _mm_or_si128(_mm_and_si128(a, lo_mask), _mm_slli_epi16(b_lo4, 4));
-        _mm_storeu_si128(o as *mut __m128i, out_hi);
-        _mm_storeu_si128(o.add(16) as *mut __m128i, out_lo);
-    }
-}
-
 /// Native search layout → sequential blocked layout — [`seq_into_native`]'s
 /// inverse. Lets the write path serialize a warm in-memory blocked cache
 /// without a full O(n·dim) repack from bit-planes.

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -13,9 +13,37 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use rayon::prelude::*;
 
 /// Block-count threshold above which a single unmasked query scans in
-/// parallel (x86). Bindings use this to decide when an nq=1 search must
-/// run inside the fork-safe pool instead of inline.
+/// parallel. Bindings use [`single_query_parallelizes`] (which wraps
+/// this) to decide when an nq=1 search must run inside the fork-safe
+/// pool instead of inline.
 pub const SINGLE_QUERY_PARALLEL_MIN_BLOCKS: usize = 256;
+
+/// Whether an nq=1 unmasked search over `n_vectors` takes the
+/// block-parallel path. The single source of truth for the gate — the
+/// core dispatch and the Python bindings' pool routing must agree, or an
+/// inline call could split parallel work outside the fork-safe pool
+/// (the #147 invariant).
+pub fn single_query_parallelizes(n_vectors: usize) -> bool {
+    n_vectors.div_ceil(crate::BLOCK) >= SINGLE_QUERY_PARALLEL_MIN_BLOCKS
+}
+
+/// Rescan a full top-k heap for its minimum. Ties on score resolve to
+/// the LARGEST index — the eviction victim among tied minima — so that
+/// sequential scans keep the lowest-index members of any tied cohort,
+/// matching the block-parallel paths' index-ascending merges. This is
+/// what makes top-k results identical across the batch, scalar, and
+/// parallel single-query paths even for bitwise-tied scores (duplicate
+/// vectors).
+#[inline(always)]
+fn rescan_min(hs: &[f32], hi: &[u64], k: usize) -> (f32, usize) {
+    let mut mi = 0usize;
+    for h in 1..k {
+        if hs[h] < hs[mi] || (hs[h] == hs[mi] && hi[h] > hi[mi]) {
+            mi = h;
+        }
+    }
+    (hs[mi], mi)
+}
 use crate::rotation::Rotation;
 use crate::{BLOCK, FLUSH_EVERY};
 
@@ -336,18 +364,16 @@ unsafe fn search_multi_query_avx2(
                         hi[*sz] = (base_vec + lane) as u64;
                         *sz += 1;
                         if *sz == k {
-                            *hmin = hs[0]; *hmi = 0;
-                            for h in 1..k {
-                                if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }
-                            }
+                            let (m, mi) = rescan_min(hs, hi, k);
+                            *hmin = m;
+                            *hmi = mi;
                         }
                     } else if score > *hmin {
                         hs[*hmi] = score;
                         hi[*hmi] = (base_vec + lane) as u64;
-                        *hmin = hs[0]; *hmi = 0;
-                        for h in 1..k {
-                            if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }
-                        }
+                        let (m, mi) = rescan_min(hs, hi, k);
+                        *hmin = m;
+                        *hmi = mi;
                     }
                 }
             } else {
@@ -368,11 +394,9 @@ unsafe fn search_multi_query_avx2(
                         if score > *hmin {
                             hs[*hmi] = score;
                             hi[*hmi] = (base_vec + lane) as u64;
-                            *hmi = 0;
-                            for h in 1..k {
-                                if hs[h] < hs[*hmi] { *hmi = h; }
-                            }
-                            *hmin = hs[*hmi];
+                            let (m, mi) = rescan_min(hs, hi, k);
+                            *hmin = m;
+                            *hmi = mi;
                         }
                     }
                 }
@@ -804,11 +828,9 @@ unsafe fn avx2_post_flush_heap_update(
                 if score > *hmin {
                     hs[*hmi] = score;
                     hi[*hmi] = (base_vec + lane) as u64;
-                    *hmi = 0;
-                    for h in 1..k {
-                        if hs[h] < hs[*hmi] { *hmi = h; }
-                    }
-                    *hmin = hs[*hmi];
+                    let (m, mi) = rescan_min(hs, hi, k);
+                    *hmin = m;
+                    *hmi = mi;
                 }
             }
         }
@@ -842,18 +864,16 @@ unsafe fn avx2_post_flush_heap_update(
                 hi[*sz] = (base_vec + lane) as u64;
                 *sz += 1;
                 if *sz == k {
-                    *hmin = hs[0]; *hmi = 0;
-                    for h in 1..k {
-                        if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }
-                    }
+                    let (m, mi) = rescan_min(hs, hi, k);
+                    *hmin = m;
+                    *hmi = mi;
                 }
             } else if score > *hmin {
                 hs[*hmi] = score;
                 hi[*hmi] = (base_vec + lane) as u64;
-                *hmin = hs[0]; *hmi = 0;
-                for h in 1..k {
-                    if hs[h] < *hmin { *hmin = hs[h]; *hmi = h; }
-                }
+                let (m, mi) = rescan_min(hs, hi, k);
+                *hmin = m;
+                *hmi = mi;
             }
         }
     } else {
@@ -874,11 +894,9 @@ unsafe fn avx2_post_flush_heap_update(
                 if score > *hmin {
                     hs[*hmi] = score;
                     hi[*hmi] = (base_vec + lane) as u64;
-                    *hmi = 0;
-                    for h in 1..k {
-                        if hs[h] < hs[*hmi] { *hmi = h; }
-                    }
-                    *hmin = hs[*hmi];
+                    let (m, mi) = rescan_min(hs, hi, k);
+                    *hmin = m;
+                    *hmi = mi;
                 }
             }
         }
@@ -1231,26 +1249,16 @@ fn score_query_into_heap(
                 heap_i[*heap_sz] = vi as u64;
                 *heap_sz += 1;
                 if *heap_sz == k {
-                    *heap_min = heap_s[0];
-                    *heap_mi = 0;
-                    for h in 1..k {
-                        if heap_s[h] < *heap_min {
-                            *heap_min = heap_s[h];
-                            *heap_mi = h;
-                        }
-                    }
+                    let (m, mi) = rescan_min(heap_s, heap_i, k);
+                    *heap_min = m;
+                    *heap_mi = mi;
                 }
             } else if score > *heap_min {
                 heap_s[*heap_mi] = score;
                 heap_i[*heap_mi] = vi as u64;
-                *heap_min = heap_s[0];
-                *heap_mi = 0;
-                for h in 1..k {
-                    if heap_s[h] < *heap_min {
-                        *heap_min = heap_s[h];
-                        *heap_mi = h;
-                    }
-                }
+                let (m, mi) = rescan_min(heap_s, heap_i, k);
+                *heap_min = m;
+                *heap_mi = mi;
             }
         }
     }
@@ -1422,24 +1430,26 @@ pub(crate) fn search(
                             heap.push((s, (base + lane) as u64));
                             if heap.len() == k {
                                 heap_mi = 0;
-                                heap_min = heap[0].0;
-                                for (h, &(hs, _)) in heap.iter().enumerate().skip(1) {
-                                    if hs < heap_min {
-                                        heap_min = hs;
+                                for (h, &(hs, hix)) in heap.iter().enumerate().skip(1) {
+                                    if hs < heap[heap_mi].0
+                                        || (hs == heap[heap_mi].0 && hix > heap[heap_mi].1)
+                                    {
                                         heap_mi = h;
                                     }
                                 }
+                                heap_min = heap[heap_mi].0;
                             }
                         } else if s > heap_min {
                             heap[heap_mi] = (s, (base + lane) as u64);
                             heap_mi = 0;
-                            heap_min = heap[0].0;
-                            for (h, &(hs, _)) in heap.iter().enumerate().skip(1) {
-                                if hs < heap_min {
-                                    heap_min = hs;
+                            for (h, &(hs, hix)) in heap.iter().enumerate().skip(1) {
+                                if hs < heap[heap_mi].0
+                                    || (hs == heap[heap_mi].0 && hix > heap[heap_mi].1)
+                                {
                                     heap_mi = h;
                                 }
                             }
+                            heap_min = heap[heap_mi].0;
                         }
                     }
                 }
@@ -1569,32 +1579,22 @@ pub(crate) fn search(
                                 heap_i[heap_sz] = i as u64;
                                 heap_sz += 1;
                                 if heap_sz == k {
-                                    heap_min = heap_s[0];
-                                    heap_mi = 0;
-                                    for h in 1..k {
-                                        if heap_s[h] < heap_min {
-                                            heap_min = heap_s[h];
-                                            heap_mi = h;
-                                        }
-                                    }
+                                    let (m, mi) = rescan_min(&heap_s, &heap_i, k);
+                                    heap_min = m;
+                                    heap_mi = mi;
                                 }
                             } else if s > heap_min {
                                 heap_s[heap_mi] = s;
                                 heap_i[heap_mi] = i as u64;
-                                heap_min = heap_s[0];
-                                heap_mi = 0;
-                                for h in 1..k {
-                                    if heap_s[h] < heap_min {
-                                        heap_min = heap_s[h];
-                                        heap_mi = h;
-                                    }
-                                }
+                                let (m, mi) = rescan_min(&heap_s, &heap_i, k);
+                                heap_min = m;
+                                heap_mi = mi;
                             }
                         }
                         let mut pairs: Vec<(f32, u64)> = heap_s[..heap_sz].iter()
                             .zip(heap_i[..heap_sz].iter())
                             .map(|(&s, &i)| (s, i)).collect();
-                        pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+                        pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.1.cmp(&b.1)));
                         let s: Vec<f32> = pairs.iter().map(|p| p.0).collect();
                         let i: Vec<i64> = pairs.iter().map(|p| p.1 as i64).collect();
                         (s, i)
@@ -1623,7 +1623,6 @@ pub(crate) fn search(
         k: usize,
         use_avx512: bool,
     ) -> (Vec<f32>, Vec<i64>) {
-        const BLOCK: usize = 32;
         let n_threads = rayon::current_num_threads().max(1);
         // Whole blocks per range, at least 64 blocks (2k vectors) each.
         let blocks_per_range = (n_blocks.div_ceil(n_threads)).max(64);
@@ -1802,7 +1801,7 @@ pub(crate) fn search(
                     let mut pairs: Vec<(f32, u64)> = heap_scores[qo][..sz].iter()
                         .zip(heap_indices[qo][..sz].iter())
                         .map(|(&s, &i)| (s, i)).collect();
-                    pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+                    pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.1.cmp(&b.1)));
                     batch_results.push((
                         pairs.iter().map(|p| p.0).collect::<Vec<f32>>(),
                         pairs.iter().map(|p| p.1 as i64).collect::<Vec<i64>>(),
@@ -1846,7 +1845,7 @@ pub(crate) fn search(
                 );
                 let mut pairs: Vec<(f32, u64)> = heap_s[..heap_sz].iter()
                     .zip(heap_i[..heap_sz].iter()).map(|(&s, &i)| (s, i)).collect();
-                pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+                pairs.sort_unstable_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal).then_with(|| a.1.cmp(&b.1)));
                 (pairs.iter().map(|p| p.0).collect(), pairs.iter().map(|p| p.1 as i64).collect())
             })
             .collect();

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -1374,8 +1374,100 @@ pub(crate) fn search(
         .collect();
 
     // Platform-specific scoring + top-k
+    // Single-query fast path (aarch64) — mirror of the x86 version: one
+    // query on a large index partitions the block range across pool
+    // workers; each range scores blocks with the single-query NEON
+    // kernel straight into a local top-k (no full scores row), then
+    // ranges merge deterministically.
+    #[cfg(target_arch = "aarch64")]
+    fn search_single_query_block_parallel_neon(
+        blocked_codes: &[u8],
+        lut: &QueryNeonLut,
+        n_byte_groups: usize,
+        vec_scales: &[f32],
+        n_vectors: usize,
+        n_blocks: usize,
+        k: usize,
+    ) -> (Vec<f32>, Vec<i64>) {
+        let n_threads = rayon::current_num_threads().max(1);
+        let blocks_per_range = (n_blocks.div_ceil(n_threads)).max(64);
+        let ranges: Vec<usize> = (0..n_blocks).step_by(blocks_per_range).collect();
+        let block_bytes = n_byte_groups * BLOCK;
+        let mut candidates: Vec<(f32, u64)> = ranges
+            .into_par_iter()
+            .flat_map(|block_start| {
+                let range_blocks = blocks_per_range.min(n_blocks - block_start);
+                let vec_start = block_start * BLOCK;
+                let range_vecs = (range_blocks * BLOCK).min(n_vectors - vec_start);
+                let codes = &blocked_codes
+                    [block_start * block_bytes..(block_start + range_blocks) * block_bytes];
+                let scales_slice = &vec_scales[vec_start..vec_start + range_vecs];
+                let mut heap: Vec<(f32, u64)> = Vec::with_capacity(k);
+                let mut heap_min = f32::NEG_INFINITY;
+                let mut heap_mi = 0usize;
+                let mut out = [0.0f32; BLOCK];
+                for b in 0..range_blocks {
+                    let base = b * BLOCK;
+                    let end = (base + BLOCK).min(range_vecs);
+                    // SAFETY: NEON is baseline on aarch64; slices are
+                    // range-relative and consistent.
+                    unsafe {
+                        score_4bit_block_neon(
+                            codes, &lut.uint8_luts, b * block_bytes, n_byte_groups,
+                            lut.scale, lut.bias, scales_slice, base, range_vecs, &mut out,
+                        );
+                    }
+                    for (lane, &s) in out[..end - base].iter().enumerate() {
+                        if heap.len() < k {
+                            heap.push((s, (base + lane) as u64));
+                            if heap.len() == k {
+                                heap_mi = 0;
+                                heap_min = heap[0].0;
+                                for (h, &(hs, _)) in heap.iter().enumerate().skip(1) {
+                                    if hs < heap_min {
+                                        heap_min = hs;
+                                        heap_mi = h;
+                                    }
+                                }
+                            }
+                        } else if s > heap_min {
+                            heap[heap_mi] = (s, (base + lane) as u64);
+                            heap_mi = 0;
+                            heap_min = heap[0].0;
+                            for (h, &(hs, _)) in heap.iter().enumerate().skip(1) {
+                                if hs < heap_min {
+                                    heap_min = hs;
+                                    heap_mi = h;
+                                }
+                            }
+                        }
+                    }
+                }
+                heap.into_iter()
+                    .map(|(s, i)| (s, i + vec_start as u64))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        candidates.sort_unstable_by(|a, b| {
+            b.0.partial_cmp(&a.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        candidates.truncate(k);
+        (
+            candidates.iter().map(|p| p.0).collect(),
+            candidates.iter().map(|p| p.1 as i64).collect(),
+        )
+    }
+
     #[cfg(target_arch = "aarch64")]
     let results = {
+        if nq == 1 && mask.is_none() && n_blocks >= SINGLE_QUERY_PARALLEL_MIN_BLOCKS {
+            vec![search_single_query_block_parallel_neon(
+                blocked_codes, &query_luts[0], n_byte_groups, vec_scales,
+                n_vectors, n_blocks, k,
+            )]
+        } else {
         // ARM: 4-query fused scoring (shares code loads + nibble splits across queries)
         const QBS: usize = 4;
         let results: Vec<Vec<(Vec<f32>, Vec<i64>)>> = (0..nq)
@@ -1511,6 +1603,7 @@ pub(crate) fn search(
             })
             .collect();
         results.into_iter().flatten().collect::<Vec<_>>()
+        }
     };
 
     // Single-query fast path (x86): one query scanning a large index is

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -11,6 +11,11 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rayon::prelude::*;
+
+/// Block-count threshold above which a single unmasked query scans in
+/// parallel (x86). Bindings use this to decide when an nq=1 search must
+/// run inside the fork-safe pool instead of inline.
+pub const SINGLE_QUERY_PARALLEL_MIN_BLOCKS: usize = 256;
 use crate::rotation::Rotation;
 use crate::{BLOCK, FLUSH_EVERY};
 
@@ -1508,8 +1513,108 @@ pub(crate) fn search(
         results.into_iter().flatten().collect::<Vec<_>>()
     };
 
+    // Single-query fast path (x86): one query scanning a large index is
+    // memory-bandwidth-bound on one core, so partition the block range
+    // across rayon workers — each range runs the existing SIMD kernel on
+    // its sub-slices (kernels index relative to the slices they are
+    // given), producing a local top-k; ranges then merge. Masked
+    // searches keep the serial path (the bitmap is absolute-indexed).
+    #[cfg(target_arch = "x86_64")]
+    fn search_single_query_block_parallel(
+        blocked_codes: &[u8],
+        lut: &QueryNeonLut,
+        n_byte_groups: usize,
+        vec_scales: &[f32],
+        n_vectors: usize,
+        n_blocks: usize,
+        k: usize,
+        use_avx512: bool,
+    ) -> (Vec<f32>, Vec<i64>) {
+        const BLOCK: usize = 32;
+        let n_threads = rayon::current_num_threads().max(1);
+        // Whole blocks per range, at least 64 blocks (2k vectors) each.
+        let blocks_per_range = (n_blocks.div_ceil(n_threads)).max(64);
+        let ranges: Vec<usize> = (0..n_blocks).step_by(blocks_per_range).collect();
+        let block_bytes = n_byte_groups * BLOCK;
+        let mut candidates: Vec<(f32, u64)> = ranges
+            .into_par_iter()
+            .flat_map(|block_start| {
+                let range_blocks = blocks_per_range.min(n_blocks - block_start);
+                let vec_start = block_start * BLOCK;
+                let range_vecs = (range_blocks * BLOCK).min(n_vectors - vec_start);
+                let codes =
+                    &blocked_codes[block_start * block_bytes..(block_start + range_blocks) * block_bytes];
+                let scales_slice = &vec_scales[vec_start..vec_start + range_vecs];
+                let lut_refs = [lut.uint8_luts.as_slice(); 4];
+                let scale_vals = [lut.scale; 4];
+                let bias_vals = [lut.bias; 4];
+                let mut heap_scores = vec![vec![f32::NEG_INFINITY; k]];
+                let mut heap_indices = vec![vec![0u64; k]];
+                let mut heap_sizes = vec![0usize];
+                let mut heap_mins = vec![f32::NEG_INFINITY];
+                let mut heap_min_idxs = vec![0usize];
+                // SAFETY: feature presence checked by the caller once.
+                unsafe {
+                    if use_avx512 {
+                        search_multi_query_avx512bw(
+                            codes, &lut_refs, &scale_vals, &bias_vals,
+                            n_byte_groups, scales_slice, range_vecs,
+                            1, k, None,
+                            &mut heap_scores, &mut heap_indices,
+                            &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
+                        );
+                    } else {
+                        search_multi_query_avx2(
+                            codes, &lut_refs, &scale_vals, &bias_vals,
+                            n_byte_groups, scales_slice, range_vecs,
+                            1, k, None,
+                            &mut heap_scores, &mut heap_indices,
+                            &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
+                        );
+                    }
+                }
+                let sz = heap_sizes[0];
+                heap_scores[0][..sz]
+                    .iter()
+                    .zip(heap_indices[0][..sz].iter())
+                    .map(|(&s, &i)| (s, i + vec_start as u64))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+        // Deterministic merge: score desc, index asc on ties.
+        candidates.sort_unstable_by(|a, b| {
+            b.0.partial_cmp(&a.0)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.1.cmp(&b.1))
+        });
+        candidates.truncate(k);
+        (
+            candidates.iter().map(|p| p.0).collect(),
+            candidates.iter().map(|p| p.1 as i64).collect(),
+        )
+    }
+
     #[cfg(target_arch = "x86_64")]
     let results = {
+        #[cfg(test)]
+        let force_scalar_single =
+            FORCE_SCALAR_FALLBACK.load(std::sync::atomic::Ordering::Relaxed);
+        #[cfg(not(test))]
+        let force_scalar_single = false;
+        let use_avx512 =
+            is_x86_feature_detected!("avx512bw") && is_x86_feature_detected!("avx512f");
+        let simd_ok = use_avx512 || is_x86_feature_detected!("avx2");
+        if nq == 1
+            && mask.is_none()
+            && n_blocks >= SINGLE_QUERY_PARALLEL_MIN_BLOCKS
+            && simd_ok
+            && !force_scalar_single
+        {
+            vec![search_single_query_block_parallel(
+                blocked_codes, &query_luts[0], n_byte_groups, vec_scales,
+                n_vectors, n_blocks, k, use_avx512,
+            )]
+        } else {
         const NQ_BATCH: usize = 4;
         let results: Vec<(Vec<f32>, Vec<i64>)> = (0..nq)
             .step_by(NQ_BATCH)
@@ -1614,6 +1719,7 @@ pub(crate) fn search(
             })
             .collect();
         results
+        }
     };
 
     #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]

--- a/turbovec/tests/concurrent_search.rs
+++ b/turbovec/tests/concurrent_search.rs
@@ -330,3 +330,47 @@ fn concurrent_prepare_races_with_search_safely() {
         }
     }
 }
+
+/// Exact score ties (duplicate vectors) must produce identical top-k
+/// members AND ordering on every search path. The construction mirrors
+/// the adversarial-review repro: the duplicated pair is the *tied
+/// minimum* of the top-k while a strictly better vector forces a heap
+/// eviction among the tied minima — the case where the batch heap and
+/// the parallel merge previously chose different survivors.
+#[test]
+fn tied_scores_agree_across_search_paths() {
+    let dim = 64usize;
+    let n = 9000usize; // above the block-parallel threshold
+    let mut v = vec![0f32; n * dim];
+    let mut s = 7u64;
+    for x in v.iter_mut() {
+        s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        *x = ((s >> 40) as f32) / (1u32 << 24) as f32 - 0.5;
+    }
+    // Query direction u; duplicates 0 and 5000 = u (tied, good score);
+    // 8500 = 3u (same direction, larger pre-normalization scale => higher
+    // score), so with k = 2 the heap must evict one tied duplicate.
+    let u: Vec<f32> = (0..dim).map(|i| ((i * 37 + 11) % 97) as f32 / 97.0 + 0.1).collect();
+    for &slot in &[0usize, 5000] {
+        v[slot * dim..(slot + 1) * dim].copy_from_slice(&u);
+    }
+    let tripled: Vec<f32> = u.iter().map(|x| 3.0 * x).collect();
+    v[8500 * dim..8501 * dim].copy_from_slice(&tripled);
+
+    let mut idx = turbovec::TurboQuantIndex::new(dim, 4).unwrap();
+    idx.add(&v);
+
+    let q = u.clone();
+    for k in [2usize, 3, 5, 10] {
+        let single = idx.search(&q, k); // nq=1: block-parallel path
+        let mut qq = q.clone();
+        qq.extend_from_slice(&q);
+        let batch = idx.search(&qq, k); // nq=2: batch path
+        assert_eq!(
+            single.indices,
+            batch.indices[..single.indices.len()],
+            "k={k}: tied-score members/order diverge between nq=1 and batch paths",
+        );
+        assert_eq!(single.scores, batch.scores[..single.scores.len()], "k={k} scores");
+    }
+}

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -22,6 +22,29 @@ use std::time::{Duration, Instant};
 use turbovec::io::{load, load_id_map, write, write_id_map, CodePayload};
 
 /// v6 payload length: sequential blocked layout, padded to 32-vector blocks.
+
+/// The native-layout bytes the fast-path loader returns for stored
+/// sequential-blocked codes: the x86 perm0 nibble interleave (mirrored
+/// from pack.rs — stable, format-documented math), identity elsewhere.
+fn expected_native(seq: &[u8]) -> Vec<u8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        const PERM0: [usize; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15];
+        let mut out = vec![0u8; seq.len()];
+        for (s, o) in seq.chunks_exact(32).zip(out.chunks_exact_mut(32)) {
+            for j in 0..16 {
+                let ba = s[PERM0[j]];
+                let bb = s[PERM0[j] + 16];
+                o[j] = (ba >> 4) | (bb & 0xF0);
+                o[16 + j] = (ba & 0x0F) | ((bb & 0x0F) << 4);
+            }
+        }
+        out
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    seq.to_vec()
+}
+
 fn test_codebook(bit_width: usize) -> (Vec<f32>, Vec<f32>) {
     // Strictly-increasing boundaries in (-1, 1) — the loader validates
     // monotonicity; centroids only need to be finite with |v| <= 1.
@@ -90,8 +113,8 @@ fn tv_panicking_write_leaves_previous_file_intact() {
     assert_eq!((bw, d, n), (4, 32, 2));
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(4).0,
             centroids: test_codebook(4).1,
         }
@@ -121,8 +144,8 @@ fn tvim_panicking_write_leaves_previous_file_intact() {
     assert_eq!((bw, d, n), (2, 16, 2));
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(2).0,
             centroids: test_codebook(2).1,
         }
@@ -148,8 +171,8 @@ fn tv_successful_overwrite_leaves_no_temp_files() {
     assert_eq!(n, 3);
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(4).0,
             centroids: test_codebook(4).1,
         }

--- a/turbovec/tests/io_versioning.rs
+++ b/turbovec/tests/io_versioning.rs
@@ -17,6 +17,29 @@ use turbovec::io::{load, load_id_map, write, write_id_map, CodePayload};
 /// v6 payload length: the sequential blocked layout is padded to whole
 /// 32-vector blocks — (ceil(n/32) * 32) lanes × (dim / codes_per_byte)
 /// byte-groups.
+
+/// The native-layout bytes the fast-path loader returns for stored
+/// sequential-blocked codes: the x86 perm0 nibble interleave (mirrored
+/// from pack.rs — stable, format-documented math), identity elsewhere.
+fn expected_native(seq: &[u8]) -> Vec<u8> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        const PERM0: [usize; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7, 15];
+        let mut out = vec![0u8; seq.len()];
+        for (s, o) in seq.chunks_exact(32).zip(out.chunks_exact_mut(32)) {
+            for j in 0..16 {
+                let ba = s[PERM0[j]];
+                let bb = s[PERM0[j] + 16];
+                o[j] = (ba >> 4) | (bb & 0xF0);
+                o[16 + j] = (ba & 0x0F) | ((bb & 0x0F) << 4);
+            }
+        }
+        out
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    seq.to_vec()
+}
+
 fn test_codebook(bit_width: usize) -> (Vec<f32>, Vec<f32>) {
     // Strictly-increasing boundaries in (-1, 1) — the loader validates
     // monotonicity; centroids only need to be finite with |v| <= 1.
@@ -65,8 +88,8 @@ fn tv_round_trip_current_format() {
     assert_eq!(n, n_vectors);
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(bit_width).0,
             centroids: test_codebook(bit_width).1,
         }
@@ -97,8 +120,8 @@ fn tv_round_trip_with_tqplus_calibration() {
     assert_eq!(n, n_vectors);
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(bit_width).0,
             centroids: test_codebook(bit_width).1,
         }
@@ -153,8 +176,8 @@ fn tvim_round_trip_current_format() {
     assert_eq!(n, n_vectors);
     assert_eq!(
         p,
-        CodePayload::BlockedSeq {
-            codes: packed.clone(),
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
             boundaries: test_codebook(bit_width).0,
             centroids: test_codebook(bit_width).1,
         }


### PR DESCRIPTION
## Summary

A measured reverse hill-climb of cold-load time (persisted `.tvim` → first search answered), scored by the worse of ARM (M3 Max) and x86 (Sapphire Rapids). **41 hypotheses tested, 10 confirmed wins** — each its own commit, each confirmed by same-session A/B (and A/B/A/B for marginal calls) on both architectures, with a full hypothesis log (including all 31 failures and their measurements) developed alongside.

**Result** (200k × dim 768 × 4-bit, 79.2 MB, warm cache, median of 21):

| | before | after | |
|---|---|---|---|
| x86 (Sapphire Rapids VM) | 48.2 ms | **11.6 ms** | 4.1× |
| ARM (M3 Max) | 14.8 ms | **3.8 ms** | 3.8× |

**vs FAISS**, official benchmark methodology (real openai-1536, precision-matched `m_pq = (bits·dim)/4`, single-thread FAISS, ~155 MB files both): turbovec **4.1× faster on ARM** (6.0 vs 24.5 ms) and **2.7× faster on x86** (22.3 vs 59.9 ms) against `IndexPQFastScan` — the loop converted x86 parity into that lead.

## The wins (one commit each)

- **H2** — cap-gated exact preallocation in the section reader (cap = real file length; the never-trust-declared-sizes posture is unchanged) kills `read_to_end`'s growth-doubling copies.
- **H5 → H15 → H18 → H19** — the read pipeline: parallel positioned reads (scoped `std::thread`, outside the fork-safety pool machinery) evolved into **direct-to-destination section reads**: the v6 format's fixed header offset lets the codes section pread straight into its exact final buffer — no intermediate whole-file buffer, no extraction copy — with one even chunk per thread. Key diagnosis en route: what looked like "parallel reads don't help" was actually **page-fault-bound single-threaded copying** of fresh allocations (~3.5 GB/s); spreading fault+copy across threads unlocked everything.
- **H16 → H21** — the x86 nibble-interleave fused first into the extraction pass (new `CodePayload::BlockedNative`), then into the read itself at **L2-sized sub-chunks**, transforming each 256 KB while its lines are resident. Non-x86 stores are already kernel-native (v6's arch-neutral layout), so ARM's path is a straight read.
- **H6 + H8** — block-parallel single-query search on both architectures: nq=1 on a large index partitions the block range across pool workers with per-range top-k and a deterministic merge (verified bit-identical to the batch path). Bindings route large-index nq=1 through the fork-safe pool — running the new parallel path inline would inject into the global sentinel registry (the #147 invariant); the exported `SINGLE_QUERY_PARALLEL_MIN_BLOCKS` keeps core and bindings agreed. x86 first search 9.7 → 2.4 ms; ARM 2.4 → 0.9 ms.
- **H7** — lazy id→slot map: cold start never consults it; load-time duplicate-id validation is kept via a sort of the id table.

## Termination + walls

The loop stopped per protocol after 20 consecutive non-improving hypotheses (H22–H41). The terminal streak established measured hardware walls: the codes read+transform runs at the VM's parallel-pread bandwidth, and the single-query scan at ~34 GB/s aggregate memory bandwidth (probe-verified) — NT-store, prefetch, chunk-size, thread-count, scheduling, and overlap variants all bounced, each logged with its refutation.

## Correctness (never traded)

- Full Rust suites green on **both architectures** at the terminal head; fork-safety suite 15/15 on Linux x86 (the guard that caught two real bugs in #271 also polices the new pool routing here); Python 634 passed (1 known local-env llama-index quirk, fails identically on main).
- All load-side validation preserved: header caps, checked arithmetic, codebook monotonicity, scale/TQ+ value checks, duplicate-id rejection, truncation errors — the fast path reuses the streamed validators and falls back to the generic reader for v5/malformed input, keeping canonical error messages.
- Search parity: the parallel single-query path verified bit-identical to the batch path across random queries; round-trip byte-stability tests unchanged and green. During development the existing `concurrent_search` round-trip test caught a real offset bug in a candidate before it ever reached a benchmark.

## Notes for review

- New public surface: `search::SINGLE_QUERY_PARALLEL_MIN_BLOCKS` and the `CodePayload::BlockedNative` variant (io-level; the file format itself is unchanged — still v6, byte-identical output).
- History includes two wip+revert pairs (H4, H9) retained deliberately: their measurements are cited by later winning commits.
- The full hypothesis log (41 rows, baselines, probes, FAISS comparisons) lives in `scratch/coldload_log.md` locally; happy to attach it to the PR or trim it into `benchmarks/` docs if wanted — left out of the diff per the no-bundling convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)