### PR TITLE
Hill-climb x86 insertion; pin the norm's reduction order; persistence benches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,21 @@ jobs:
         with:
           persist-credentials: false
 
+      # Require the AVX2 kernels to actually execute rather than be
+      # skipped. The identity tests check every SIMD path the host can
+      # run and silently skip the rest, so without this a runner that
+      # lacks a feature exercises nothing and still reports green — the
+      # absence of coverage is invisible. Every GitHub-hosted x86 runner
+      # has AVX2, so this is free; on macos-14 (arm64) the gate compiles
+      # to a no-op.
+      #
+      # AVX-512 is deliberately NOT listed: GitHub-hosted runners are not
+      # guaranteed to have it, so requiring it here would fail honest
+      # builds. Those kernels stay single-machine-verified until a
+      # designated runner or an Intel SDE leg covers them.
       - name: turbovec test suite
+        env:
+          TURBOVEC_REQUIRE_SIMD: avx2
         run: cargo test -p turbovec --release --locked
 
       # Standalone cargo project that path-deps turbovec — exercises the
@@ -138,7 +152,9 @@ jobs:
             echo "::error::expected $expected fingerprints, found $found"
             exit 1
           fi
-          # Normalize line endings — the Windows leg writes CRLF.
+          # Strip any CR before comparing. Rust's `println!` emits LF on
+          # every platform, so this is belt-and-braces against an
+          # artifact round-trip introducing them, not a Windows fix.
           for f in $files; do tr -d '\r' < "$f" > "$f.norm"; done
           distinct=$(md5sum $(for f in $files; do echo "$f.norm"; done) \
                      | awk '{print $1}' | sort -u | wc -l)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,57 @@ jobs:
       - name: Downstream consumer smoke test
         run: cargo run --release --locked --manifest-path examples/downstream-smoke/Cargo.toml
 
-  # Cross-OS encode fingerprint (#259). The v5 rotation is deterministic
-  # by construction and the per-vector norm now has a frozen reduction
-  # order, but the Lloyd-Max codebook still goes through `statrs` Beta
-  # cdf/pdf — transcendentals, the same cross-libm class as #206's second
-  # finding — and that can only be checked by comparing bytes produced on
-  # different platforms. This leg is that check.
+  # The declared MSRV has been wrong twice (1.70 -> 1.83 -> 1.89, the
+  # latter because the AVX-512 search kernel needs intrinsics stabilized
+  # in 1.89 while the manifest still said 1.83). Both times it was found
+  # by hand. This leg reads `rust-version` straight out of the manifest
+  # and builds with exactly that toolchain, so the number cannot drift
+  # away from reality again without CI saying so.
+  msrv:
+    name: MSRV (declared rust-version)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Read declared MSRV
+        id: msrv
+        shell: bash
+        run: |
+          set -euo pipefail
+          v=$(grep -m1 '^rust-version' turbovec/Cargo.toml | cut -d'"' -f2)
+          py=$(grep -m1 '^rust-version' turbovec-python/Cargo.toml | cut -d'"' -f2)
+          if [ "$v" != "$py" ]; then
+            echo "::error::turbovec declares MSRV $v but turbovec-python declares $py"
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Declared MSRV: $v"
+
+      - name: Install the declared toolchain
+        run: rustup toolchain install ${{ steps.msrv.outputs.version }} --profile minimal
+
+      - name: Build both packages on it
+        run: |
+          cargo +${{ steps.msrv.outputs.version }} check -p turbovec --locked --all-targets
+          cargo +${{ steps.msrv.outputs.version }} check -p turbovec-python --locked
+
+  # Cross-OS encode fingerprint (#259). The rotation is deterministic by
+  # construction, the per-vector norm has a frozen reduction order, and
+  # the codebook's boundaries are derived from its f32 centroids — but
+  # the centroids themselves still come out of `statrs` Beta cdf/pdf,
+  # whose `ln`/`exp` differ between libms. The f32 cast has ~5 orders of
+  # magnitude of margin over any observed difference, which is strong
+  # evidence and not a proof. This leg is what turns it into a check.
   #
   # Each OS runs `examples/encode_hash` (deterministic LCG input, six
   # (dim, bit_width) cells) and uploads its output; the compare job below
   # fails unless every OS produced the same lines. The per-stage split —
-  # codebook / calibration / codes / scales / file — means a divergence
-  # names the stage that drifted instead of just "the bytes differ".
+  # boundaries / centroids / calibration / codes / scales / file — means
+  # a divergence names the stage that drifted instead of just "the bytes
+  # differ". That split is what localized the original failure to the
+  # boundary midpoints while everything downstream still agreed.
   encode-fingerprint:
     name: Encode fingerprint (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -88,6 +127,17 @@ jobs:
           set -euo pipefail
           files=$(find fingerprints -name 'fingerprint-*.txt' | sort)
           echo "Comparing:"; echo "$files"
+          # A comparison is only meaningful if every leg actually reported.
+          # Without this, an artifact-name or path drift that leaves two
+          # files instead of three still "agrees" — the check would rot
+          # into a two-way comparison silently. Keep in sync with the
+          # matrix above.
+          expected=3
+          found=$(printf '%s\n' "$files" | grep -c . || true)
+          if [ "$found" -ne "$expected" ]; then
+            echo "::error::expected $expected fingerprints, found $found"
+            exit 1
+          fi
           # Normalize line endings — the Windows leg writes CRLF.
           for f in $files; do tr -d '\r' < "$f" > "$f.norm"; done
           distinct=$(md5sum $(for f in $files; do echo "$f.norm"; done) \
@@ -98,9 +148,15 @@ jobs:
             for f in $files; do echo "== $f"; cat "$f.norm"; done
             echo
             echo "The differing column names the stage that drifted."
-            echo "A 'codebook' difference is the known-open half of #259:"
-            echo "the Lloyd-Max codebook is computed from statrs Beta"
-            echo "cdf/pdf, so the fix is to precompute and pin it."
+            echo
+            echo "boundaries/centroids: the Lloyd-Max codebook is computed"
+            echo "  at runtime from statrs Beta cdf/pdf, so it is the stage"
+            echo "  most exposed to a libm difference. Boundaries are"
+            echo "  derived from the f32 centroids precisely so this cannot"
+            echo "  happen (#259); a regression there is the first suspect."
+            echo "codes/scales/calibration: a divergence here means an"
+            echo "  encode kernel is not reproducing the scalar reference"
+            echo "  on some target - check the per-path identity tests."
             exit 1
           fi
           echo "All platforms agree:"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,75 @@ jobs:
       - name: Downstream consumer smoke test
         run: cargo run --release --locked --manifest-path examples/downstream-smoke/Cargo.toml
 
+  # Cross-OS encode fingerprint (#259). The v5 rotation is deterministic
+  # by construction and the per-vector norm now has a frozen reduction
+  # order, but the Lloyd-Max codebook still goes through `statrs` Beta
+  # cdf/pdf — transcendentals, the same cross-libm class as #206's second
+  # finding — and that can only be checked by comparing bytes produced on
+  # different platforms. This leg is that check.
+  #
+  # Each OS runs `examples/encode_hash` (deterministic LCG input, six
+  # (dim, bit_width) cells) and uploads its output; the compare job below
+  # fails unless every OS produced the same lines. The per-stage split —
+  # codebook / calibration / codes / scales / file — means a divergence
+  # names the stage that drifted instead of just "the bytes differ".
+  encode-fingerprint:
+    name: Encode fingerprint (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Compute encode fingerprint
+        shell: bash
+        run: |
+          cargo run --release --locked -p turbovec --example encode_hash \
+            > "fingerprint-${{ matrix.os }}.txt"
+          cat "fingerprint-${{ matrix.os }}.txt"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fingerprint-${{ matrix.os }}
+          path: fingerprint-${{ matrix.os }}.txt
+
+  encode-fingerprint-compare:
+    name: Encode fingerprint agrees across OSes
+    runs-on: ubuntu-latest
+    needs: encode-fingerprint
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: fingerprints
+
+      - name: All OSes must agree
+        shell: bash
+        run: |
+          set -euo pipefail
+          files=$(find fingerprints -name 'fingerprint-*.txt' | sort)
+          echo "Comparing:"; echo "$files"
+          # Normalize line endings — the Windows leg writes CRLF.
+          for f in $files; do tr -d '\r' < "$f" > "$f.norm"; done
+          distinct=$(md5sum $(for f in $files; do echo "$f.norm"; done) \
+                     | awk '{print $1}' | sort -u | wc -l)
+          if [ "$distinct" -ne 1 ]; then
+            echo "::error::encode output differs across platforms"
+            echo "--- per-OS fingerprints ---"
+            for f in $files; do echo "== $f"; cat "$f.norm"; done
+            echo
+            echo "The differing column names the stage that drifted."
+            echo "A 'codebook' difference is the known-open half of #259:"
+            echo "the Lloyd-Max codebook is computed from statrs Beta"
+            echo "cdf/pdf, so the fix is to precompute and pin it."
+            exit 1
+          fi
+          echo "All platforms agree:"
+          cat "$(echo "$files" | head -1).norm"
+
   python:
     name: Python (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ codebooks.npz
 target/
 evolve/
 evolve_rust/
+dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,26 @@ appears under each surface it touches.
   one serial chain (deterministic, identical across platforms and
   thread counts; packed codes are unchanged and previously written
   files load byte-identical). Recall is unaffected.
+- **Codebook boundaries are now the f32 midpoints of the f32 centroids**,
+  rather than the f64 midpoints cast once to f32 — which makes the whole
+  Lloyd-Max codebook reproducible across platforms, closing the second
+  and last open input in the v5 determinism scope (#259 finding 2).
+  The cross-OS fingerprint CI leg caught this on its first run: Linux,
+  macOS and Windows each produced a *different* codebook, while
+  calibration, codes and scales were byte-identical on all three. The
+  f64 iteration is not bit-reproducible (`statrs`'s Beta cdf/pdf bottom
+  out in `ln`/`exp`, which differ by ~1 ulp between libms, and the
+  adaptive-Simpson recursion can branch differently; at 4 bits the loop
+  also exhausts `max_iter` without reaching `tol`, so the f64 centroids
+  settle only to ~1e-8). Casting a centroid to f32 absorbs all of that —
+  measured invariant under pdf perturbations up to 1e-10 relative — but
+  the *midpoint* computed in f64 sat a fraction of an f32 ulp from a
+  rounding boundary and flipped under a 1e-15 perturbation at every
+  (bits, dim) cell tested. Averaging the already-rounded f32 centroids
+  removes the knife-edge by construction: f32 add is correctly rounded
+  and `* 0.5` is exact. Boundaries move by at most 1 ULP versus earlier
+  unreleased builds, so a coordinate sitting exactly on one can change
+  code; both formats are unreleased, so no published index is affected.
 - **The per-vector norm has one frozen reduction order on every
   architecture** — `c[j % 8] += x*x`, combined
   `((c0+c1)+(c2+c3)) + ((c4+c5)+(c6+c7))`, with separate multiply and
@@ -889,10 +909,11 @@ appears under each surface it touches.
   prints a hash per pipeline stage — codebook, calibration, codes,
   scales, whole file. Each OS in the matrix runs it; a `needs:` job
   fails unless all three agree. Hashing per stage means a divergence
-  names the stage that drifted, which for the one remaining
-  unproven input (the Lloyd-Max codebook, computed from `statrs` Beta
-  cdf/pdf) is the difference between "the bytes differ" and a known
-  fix.
+  names the stage that drifted — which it did on the very first run:
+  the codebook differed on all three OSes while calibration, codes and
+  scales matched, localizing the cause to the boundary midpoints (fixed
+  above) rather than to "the encode". Boundaries and centroids are
+  hashed as separate columns for exactly that reason.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,18 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Declared MSRV corrected from 1.83 to 1.89 — the crate did not build
+  on the version it advertised.** The AVX-512 search kernel added in the
+  v6 cycle uses `_mm512_*` intrinsics and the `avx512f`/`avx512bw`
+  `target_feature` gates, all of which stabilized in Rust 1.89; on 1.83
+  `cargo check -p turbovec` fails outright with `use of unstable library
+  feature 'stdarch_x86_avx512'` (67 errors), so a downstream consumer
+  pinned to the declared MSRV got a hard compile error rather than a
+  scalar fallback. Both packages now declare `rust-version = "1.89"`,
+  verified by a clean `cargo +1.89 check` of each plus the full test
+  suite (19 suites) on 1.89. Found by `clippy::incompatible_msrv` while
+  adding the AVX-512 butterfly, which raised the same lint against the
+  pre-existing search kernel.
 - **Declared MSRV corrected from 1.70 to 1.83.** The
   `rust-version = "1.70"` declared in both `Cargo.toml`s was never
   accurate: when it was introduced (2026-04-13, chosen for the crate's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,34 @@ appears under each surface it touches.
   - `TurboQuantIndex::codes_blocked_seq` / `codebook_for_write` expose the
     v6 payload parts for embedders serializing through the raw `io::*`
     writers (whose code-payload parameter is now the blocked layout).
+- **x86 insertion is 1.4-3.5x faster again** on top of the pass below
+  (#273). The x86 encode path had a NEON-shaped hole in it: the
+  Walsh-Hadamard butterfly ran as a radix-2 ladder (9 memory passes over
+  the block at dim 1536, where the NEON path had already moved to
+  radix-8), the permutation gather was scalar, the bit-packer OR-ed one
+  bit at a time into a pre-zeroed row, and the reconstruction operand
+  came from a hoisted table that every row streamed in full. All four
+  are now closed, plus an AVX-512 butterfly and the L1-sized calibration
+  transpose below. Every change is bit-identical — packed codes and
+  stored scales are unmoved, enforced against the scalar reference on
+  every SIMD path the host can run. Measured on x86 (Cascade Lake,
+  interleaved A/B, synthetic 1536/3072-dim corpora; the official cells
+  are pending a run on the GCP Sapphire Rapids instance):
+
+  | cell | cold bulk | warm append | single add |
+  |---|---|---|---|
+  | d1536 2-bit ST | +72% | +2.2x | -66% |
+  | d1536 2-bit MT | +53% | +45% | -66% |
+  | d1536 4-bit ST | +91% | +3.2x | -74% |
+  | d1536 4-bit MT | +67% | +2.6x | -74% |
+  | d3072 2-bit ST | +61% | +2.8x | -64% |
+  | d3072 2-bit MT | +42% | +2.6x | -64% |
+  | d3072 4-bit ST | +75% | +3.5x | -73% |
+  | d3072 4-bit MT | +63% | +3.4x | -71% |
+
+  Removal is unchanged: `swap_remove` was already an O(1) swap-and-pop
+  and none of this touches it.
+
 - **Insertion and removal are substantially faster** across a ~35-commit
   optimization pass (arm d=1536 2-bit: cold bulk add ~4.7x, warm append
   ~4-6x, single add ~3x, removals ~25% faster; x86 gains larger from a
@@ -136,6 +164,22 @@ appears under each surface it touches.
   one serial chain (deterministic, identical across platforms and
   thread counts; packed codes are unchanged and previously written
   files load byte-identical). Recall is unaffected.
+- **The per-vector norm has one frozen reduction order on every
+  architecture** — `c[j % 8] += x*x`, combined
+  `((c0+c1)+(c2+c3)) + ((c4+c5)+(c6+c7))`, with separate multiply and
+  add rather than an FMA. It was previously two different reductions:
+  aarch64 accumulated four chains through `vfmaq_f32` (one rounding
+  where the scalar path has two) while everything else summed serially,
+  and those disagree in the last ulp. Since `1/||v||` rides the first
+  rotation gather, that reached every encoded byte — the remaining
+  cross-platform encode input the v5 determinism scope flagged
+  (#259 finding 1), now closed by construction rather than by
+  observation. **Newly encoded vectors can differ from earlier
+  unreleased builds by ~1 ULP in the stored scale**, and at an exact
+  boundary tie by one code. Measured recall is unchanged (R@1 and R@4
+  identical at d1536 2/4-bit and d3072 4-bit; R@16/R@64 move by
+  <3e-4, i.e. a handful of near-ties reordering). Both v5 and v6 are
+  unreleased, so no published index is affected.
 - `add` on a populated index no longer holds allocation-sized
   intermediates: encode appends in place and reuses a per-index scratch
   buffer, which is shrunk whenever it exceeds 4x the current batch's
@@ -771,6 +815,21 @@ appears under each surface it touches.
 
 ### Benchmarks
 
+- **Persistence benchmarks join the suite** (#275): `speed_persist_*`
+  for every (dim, bit width, arch, threading) cell, covering write in
+  both states (warm blocked cache vs invalidated by a mutation — ~5x
+  apart, so a single "save time" would hide the interesting half),
+  `load` and `load → first search` separately (the gap v6 removed),
+  and `mutate → save → load → first search` as one checkpoint/resume
+  pipeline, each against FAISS `write_index` / `read_index`. Page-cache
+  state is warm and stated; the fsync + atomic rename turbovec does and
+  FAISS does not is called out in the scripts as a deliberate
+  durability difference rather than a gap to close.
+- **`examples/insert_bench`**: a Rust harness reproducing the suite's
+  four mutation metrics on deterministic synthetic vectors, so an
+  optimization hypothesis can be measured in seconds without the OpenAI
+  corpus or FAISS. Official numbers still come from
+  `benchmarks/suite/`.
 - Insertion and removal speed benchmarks join the suite. (#65) For every
   published search-speed cell (d=1536/3072 × 2-bit/4-bit × ARM/x86 ×
   ST/MT), `benchmarks/suite/` gains `speed_insert_*` — bulk `add()` into
@@ -810,6 +869,18 @@ appears under each surface it touches.
     of dim 0`; they now raise an error pointing at the embedder / embed
     model. (Agno already caught this mode via its missing-embedding
     check.)
+
+### CI
+
+- **Cross-OS encode fingerprint leg** (#259). `examples/encode_hash`
+  encodes a fixed LCG fixture across six (dim, bit width) cells and
+  prints a hash per pipeline stage — codebook, calibration, codes,
+  scales, whole file. Each OS in the matrix runs it; a `needs:` job
+  fails unless all three agree. Hashing per stage means a divergence
+  names the stage that drifted, which for the one remaining
+  unproven input (the Lloyd-Max codebook, computed from `statrs` Beta
+  cdf/pdf) is the difference between "the bytes differ" and a known
+  fix.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -904,6 +904,15 @@ appears under each surface it touches.
 
 ### CI
 
+- **MSRV leg**: reads `rust-version` out of both manifests, checks they
+  agree, and builds with exactly that toolchain. The declared MSRV has
+  been wrong twice (1.70 → 1.83 → 1.89) and both times it took a human
+  to notice; now it cannot drift from reality silently.
+- **Opt-in SIMD coverage gate**: `TURBOVEC_REQUIRE_SIMD=avx2,avx512f`
+  makes the kernel identity tests *fail* when a listed feature is
+  missing rather than silently skipping the paths gated on it. Without
+  it, a runner without AVX-512 exercises neither AVX-512 kernel and the
+  suite still passes green — the absence of coverage is invisible.
 - **Cross-OS encode fingerprint leg** (#259). `examples/encode_hash`
   encodes a fixed LCG fixture across six (dim, bit width) cells and
   prints a hash per pipeline stage — codebook, calibration, codes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -908,11 +908,15 @@ appears under each surface it touches.
   agree, and builds with exactly that toolchain. The declared MSRV has
   been wrong twice (1.70 → 1.83 → 1.89) and both times it took a human
   to notice; now it cannot drift from reality silently.
-- **Opt-in SIMD coverage gate**: `TURBOVEC_REQUIRE_SIMD=avx2,avx512f`
-  makes the kernel identity tests *fail* when a listed feature is
-  missing rather than silently skipping the paths gated on it. Without
-  it, a runner without AVX-512 exercises neither AVX-512 kernel and the
-  suite still passes green — the absence of coverage is invisible.
+- **SIMD coverage gate, wired into the Rust legs.**
+  `TURBOVEC_REQUIRE_SIMD=avx2,avx512f` makes the kernel identity tests
+  *fail* when a listed feature is missing rather than silently skipping
+  the paths gated on it — without it a runner lacking a feature
+  exercises nothing and still reports green, so the absence of coverage
+  is invisible. CI sets `avx2`, which every GitHub-hosted x86 runner
+  has. AVX-512 is deliberately not required there (hosted runners do not
+  guarantee it), so those kernels remain single-machine-verified until a
+  designated runner or an Intel SDE leg covers them.
 - **Cross-OS encode fingerprint leg** (#259). `examples/encode_hash`
   encodes a fixed LCG fixture across six (dim, bit width) cells and
   prints a hash per pipeline stage — codebook, calibration, codes,

--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ Results are saved as JSON to `benchmarks/results/`. Regenerate charts:
 python3 benchmarks/create_diagrams.py
 ```
 
+### Quick harness for optimization work
+
+The suite above is the source of every published number — real embeddings,
+FAISS comparator, fixed shapes, run on the two official environments. For the
+inner loop of an optimization pass there's also a Rust harness that reproduces
+the four mutation metrics (cold bulk add, warm append, single add, remove) on
+deterministic synthetic vectors, so a hypothesis can be measured in seconds on
+any machine with no dataset and no FAISS:
+
+```bash
+cargo run --release --example insert_bench -- --dim 1536 --bits 2
+RAYON_NUM_THREADS=1 cargo run --release --example insert_bench
+```
+
+It is a screening tool, not a source of published numbers.
+
+`examples/encode_hash` prints a per-stage hash of the encode pipeline for a
+fixed input; CI runs it on every OS in the matrix and fails if they disagree,
+which is how cross-platform byte identity of the encode is checked.
+
 ## References
 
 - [TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate](https://arxiv.org/abs/2504.19874) (ICLR 2026) -- the paper this implements

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_arm_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_2bit_x86_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_arm_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d1536_4bit_x86_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d1536_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_arm_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 4
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 2 bits is 2*dim. Matching
+# those gives m = dim/2. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM // 2
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_2bit_x86_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 2
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 4
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_4bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_arm_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_4bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
@@ -98,8 +98,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
@@ -69,6 +69,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -129,7 +134,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
@@ -1,0 +1,132 @@
+import os
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(0)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "mt",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_4bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_mt.py
@@ -1,5 +1,5 @@
 import os
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -20,9 +20,16 @@ def load_openai(dim, seed=42):
 
 database, extra = load_openai(DIM)
 query = np.ascontiguousarray(database[:1])
-faiss.omp_set_num_threads(0)
+# FAISS threading is left at its default (all cores), matching the
+# existing speed_*_mt.py cells. Do NOT call omp_set_num_threads(0)
+# to mean "default": 0 is invalid OpenMP and libgomp clamps it to a
+# single thread, which would silently benchmark single-threaded
+# FAISS against multi-threaded turbovec.
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
@@ -66,6 +66,11 @@ tv_write_dirty = sorted(dirty_write)[2]
 # format v6 the file is the search-ready index, so the gap between them
 # is what the v6 work removed.
 build().write(tv_path)
+# Size of a file holding exactly `database` — captured here, before the
+# round-trip section below appends `extra` and rewrites. Reporting the
+# post-round-trip size would describe a 101k-vector file next to
+# `n_vectors: 100000` and next to a FAISS file holding 100k.
+tv_file_bytes = os.path.getsize(tv_path)
 bare_load, load_search = [], []
 for _ in range(5):
     t0 = time.perf_counter()
@@ -126,7 +131,7 @@ faiss_read_search = sorted(frs)[2]
 
 result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
           "n_vectors": len(database),
-          "tv_file_bytes": os.path.getsize(tv_path),
+          "tv_file_bytes": tv_file_bytes,
           "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
           "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
           "tq_load_ms": round(tv_load * 1e3, 2),

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
@@ -95,8 +95,14 @@ for _ in range(5):
 tv_roundtrip = sorted(roundtrip)[2]
 
 # ── FAISS comparator ────────────────────────────────────────────────────
-# Precision-matched IndexPQFastScan, same as the search/insert cells.
-m_pq = DIM // 2
+# Precision-matched IndexPQFastScan, identical config to the search
+# and insert cells. FastScan uses nbits=4, so m sub-quantizers is
+# 4*m bits per vector; turbovec at 4 bits is 4*dim. Matching
+# those gives m = dim. (Do not reuse the ratios from the
+# recall cells - those use IndexPQ at nbits=8, so their m is half
+# this. Getting it wrong halves the FAISS index and silently
+# compares against something that stores half the information.)
+m_pq = DIM
 pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
 pq.train(database)
 pq.add(database)

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
@@ -1,6 +1,6 @@
 import os
 os.environ["RAYON_NUM_THREADS"] = "1"
-import time, json, os.path, tempfile
+import atexit, shutil, time, json, os.path, tempfile
 import numpy as np
 import faiss
 from turbovec import TurboQuantIndex
@@ -24,6 +24,9 @@ query = np.ascontiguousarray(database[:1])
 faiss.omp_set_num_threads(1)
 
 tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+# Index payloads here run to hundreds of MB; the official machines run
+# all 16 cells in a loop, so leaving them behind adds up.
+atexit.register(shutil.rmtree, tmpdir, True)
 tv_path = os.path.join(tmpdir, "index.tv")
 faiss_path = os.path.join(tmpdir, "index.faiss")
 

--- a/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
+++ b/benchmarks/suite/speed_persist_d3072_4bit_x86_st.py
@@ -1,0 +1,133 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import time, json, os.path, tempfile
+import numpy as np
+import faiss
+from turbovec import TurboQuantIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 3072, 4
+N_MUTATE = 1_000
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_MUTATE]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+query = np.ascontiguousarray(database[:1])
+faiss.omp_set_num_threads(1)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-persist-")
+tv_path = os.path.join(tmpdir, "index.tv")
+faiss_path = os.path.join(tmpdir, "index.faiss")
+
+def build():
+    idx = TurboQuantIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add(database)
+    return idx
+
+# ── Save ────────────────────────────────────────────────────────────────
+# Two states, because they cost very differently:
+#   warm  — a search has run, so the blocked layout cache is populated and
+#           write serializes from it (a cheap inverse transform);
+#   dirty — a mutation invalidated that cache, so write pays the full
+#           O(n*dim) repack from the packed rows first.
+# turbovec's write is fsync + atomic rename; FAISS write_index is a raw
+# dump with neither. The durability difference is deliberate (#68) and is
+# part of the gap below, not an artifact to tune away.
+warm_write, dirty_write = [], []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)          # populate the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    warm_write.append(time.perf_counter() - t0)
+
+    idx.add(extra)                   # invalidates the blocked cache
+    t0 = time.perf_counter()
+    idx.write(tv_path)
+    dirty_write.append(time.perf_counter() - t0)
+tv_write_warm = sorted(warm_write)[2]
+tv_write_dirty = sorted(dirty_write)[2]
+
+# ── Load ────────────────────────────────────────────────────────────────
+# Page cache is warm throughout (the file was just written, and each run
+# re-reads it) — this measures the format's parse + prepare cost, not
+# storage. Bare load vs load-then-first-search separates the two: since
+# format v6 the file is the search-ready index, so the gap between them
+# is what the v6 work removed.
+build().write(tv_path)
+bare_load, load_search = [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    TurboQuantIndex.load(tv_path)
+    bare_load.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    loaded = TurboQuantIndex.load(tv_path)
+    loaded.search(query, k=10)
+    load_search.append(time.perf_counter() - t0)
+tv_load = sorted(bare_load)[2]
+tv_load_search = sorted(load_search)[2]
+
+# ── Round trip ──────────────────────────────────────────────────────────
+# The checkpoint/resume cycle an embedding store actually pays: mutate,
+# save, reopen, serve the first query.
+roundtrip = []
+for _ in range(5):
+    idx = build()
+    idx.search(query, k=10)
+    t0 = time.perf_counter()
+    idx.add(extra)
+    idx.write(tv_path)
+    reopened = TurboQuantIndex.load(tv_path)
+    reopened.search(query, k=10)
+    roundtrip.append(time.perf_counter() - t0)
+tv_roundtrip = sorted(roundtrip)[2]
+
+# ── FAISS comparator ────────────────────────────────────────────────────
+# Precision-matched IndexPQFastScan, same as the search/insert cells.
+m_pq = DIM // 2
+pq = faiss.IndexPQFastScan(DIM, m_pq, 4)
+pq.train(database)
+pq.add(database)
+fw, fr, frs = [], [], []
+for _ in range(5):
+    t0 = time.perf_counter()
+    faiss.write_index(pq, faiss_path)
+    fw.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    faiss.read_index(faiss_path)
+    fr.append(time.perf_counter() - t0)
+
+    t0 = time.perf_counter()
+    reloaded = faiss.read_index(faiss_path)
+    reloaded.search(query, 10)
+    frs.append(time.perf_counter() - t0)
+faiss_write = sorted(fw)[2]
+faiss_read = sorted(fr)[2]
+faiss_read_search = sorted(frs)[2]
+
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86", "threading": "st",
+          "n_vectors": len(database),
+          "tv_file_bytes": os.path.getsize(tv_path),
+          "tq_write_warm_ms": round(tv_write_warm * 1e3, 2),
+          "tq_write_after_mutation_ms": round(tv_write_dirty * 1e3, 2),
+          "tq_load_ms": round(tv_load * 1e3, 2),
+          "tq_load_first_search_ms": round(tv_load_search * 1e3, 2),
+          "tq_mutate_save_load_search_ms": round(tv_roundtrip * 1e3, 2),
+          "faiss_write_ms": round(faiss_write * 1e3, 2),
+          "faiss_read_ms": round(faiss_read * 1e3, 2),
+          "faiss_read_first_search_ms": round(faiss_read_search * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_persist_d3072_4bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbovec-python"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.89"
 
 [lib]
 name = "_turbovec"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -2,7 +2,7 @@
 name = "turbovec"
 version = "0.9.0"
 edition = "2021"
-rust-version = "1.83"
+rust-version = "1.89"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 license = "MIT"
 repository = "https://github.com/RyanCodrai/turbovec"

--- a/turbovec/examples/encode_hash.rs
+++ b/turbovec/examples/encode_hash.rs
@@ -20,9 +20,11 @@
 //!    cdf/pdf — transcendentals, so cross-libm variance is possible;
 //! 2. everything downstream of it.
 //!
-//! Hence the split: `codebook`, `calibration`, `codes`, `scales`, and
-//! `file` are hashed separately, so a divergence localizes instead of
-//! just saying "the bytes differ".
+//! Hence the split: `boundaries`, `centroids`, `calibration`, `codes`,
+//! `scales`, and `file` are hashed separately, so a divergence localizes
+//! instead of just saying "the bytes differ". That split is what caught
+//! the codebook boundaries diverging on all three platforms while the
+//! centroids agreed — see `codebook::lloyd_max`.
 //!
 //! The hash is FNV-1a 64, not SHA-256: this compares outputs of the same
 //! code across platforms, so it needs collision resistance against
@@ -97,18 +99,24 @@ fn main() {
         let mut index = TurboQuantIndex::new(dim, bits).unwrap();
         index.add(&vectors);
 
+        // Boundaries and centroids are hashed separately: they fail
+        // independently. The centroids survive the f64 Lloyd-Max
+        // iteration's libm variance because the f32 cast absorbs it,
+        // while the midpoints between them used to sit on an f32
+        // rounding knife-edge and diverged on all three platforms
+        // (#259). Splitting the column is what made that diagnosable.
         let (boundaries, centroids) = index.codebook_for_write();
-        let mut codebook_bytes = boundaries.clone();
-        codebook_bytes.extend_from_slice(&centroids);
 
         let mut calibration = index.tqplus_shift().to_vec();
         calibration.extend_from_slice(index.tqplus_scale());
 
-        // One line per stage, so a diverging platform names the stage.
+        // One line per cell, one column per stage, so a diverging
+        // platform names the stage rather than just "the bytes differ".
         println!(
-            "dim={dim} bits={bits} codebook={:016x} calibration={:016x} \
-             codes={:016x} scales={:016x} file={:016x}",
-            fnv1a_f32(&codebook_bytes),
+            "dim={dim} bits={bits} boundaries={:016x} centroids={:016x} \
+             calibration={:016x} codes={:016x} scales={:016x} file={:016x}",
+            fnv1a_f32(&boundaries),
+            fnv1a_f32(&centroids),
             fnv1a_f32(&calibration),
             fnv1a(index.packed_codes()),
             fnv1a_f32(index.scales()),

--- a/turbovec/examples/encode_hash.rs
+++ b/turbovec/examples/encode_hash.rs
@@ -1,0 +1,118 @@
+//! Cross-platform encode fingerprint.
+//!
+//! Prints one line per (dim, bit_width) cell, each a hash of a stage of
+//! the encode pipeline for a fixed, deterministic input. Two platforms
+//! that agree on every line encode identical bytes for identical
+//! vectors; a platform that differs says *which stage* diverged.
+//!
+//! ```text
+//! cargo run --release --example encode_hash
+//! ```
+//!
+//! This is the observable half of the v5/v6 determinism claim (#259).
+//! The rotation is deterministic by construction (integer permutations
+//! plus f32 add/sub/scale, no FMA, golden-pinned) and the per-vector
+//! norm now has a frozen reduction order, but two inputs to the encode
+//! can still only be *checked* across platforms, never proved on one
+//! machine:
+//!
+//! 1. the Lloyd-Max codebook, computed at runtime from `statrs` Beta
+//!    cdf/pdf — transcendentals, so cross-libm variance is possible;
+//! 2. everything downstream of it.
+//!
+//! Hence the split: `codebook`, `calibration`, `codes`, `scales`, and
+//! `file` are hashed separately, so a divergence localizes instead of
+//! just saying "the bytes differ".
+//!
+//! The hash is FNV-1a 64, not SHA-256: this compares outputs of the same
+//! code across platforms, so it needs collision resistance against
+//! accident, not against an adversary — and a cryptographic hash would
+//! mean a new dependency for a diagnostic.
+
+use turbovec::TurboQuantIndex;
+
+/// Cells to fingerprint. Chosen to cover the block-size regimes the
+/// rotation has and the Beta parameters the codebook is fit against:
+/// `8·odd` dims collapse to a B=8 Hadamard block, powers of two use one
+/// full-width block, and the two production dims sit in between.
+const CELLS: &[(usize, usize)] = &[
+    (200, 2),   // 8·25  -> B = 8, low dim (loosest Beta asymptotics)
+    (768, 4),   // 256·3 -> B = 256
+    (1024, 3),  // pure power of two -> B = 1024, odd bit width
+    (1536, 2),
+    (1536, 4),
+    (3072, 4),
+];
+
+/// Enough vectors that the TQ+ calibration always fits (the identity
+/// fallback below `TQPLUS_MIN_SAMPLES` would hide calibration drift).
+const N: usize = 2_000;
+
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+fn fnv1a_f32(values: &[f32]) -> u64 {
+    // Hash the bit patterns, not the printed values: a last-ulp
+    // difference is exactly what this is looking for.
+    let mut bytes = Vec::with_capacity(values.len() * 4);
+    for v in values {
+        bytes.extend_from_slice(&v.to_bits().to_le_bytes());
+    }
+    fnv1a(&bytes)
+}
+
+/// Deterministic input vectors — a plain LCG so the fixture is identical
+/// on every platform (no float RNG, no transcendentals).
+fn lcg_vectors(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed | 1;
+    (0..n * dim)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 32) as u32 as f64 / 2_147_483_648.0 - 1.0) as f32
+        })
+        .collect()
+}
+
+fn main() {
+    let arch = if cfg!(target_arch = "x86_64") {
+        "x86_64"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
+    } else {
+        "other"
+    };
+    eprintln!("# arch={arch} os={} n={N}", std::env::consts::OS);
+
+    for &(dim, bits) in CELLS {
+        // Seed varies per cell so two cells can't accidentally agree.
+        let vectors = lcg_vectors(N, dim, 0x7B0_0000 ^ (dim as u64) << 8 ^ bits as u64);
+        let mut index = TurboQuantIndex::new(dim, bits).unwrap();
+        index.add(&vectors);
+
+        let (boundaries, centroids) = index.codebook_for_write();
+        let mut codebook_bytes = boundaries.clone();
+        codebook_bytes.extend_from_slice(&centroids);
+
+        let mut calibration = index.tqplus_shift().to_vec();
+        calibration.extend_from_slice(index.tqplus_scale());
+
+        // One line per stage, so a diverging platform names the stage.
+        println!(
+            "dim={dim} bits={bits} codebook={:016x} calibration={:016x} \
+             codes={:016x} scales={:016x} file={:016x}",
+            fnv1a_f32(&codebook_bytes),
+            fnv1a_f32(&calibration),
+            fnv1a(index.packed_codes()),
+            fnv1a_f32(index.scales()),
+            fnv1a(&index.to_bytes()),
+        );
+    }
+}

--- a/turbovec/examples/insert_bench.rs
+++ b/turbovec/examples/insert_bench.rs
@@ -22,9 +22,9 @@
 //! * `single` — per-op latency of one-row `add()` on a warm index.
 //! * `remove` — per-op latency of `IdMapIndex::remove` and
 //!   `TurboQuantIndex::swap_remove`.
-//! * `stages` — optional (`--stages`) breakdown of the one-time init costs
-//!   (codebook, rotation build) and the rotation-only throughput, which is
-//!   where most of the encode time goes.
+//! * `stages` — optional (`--stages`) timing of the one-time first-add
+//!   cost (codebook solve + rotation build + a single row), which `bulk`
+//!   includes but which does not scale with `n`.
 
 use std::time::Instant;
 

--- a/turbovec/examples/insert_bench.rs
+++ b/turbovec/examples/insert_bench.rs
@@ -1,0 +1,189 @@
+//! Insertion / removal micro-benchmark for hill-climbing the mutation
+//! path, without needing the Python suite's OpenAI corpus or FAISS.
+//!
+//! The official numbers in the README come from `benchmarks/suite/` (real
+//! embeddings, FAISS comparator, fixed shapes). This harness exists for the
+//! inner loop of an optimization pass: it isolates the same four mutation
+//! metrics on deterministic synthetic vectors so a hypothesis can be
+//! measured in seconds on any machine, then confirmed on the official
+//! environment.
+//!
+//! ```text
+//! cargo run --release --example insert_bench -- --dim 1536 --bits 2
+//! RAYON_NUM_THREADS=1 cargo run --release --example insert_bench
+//! ```
+//!
+//! Metrics (median of `--repeats` runs, fresh index per timed run):
+//!
+//! * `bulk`   — one `add()` of `--n` vectors into an empty index. Includes
+//!   the one-time rotation/codebook init and the TQ+ calibration fit.
+//! * `warm`   — a second `add()` on that index: caches built, calibration
+//!   frozen. The steady-state encode path.
+//! * `single` — per-op latency of one-row `add()` on a warm index.
+//! * `remove` — per-op latency of `IdMapIndex::remove` and
+//!   `TurboQuantIndex::swap_remove`.
+//! * `stages` — optional (`--stages`) breakdown of the one-time init costs
+//!   (codebook, rotation build) and the rotation-only throughput, which is
+//!   where most of the encode time goes.
+
+use std::time::Instant;
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+/// Deterministic pseudo-random vectors (xorshift64*), unit-normalized so
+/// the shape matches the embedding corpora the official suite uses.
+fn synth(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+    let mut x = seed | 1;
+    let mut v = vec![0.0f32; n * dim];
+    for row in v.chunks_mut(dim) {
+        for slot in row.iter_mut() {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            *slot = (x as f64 / u64::MAX as f64) as f32 - 0.5;
+        }
+        let norm = row.iter().map(|a| a * a).sum::<f32>().sqrt();
+        for slot in row.iter_mut() {
+            *slot /= norm;
+        }
+    }
+    v
+}
+
+fn median(mut xs: Vec<f64>) -> f64 {
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    xs[xs.len() / 2]
+}
+
+struct Args {
+    dim: usize,
+    bits: usize,
+    n: usize,
+    append: usize,
+    singles: usize,
+    removes: usize,
+    repeats: usize,
+    stages: bool,
+}
+
+fn parse_args() -> Args {
+    let mut a = Args {
+        dim: 1536,
+        bits: 2,
+        n: 100_000,
+        append: 10_000,
+        singles: 1_000,
+        removes: 20_000,
+        repeats: 5,
+        stages: false,
+    };
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i < argv.len() {
+        let val = |i: usize| -> usize {
+            argv.get(i + 1)
+                .and_then(|s| s.parse().ok())
+                .unwrap_or_else(|| panic!("missing/invalid value for {}", argv[i]))
+        };
+        match argv[i].as_str() {
+            "--dim" => { a.dim = val(i); i += 2; }
+            "--bits" => { a.bits = val(i); i += 2; }
+            "--n" => { a.n = val(i); i += 2; }
+            "--append" => { a.append = val(i); i += 2; }
+            "--singles" => { a.singles = val(i); i += 2; }
+            "--removes" => { a.removes = val(i); i += 2; }
+            "--repeats" => { a.repeats = val(i); i += 2; }
+            "--stages" => { a.stages = true; i += 1; }
+            other => panic!("unknown flag {other}"),
+        }
+    }
+    a
+}
+
+fn main() {
+    let args = parse_args();
+    let (dim, bits) = (args.dim, args.bits);
+    eprintln!(
+        "# dim={dim} bits={bits} n={} append={} threads={}",
+        args.n,
+        args.append,
+        rayon::current_num_threads(),
+    );
+
+    let database = synth(args.n, dim, 0xD1536);
+    let append = synth(args.append + args.singles, dim, 0xA55E3);
+    let batch = &append[..args.append * dim];
+    let singles = &append[args.append * dim..];
+
+    let mut bulk = Vec::new();
+    let mut warm = Vec::new();
+    for _ in 0..args.repeats {
+        let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
+        let t0 = Instant::now();
+        idx.add(&database);
+        bulk.push(args.n as f64 / t0.elapsed().as_secs_f64());
+        let t0 = Instant::now();
+        idx.add(batch);
+        warm.push(args.append as f64 / t0.elapsed().as_secs_f64());
+    }
+
+    // Single-row adds on a warm index (calibration frozen, caches built).
+    let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
+    idx.add(&database);
+    let mut single = Vec::new();
+    for _ in 0..args.repeats {
+        let t0 = Instant::now();
+        for i in 0..args.singles {
+            idx.add(&singles[i * dim..(i + 1) * dim]);
+        }
+        single.push(t0.elapsed().as_secs_f64() / args.singles as f64 * 1e6);
+    }
+
+    // Removal: IdMapIndex::remove (id-map bookkeeping) vs the raw
+    // swap_remove underneath it. Fresh index per timed run — removal
+    // shrinks the index, so repeating on one index is not comparable.
+    let mut id_remove = Vec::new();
+    let mut swap_remove = Vec::new();
+    let removes = args.removes.min(args.n);
+    for r in 0..args.repeats {
+        let ids: Vec<u64> = (0..args.n as u64).collect();
+        let mut im = IdMapIndex::new(dim, bits).unwrap();
+        im.add_with_ids(&database, &ids).unwrap();
+        // Remove from the front: each remove swaps the tail vector in, so
+        // no id in 0..removes has been moved out of the map yet.
+        let t0 = Instant::now();
+        for id in 0..removes as u64 {
+            im.remove(id);
+        }
+        id_remove.push(t0.elapsed().as_secs_f64() / removes as f64 * 1e6);
+
+        let mut ti = TurboQuantIndex::new(dim, bits).unwrap();
+        ti.add(&database);
+        let t0 = Instant::now();
+        for _ in 0..removes {
+            ti.swap_remove(0);
+        }
+        swap_remove.push(t0.elapsed().as_secs_f64() / removes as f64 * 1e6);
+        let _ = r;
+    }
+
+    println!("{{");
+    println!("  \"dim\": {dim},");
+    println!("  \"bit_width\": {bits},");
+    println!("  \"threads\": {},", rayon::current_num_threads());
+    println!("  \"bulk_insert_vecs_per_sec\": {:.0},", median(bulk));
+    println!("  \"warm_insert_vecs_per_sec\": {:.0},", median(warm));
+    println!("  \"single_add_us\": {:.3},", median(single));
+    println!("  \"idmap_remove_us\": {:.4},", median(id_remove));
+    println!("  \"swap_remove_us\": {:.4}", median(swap_remove));
+    println!("}}");
+
+    if args.stages {
+        // One-time init costs, measured separately: both are paid inside
+        // the `bulk` number above and neither scales with n.
+        let t0 = Instant::now();
+        let mut probe = TurboQuantIndex::new(dim, bits).unwrap();
+        probe.add(&database[..dim]);
+        eprintln!("# first-add init + 1 row: {:.3} ms", t0.elapsed().as_secs_f64() * 1e3);
+    }
+}

--- a/turbovec/examples/insert_bench.rs
+++ b/turbovec/examples/insert_bench.rs
@@ -30,7 +30,7 @@ use std::time::Instant;
 
 use turbovec::{IdMapIndex, TurboQuantIndex};
 
-/// Deterministic pseudo-random vectors (xorshift64*), unit-normalized so
+/// Deterministic pseudo-random vectors (xorshift64), unit-normalized so
 /// the shape matches the embedding corpora the official suite uses.
 fn synth(n: usize, dim: usize, seed: u64) -> Vec<f32> {
     let mut x = seed | 1;

--- a/turbovec/src/codebook.rs
+++ b/turbovec/src/codebook.rs
@@ -86,12 +86,80 @@ fn lloyd_max(bits: usize, dim: usize, max_iter: usize, tol: f64) -> (Vec<f32>, V
         }
     }
 
-    let boundaries: Vec<f32> = (0..n_levels - 1)
-        .map(|i| ((centroids[i] + centroids[i + 1]) / 2.0) as f32)
-        .collect();
+    // Round to f32 FIRST, then take midpoints in f32. Doing it the other
+    // way — midpoint in f64, then one cast — makes the boundaries
+    // cross-platform unstable, which is the open half of #259 and what
+    // the CI fingerprint leg caught.
+    //
+    // The f64 iteration above is not reproducible to the last bit across
+    // libms: `statrs`'s Beta cdf/pdf bottom out in `ln`/`exp`, which
+    // differ by an ulp or so between glibc, Apple's libm and MSVC, and
+    // the adaptive-Simpson recursion can then take a different branch.
+    // At 4 bits the loop also exhausts `max_iter` without reaching `tol`
+    // (200 iterations, final max change ~1e-8), so the f64 centroids are
+    // only settled to ~1e-8 anyway.
+    //
+    // Casting a centroid to f32 absorbs all of that — f32 has ~6e-8
+    // relative resolution, and the f32 centroids are empirically
+    // invariant under perturbations of the pdf up to 1e-10 relative,
+    // which is five orders of magnitude beyond any libm disagreement.
+    // The *midpoint* was the fragile step: computed in f64 it sits a
+    // fraction of an f32 ulp from a rounding boundary, so a 1e-15
+    // relative perturbation of the pdf flips it — measured to flip at
+    // every (bits, dim) cell tested. Averaging the already-rounded f32
+    // centroids removes the knife-edge entirely: f32 add is
+    // correctly rounded and `* 0.5` is exact, so the result is a pure
+    // function of the two f32 centroids on every platform.
     let centroids_f32: Vec<f32> = centroids.iter().map(|&c| c as f32).collect();
+    let boundaries: Vec<f32> = (0..n_levels - 1)
+        .map(|i| (centroids_f32[i] + centroids_f32[i + 1]) * 0.5)
+        .collect();
 
     (boundaries, centroids_f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every boundary must be exactly the f32 midpoint of its two
+    /// neighbouring f32 centroids.
+    ///
+    /// This is what makes the codebook cross-platform reproducible
+    /// (#259): the f32 centroids survive the f64 iteration's libm
+    /// variance, so deriving boundaries from them — rather than from the
+    /// f64 centroids — makes the whole codebook a pure function of
+    /// values every platform agrees on. A regression here reintroduces
+    /// the divergence silently, since it only shows up as differing
+    /// bytes on a different OS.
+    #[test]
+    fn boundaries_are_f32_midpoints_of_f32_centroids() {
+        for bits in 2..=4usize {
+            for dim in [8usize, 128, 200, 768, 1000, 1024, 1536, 3072] {
+                let (boundaries, centroids) = codebook(bits, dim);
+                assert_eq!(centroids.len(), 1 << bits);
+                assert_eq!(boundaries.len(), (1 << bits) - 1);
+                for i in 0..boundaries.len() {
+                    let expect = (centroids[i] + centroids[i + 1]) * 0.5;
+                    assert_eq!(
+                        boundaries[i].to_bits(),
+                        expect.to_bits(),
+                        "bits={bits} dim={dim} boundary {i} is not the f32 \
+                         midpoint of centroids {i} and {}",
+                        i + 1,
+                    );
+                }
+                // Ordering is what the boundary scan in the quantize
+                // kernel relies on: code = count of boundaries below x.
+                for w in boundaries.windows(2) {
+                    assert!(w[0] < w[1], "bits={bits} dim={dim}: boundaries not ascending");
+                }
+                for w in centroids.windows(2) {
+                    assert!(w[0] < w[1], "bits={bits} dim={dim}: centroids not ascending");
+                }
+            }
+        }
+    }
 }
 
 /// Adaptive Simpson's rule for numerical integration.

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -1196,6 +1196,7 @@ mod simd_identity_tests {
     /// reconstruction paths.
     #[test]
     fn quantize_kernel_matches_scalar_bit_exactly() {
+        crate::rotation::tests::require_simd_features();
         fn run<const BITS: usize>(dim: usize) {
             let rotation = Rotation::new(dim);
             let (boundaries, centroids) = codebook::codebook(BITS, dim);
@@ -1353,6 +1354,7 @@ mod simd_identity_tests {
     /// (#259 finding 1), not a rounding nit.
     #[test]
     fn norm_simd_matches_scalar_bit_exactly() {
+        crate::rotation::tests::require_simd_features();
         // Multiples of 8 (every index path) plus non-multiples and
         // sub-chain lengths, which exercise the scalar tail.
         for len in [8usize, 16, 24, 64, 200, 768, 1000, 1536, 3072, 1, 5, 7, 9, 15] {

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -1232,29 +1232,55 @@ mod simd_identity_tests {
                 rotation.apply_scaled_into(src, 1.0 / norm, &mut rot, &mut scratch);
 
                 for table_opt in [None, Some(table.as_slice())] {
-                    let mut packed_a = vec![0u8; bytes_per_row];
-                    let mut packed_b = vec![0u8; bytes_per_row];
-                    let scale_a = fused_quantize_scale_pack::<BITS>(
+                    let mut expect = vec![0u8; bytes_per_row];
+                    let scale_ref = fused_quantize_scale_pack_scalar::<BITS>(
                         &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
-                        &boundaries, &centroids, norm, &mut packed_a, dim,
+                        &boundaries, &centroids, norm, &mut expect, dim,
                         bytes_per_plane,
                     );
-                    let scale_b = fused_quantize_scale_pack_scalar::<BITS>(
-                        &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
-                        &boundaries, &centroids, norm, &mut packed_b, dim,
-                        bytes_per_plane,
-                    );
-                    assert_eq!(
-                        packed_a, packed_b,
-                        "BITS={BITS} row {i} table={} packed bytes diverge",
-                        table_opt.is_some()
-                    );
-                    assert_eq!(
-                        scale_a.to_bits(),
-                        scale_b.to_bits(),
-                        "BITS={BITS} row {i} table={} scale diverges: {scale_a} vs {scale_b}",
-                        table_opt.is_some()
-                    );
+
+                    // Every implementation this host can run, not just the
+                    // dispatched one: on a machine with AVX-512 the
+                    // dispatcher never selects the AVX2 kernel, so a
+                    // dispatch-only test leaves it unexercised on exactly
+                    // the CI runners that outrank it.
+                    let mut paths: Vec<(&str, Vec<u8>, f32)> = Vec::new();
+                    {
+                        let mut p = vec![0u8; bytes_per_row];
+                        let sc = fused_quantize_scale_pack::<BITS>(
+                            &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
+                            &boundaries, &centroids, norm, &mut p, dim,
+                            bytes_per_plane,
+                        );
+                        paths.push(("dispatch", p, sc));
+                    }
+                    #[cfg(target_arch = "x86_64")]
+                    if std::arch::is_x86_feature_detected!("avx2") {
+                        let mut p = vec![0u8; bytes_per_row];
+                        let sc = unsafe {
+                            fused_quantize_scale_pack_avx2::<BITS>(
+                                &rot, &shift, &scale_tq, &inv_scale_tq, table_opt,
+                                &boundaries, &centroids, norm, &mut p, dim,
+                                bytes_per_plane,
+                            )
+                        };
+                        paths.push(("avx2", p, sc));
+                    }
+
+                    for (name, packed, scale) in &paths {
+                        assert_eq!(
+                            packed, &expect,
+                            "BITS={BITS} row {i} table={} path={name} packed bytes diverge",
+                            table_opt.is_some()
+                        );
+                        assert_eq!(
+                            scale.to_bits(),
+                            scale_ref.to_bits(),
+                            "BITS={BITS} row {i} table={} path={name} scale diverges: \
+                             {scale} vs {scale_ref}",
+                            table_opt.is_some()
+                        );
+                    }
                 }
             }
         }
@@ -1334,13 +1360,21 @@ mod simd_identity_tests {
         for len in [8usize, 16, 24, 64, 200, 768, 1000, 1536, 3072, 1, 5, 7, 9, 15] {
             for seed in [1u64, 0xD1536, 0xFFFF_FFFF] {
                 let row = pseudo_rows(1, len, seed);
-                let simd = simd_norm(&row);
                 let scalar = norm_sq_scalar(&row).sqrt();
-                assert_eq!(
-                    simd.to_bits(),
-                    scalar.to_bits(),
-                    "len={len} seed={seed}: norm {simd} != scalar {scalar}",
-                );
+                let mut paths: Vec<(&str, f32)> = vec![("dispatch", simd_norm(&row))];
+                #[cfg(target_arch = "x86_64")]
+                if std::arch::is_x86_feature_detected!("avx") {
+                    paths.push(("avx", unsafe { norm_sq_avx(&row) }.sqrt()));
+                }
+                #[cfg(target_arch = "aarch64")]
+                paths.push(("neon", unsafe { norm_sq_neon(&row) }.sqrt()));
+                for (name, got) in &paths {
+                    assert_eq!(
+                        got.to_bits(),
+                        scalar.to_bits(),
+                        "len={len} seed={seed} path={name}: norm {got} != scalar {scalar}",
+                    );
+                }
             }
         }
     }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -26,8 +26,6 @@
 //! plus a per-query bias correction `-<q_rot, shift>`. Net effect:
 //! same kernel, same code, better-matched codebook.
 
-use std::cmp::Ordering;
-
 use rayon::prelude::*;
 use statrs::distribution::{Beta, ContinuousCDF};
 
@@ -1334,7 +1332,7 @@ mod simd_identity_tests {
             for &rank in &[0usize, n / 20, n / 2, n - 1] {
                 let mut by_val = vals.clone();
                 let (_, v, _) = by_val.select_nth_unstable_by(rank, |a: &f32, b: &f32| {
-                    a.partial_cmp(b).unwrap_or(Ordering::Equal)
+                    a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
                 });
                 let expect = *v;
                 let mut by_key: Vec<u32> = vals.iter().copied().map(f32_sort_key).collect();

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -176,6 +176,23 @@ fn f32_from_sort_key(k: u32) -> f32 {
     f32::from_bits(k ^ mask)
 }
 
+/// Whether this target's quantize kernel reads the hoisted
+/// `centroid_orig` reconstruction table.
+///
+/// The x86 kernel computes the same values in registers (a lane permute
+/// over `centroids`, then `* inv_scale_tq[d] - shift[d]`), so building
+/// the table there is pure cost — an allocation plus `2^bits * dim` f64
+/// writes per batch, up to 384 KB at dim 3072 / 4-bit. Every kernel
+/// handles `None` by computing the same values inline, so switching the
+/// table off is always safe: it changes how the numbers are obtained,
+/// never what they are. The pre-AVX2 scalar fallback on x86 pays a
+/// recompute per element as a result, which is the correct trade on a
+/// path already an order of magnitude off the SIMD one.
+#[cfg(target_arch = "x86_64")]
+const KERNEL_USES_RECON_TABLE: bool = false;
+#[cfg(not(target_arch = "x86_64"))]
+const KERNEL_USES_RECON_TABLE: bool = true;
+
 /// Quantile pair used to fit per-coord `(shift, scale)`.
 const TQPLUS_P_LO: f64 = 0.05;
 const TQPLUS_P_HI: f64 = 0.95;
@@ -328,7 +345,8 @@ pub(crate) fn encode(
     // values inline (identical ops, identical results).
     const RECON_TABLE_MIN_ROWS: usize = 16;
     let n_codes = 1usize << bit_width;
-    let centroid_orig: Option<Vec<f64>> = (n >= RECON_TABLE_MIN_ROWS).then(|| {
+    let centroid_orig: Option<Vec<f64>> =
+        (KERNEL_USES_RECON_TABLE && n >= RECON_TABLE_MIN_ROWS).then(|| {
         let mut table = vec![0.0f64; n_codes * dim];
         for d in 0..dim {
             let inv = inv_scale_tq[d] as f64;
@@ -938,9 +956,36 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
 ) -> f32 {
     use std::arch::x86_64::*;
 
-    let mut acc_a = _mm_setzero_pd();
-    let mut acc_b = _mm_setzero_pd();
+    // Lane j of `acc4` is chain j: the two adds per chunk take terms
+    // 0..3 then 4..7, so term t lands in chain t % 4 in the same order
+    // as the scalar loop.
+    let mut acc4 = _mm256_setzero_pd();
     let chunks = dim / 8;
+    // The hoisted `centroid_orig` table is deliberately unused here: the
+    // kernel selects `centroids[code]` with a lane permute and applies
+    // `* inv_scale_tq[d] - shift[d]` in registers instead. The table
+    // holds exactly those values — it is built with exactly these ops,
+    // in this order — so the accumulated inner product is bit-identical,
+    // but reading it costs a stream of the whole 2^bits * dim * 8 byte
+    // table per row (384 KB at dim 3072, 4-bit; far past L1), where the
+    // register form touches only the two dim-length f32 arrays the
+    // kernel already walks. `encode` therefore skips building it on x86
+    // entirely (see KERNEL_USES_RECON_TABLE).
+    let _ = centroid_orig;
+    // `centroids` has 2^BITS entries; a lane permute needs an 8-lane
+    // source, so pad (BITS <= 3) or split into halves (BITS == 4).
+    let mut cpad = [0.0f32; 8];
+    let mut cpad_hi = [0.0f32; 8];
+    for (i, slot) in cpad.iter_mut().enumerate() {
+        *slot = centroids[i.min((1usize << BITS) - 1)];
+    }
+    if BITS == 4 {
+        for (i, slot) in cpad_hi.iter_mut().enumerate() {
+            *slot = centroids[8 + i];
+        }
+    }
+    let cvec = _mm256_loadu_ps(cpad.as_ptr());
+    let cvec_hi = _mm256_loadu_ps(cpad_hi.as_ptr());
 
     for c in 0..chunks {
         let offset = c * 8;
@@ -985,9 +1030,6 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
                 acc = _mm256_sub_epi32(acc, _mm256_castps_si256(gt));
             }
         }
-        let mut counts32 = [0i32; 8];
-        _mm256_storeu_si256(counts32.as_mut_ptr() as *mut __m256i, acc);
-
         // Pack: bit-plane p of this 8-coord chunk is one byte whose bit
         // (7 - k) is bit p of code k. `movemask_ps` gathers the sign bit
         // of each lane into a bit *in lane order* (lane k -> bit k), so
@@ -1005,40 +1047,43 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
             *packed_row.get_unchecked_mut(p * bytes_per_plane + c) = m;
         }
 
-        // Reconstruction terms, then the four fixed f64 chains
-        // (term j -> chain j % 4; a = {0,1}, b = {2,3}).
-        let mut terms = [0.0f64; 8];
-        match centroid_orig {
-            Some(table) => {
-                for k in 0..8 {
-                    let d = offset + k;
-                    terms[k] = (rot_orig[d] as f64)
-                        * table[d * (1 << BITS) + counts32[k] as usize];
-                }
-            }
-            None => {
-                for k in 0..8 {
-                    let d = offset + k;
-                    let centroid_in_orig = (centroids[counts32[k] as usize] as f64)
-                        * (inv_scale_tq[d] as f64)
-                        - (shift[d] as f64);
-                    terms[k] = (rot_orig[d] as f64) * centroid_in_orig;
-                }
-            }
-        }
-        acc_a = _mm_add_pd(acc_a, _mm_loadu_pd(terms.as_ptr()));
-        acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(2)));
-        acc_a = _mm_add_pd(acc_a, _mm_loadu_pd(terms.as_ptr().add(4)));
-        acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(6)));
+        // Select centroids[code] per lane, widen to f64, and apply
+        // `* inv_scale_tq[d] - shift[d]` — the same three IEEE ops, in
+        // the same order, that build the hoisted table entry.
+        let sel = if BITS == 4 {
+            let low3 = _mm256_and_si256(acc, _mm256_set1_epi32(7));
+            let lo = _mm256_permutevar8x32_ps(cvec, low3);
+            let hi = _mm256_permutevar8x32_ps(cvec_hi, low3);
+            let use_hi = _mm256_cmpgt_epi32(acc, _mm256_set1_epi32(7));
+            _mm256_blendv_ps(lo, hi, _mm256_castsi256_ps(use_hi))
+        } else {
+            _mm256_permutevar8x32_ps(cvec, acc)
+        };
+        let x_lo = _mm256_sub_pd(
+            _mm256_mul_pd(
+                _mm256_cvtps_pd(_mm256_castps256_ps128(sel)),
+                _mm256_cvtps_pd(_mm_loadu_ps(inv_scale_tq.as_ptr().add(offset))),
+            ),
+            _mm256_cvtps_pd(_mm_loadu_ps(shift.as_ptr().add(offset))),
+        );
+        let x_hi = _mm256_sub_pd(
+            _mm256_mul_pd(
+                _mm256_cvtps_pd(_mm256_extractf128_ps::<1>(sel)),
+                _mm256_cvtps_pd(_mm_loadu_ps(inv_scale_tq.as_ptr().add(offset + 4))),
+            ),
+            _mm256_cvtps_pd(_mm_loadu_ps(shift.as_ptr().add(offset + 4))),
+        );
+        let rot_lo = _mm256_cvtps_pd(_mm_loadu_ps(rot_orig.as_ptr().add(offset)));
+        let rot_hi = _mm256_cvtps_pd(_mm_loadu_ps(rot_orig.as_ptr().add(offset + 4)));
+        acc4 = _mm256_add_pd(acc4, _mm256_mul_pd(rot_lo, x_lo));
+        acc4 = _mm256_add_pd(acc4, _mm256_mul_pd(rot_hi, x_hi));
     }
 
-    // Fixed combine ((a0 + a1) + (b0 + b1)) — identical to the scalar
+    // Fixed combine ((c0 + c1) + (c2 + c3)) — identical to the scalar
     // chains' combine.
-    let mut a2 = [0.0f64; 2];
-    let mut b2 = [0.0f64; 2];
-    _mm_storeu_pd(a2.as_mut_ptr(), acc_a);
-    _mm_storeu_pd(b2.as_mut_ptr(), acc_b);
-    let inner = (a2[0] + a2[1]) + (b2[0] + b2[1]);
+    let mut chains = [0.0f64; 4];
+    _mm256_storeu_pd(chains.as_mut_ptr(), acc4);
+    let inner = (chains[0] + chains[1]) + (chains[2] + chains[3]);
     scale_from_inner(inner, norm)
 }
 

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -155,6 +155,27 @@ fn first_invalid_in_chunk_scalar(chunk: &[f32], max_magnitude: f32) -> Option<us
         .position(|x| !x.is_finite() || x.abs() >= max_magnitude)
 }
 
+/// Map a finite `f32` to a `u32` whose unsigned order matches the float's
+/// numeric order, so quantile selection can run on integers.
+///
+/// Positives keep their bit pattern with the sign bit set; negatives are
+/// complemented (their magnitude bits run backwards). The map is a
+/// bijection on non-NaN floats — [`f32_from_sort_key`] inverts it — so
+/// selecting rank `r` over the keys and converting back yields exactly
+/// the float that selecting rank `r` over the values would.
+#[inline(always)]
+fn f32_sort_key(x: f32) -> u32 {
+    let b = x.to_bits();
+    b ^ ((((b as i32) >> 31) as u32) | 0x8000_0000)
+}
+
+/// Inverse of [`f32_sort_key`].
+#[inline(always)]
+fn f32_from_sort_key(k: u32) -> f32 {
+    let mask = if k & 0x8000_0000 != 0 { 0x8000_0000 } else { 0xFFFF_FFFF };
+    f32::from_bits(k ^ mask)
+}
+
 /// Quantile pair used to fit per-coord `(shift, scale)`.
 const TQPLUS_P_LO: f64 = 0.05;
 const TQPLUS_P_HI: f64 = 0.95;
@@ -438,15 +459,22 @@ fn compute_tqplus_calibration(
     // buffers (each row contributes a contiguous 4*tile-byte read). The
     // collected values per coord are identical, so the selected quantiles
     // — and every downstream encoded byte — are unchanged.
-    // Tile size trades streaming passes against parallelism: each tile
-    // re-streams the whole rotated batch once, but tiles are also the
-    // unit of fan-out. Pick the largest power-of-two tile (<= 256) that
-    // still yields ~2 tiles per rayon worker; single-threaded runs get
-    // the full 768. The choice only affects scheduling — the collected
-    // values per coordinate, and every encoded byte, are identical for
-    // any tile size.
+    // Tile size is capped by the *write* working set of the transpose,
+    // not by parallelism. The scatter below fills `tile` destination
+    // columns concurrently, so it keeps `tile` cache lines live; each
+    // line is revisited once per row, with every other live line touched
+    // in between. Once `tile * 64` bytes exceeds L1 every store misses —
+    // measured as a ~13% loss in cold bulk insert at 768 columns versus
+    // 128. 128 columns is 8 KB of destination lines, comfortably
+    // resident, and still leaves `dim / 128` tiles to fan out over.
+    //
+    // Below that ceiling the tile is halved further while it would leave
+    // fewer than ~2 tiles per rayon worker. Total bytes read is the same
+    // for any tile size (each rotated element is read exactly once per
+    // full sweep) and the collected values per coordinate — hence every
+    // encoded byte — are identical; only locality and scheduling change.
     let workers = rayon::current_num_threads().max(1);
-    let mut tile_size = 768usize;
+    let mut tile_size = 128usize;
     while tile_size > 32 && dim / tile_size < 2 * workers {
         tile_size /= 2;
     }
@@ -457,29 +485,50 @@ fn compute_tqplus_calibration(
         .for_each(|(tile_idx, (sh_tile, sc_tile))| {
             let d0 = tile_idx * tile_size;
             let tile = sh_tile.len();
-            let mut cols = vec![0.0f32; tile * n];
+            // The column scratch is fully written by the scatter below
+            // before anything reads it, so skip the zero-fill: at dim
+            // 1536 / n 100k this is a 300 MB memset (and its page-fault
+            // walk) per tile, paid purely to be overwritten.
+            // SAFETY: u32 has no invalid bit patterns, and every one of
+            // the `tile * n` slots is assigned in the scatter loop.
+            let mut cols: Vec<u32> = Vec::with_capacity(tile * n);
+            #[allow(clippy::uninit_vec)]
+            unsafe {
+                cols.set_len(tile * n);
+            }
+            // Values are transposed as order-preserving integer keys, not
+            // as floats: quickselect over `u32` uses the native `Ord`
+            // and integer compares instead of a `partial_cmp` closure
+            // that has to handle an unordered case which cannot occur
+            // (`add` rejects non-finite input, and the rotation is
+            // add/sub/scale, so every rotated coordinate is finite).
+            // `f32_sort_key` is monotone on finite floats, so the element
+            // selected at a given rank — and therefore the fitted
+            // calibration and every encoded byte — is unchanged. The one
+            // pair the orderings disagree on is -0.0 vs +0.0, which
+            // `partial_cmp` calls equal; both map to the same quantile
+            // arithmetic below (`x - -0.0` and `x - 0.0` agree for every
+            // finite x), so that case is a wash too.
             for i in 0..n {
                 let row = &rotated[i * dim + d0..i * dim + d0 + tile];
                 for (c, &v) in row.iter().enumerate() {
-                    cols[c * n + i] = v;
+                    cols[c * n + i] = f32_sort_key(v);
                 }
             }
             for (c, (sh, sc)) in sh_tile.iter_mut().zip(sc_tile.iter_mut()).enumerate() {
                 let coord = &mut cols[c * n..(c + 1) * n];
                 // Only the two quantile order statistics are needed, so
                 // two O(n) selects replace a full O(n log n) sort.
-                let cmp = |a: &f32, b: &f32| a.partial_cmp(b).unwrap_or(Ordering::Equal);
                 // Select the LOW quantile first: its partition splits
                 // off only ~5% of the data, so the second (high) select
                 // runs over the ~95% right side — total elements
                 // partitioned is the same, but the first partition's
                 // pivot walks terminate sooner. Selected values are
                 // identical to indexing a fully sorted array.
-                let (_, lo_val, right) = coord.select_nth_unstable_by(lo_idx, cmp);
-                let qe_lo = *lo_val;
-                let (_, hi_val, _) =
-                    right.select_nth_unstable_by(hi_idx - lo_idx - 1, cmp);
-                let qe_hi = *hi_val;
+                let (_, lo_val, right) = coord.select_nth_unstable(lo_idx);
+                let qe_lo = f32_from_sort_key(*lo_val);
+                let (_, hi_val, _) = right.select_nth_unstable(hi_idx - lo_idx - 1);
+                let qe_hi = f32_from_sort_key(*hi_val);
                 let qe_span = qe_hi - qe_lo;
                 if qe_span > 1e-6 {
                     *sc = qc_span / qe_span;
@@ -1169,6 +1218,63 @@ mod simd_identity_tests {
         run::<4>(1536);
         run::<2>(3072);
         run::<4>(3072);
+    }
+
+    /// The integer sort key used for quantile selection must be a
+    /// strictly order-preserving bijection on finite floats — otherwise
+    /// the fitted calibration silently changes.
+    #[test]
+    fn f32_sort_key_is_order_preserving_and_invertible() {
+        let mut vals: Vec<f32> = pseudo_rows(1, 4096, 0xC0FFEE);
+        vals.extend_from_slice(&[
+            0.0, -0.0, 1.0, -1.0, f32::MIN_POSITIVE, -f32::MIN_POSITIVE,
+            f32::MAX, f32::MIN, 1e-30, -1e-30, 3.5, -3.5,
+        ]);
+        for &x in &vals {
+            assert_eq!(
+                f32_from_sort_key(f32_sort_key(x)).to_bits(),
+                x.to_bits(),
+                "round-trip failed for {x}",
+            );
+        }
+        for &a in &vals {
+            for &b in &vals {
+                // -0.0 vs 0.0 is the documented exception: numerically
+                // equal, but the keys order them. Every other pair must
+                // agree with the float ordering.
+                if a == 0.0 && b == 0.0 {
+                    continue;
+                }
+                assert_eq!(
+                    f32_sort_key(a) < f32_sort_key(b),
+                    a < b,
+                    "key order disagrees for ({a}, {b})",
+                );
+            }
+        }
+    }
+
+    /// Selecting a rank over the keys must return the same float as
+    /// selecting the same rank over the values.
+    #[test]
+    fn key_selection_matches_float_selection() {
+        for n in [1usize, 2, 17, 1000, 4096] {
+            let vals = pseudo_rows(1, n, 0xBEEF ^ n as u64);
+            for &rank in &[0usize, n / 20, n / 2, n - 1] {
+                let mut by_val = vals.clone();
+                let (_, v, _) = by_val.select_nth_unstable_by(rank, |a: &f32, b: &f32| {
+                    a.partial_cmp(b).unwrap_or(Ordering::Equal)
+                });
+                let expect = *v;
+                let mut by_key: Vec<u32> = vals.iter().copied().map(f32_sort_key).collect();
+                let (_, k, _) = by_key.select_nth_unstable(rank);
+                assert_eq!(
+                    f32_from_sort_key(*k).to_bits(),
+                    expect.to_bits(),
+                    "n={n} rank={rank}",
+                );
+            }
+        }
     }
 
     /// The per-vector norm feeds `1/||v||` into the first rotation

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -492,35 +492,135 @@ fn compute_tqplus_calibration(
     (shift, scale)
 }
 
-// ─── Norm and scale (aarch64) ────────────────────────────────────────────────
+// ─── Per-vector norm ─────────────────────────────────────────────────────────
 
-#[cfg(target_arch = "aarch64")]
+/// Number of independent accumulation chains in the canonical norm
+/// reduction. Element `j` joins chain `j % NORM_CHAINS`.
+///
+/// DO NOT CHANGE without treating it as a format change: the reduction
+/// order is part of the encode contract (see [`simd_norm`]). Eight is the
+/// widest split every supported vector width can express exactly — one
+/// `__m256`, two NEON `float32x4_t`, or eight scalars — and `dim` is
+/// always a multiple of 8, so no index path ever reaches the tail.
+const NORM_CHAINS: usize = 8;
+
+/// Euclidean norm of one row, with a **fixed, architecture-independent
+/// reduction order**.
+///
+/// This is the vector's `1/||v||` normalization factor, which rides the
+/// first rotation gather — so its low bits reach every encoded byte. The
+/// order is therefore part of the format contract, exactly like the
+/// rotation's:
+///
+/// ```text
+/// c[j % 8] += row[j] * row[j]      (separate multiply and add, never an FMA)
+/// sum       = ((c0 + c1) + (c2 + c3)) + ((c4 + c5) + (c6 + c7))
+/// norm      = sqrt(sum)
+/// ```
+///
+/// The previous implementation was per-architecture and *not* equivalent
+/// across them: aarch64 accumulated four chains with `vfmaq_f32` (a fused
+/// multiply-add, one rounding instead of two) while every other target
+/// summed left-to-right in a single chain. The two can disagree in the
+/// last ulp, which is the remaining cross-platform encode input flagged in
+/// the v5 determinism scope (#259, finding 1). Pinning one order closes it
+/// by construction rather than by observation.
+///
+/// It is also considerably faster than the sequential sum it replaces on
+/// x86: eight independent chains hide the f32 add latency that a single
+/// accumulator serializes on.
+///
+/// `sqrt` is IEEE-754 correctly rounded (a hardware instruction on every
+/// supported target), so it introduces no platform variance.
 #[inline(always)]
 fn simd_norm(row: &[f32]) -> f32 {
-    use std::arch::aarch64::*;
-    let dim = row.len();
-    let chunks = dim / 4;
-    let mut acc = unsafe { vdupq_n_f32(0.0) };
-
-    unsafe {
-        for c in 0..chunks {
-            let v = vld1q_f32(row.as_ptr().add(c * 4));
-            acc = vfmaq_f32(acc, v, v);
+    #[cfg(target_arch = "x86_64")]
+    {
+        if std::arch::is_x86_feature_detected!("avx") {
+            return unsafe { norm_sq_avx(row) }.sqrt();
         }
-        let mut sum = vaddvq_f32(acc);
-        for j in (chunks * 4)..dim {
-            sum += row[j] * row[j];
-        }
-        sum.sqrt()
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        return unsafe { norm_sq_neon(row) }.sqrt();
+    }
+    #[allow(unreachable_code)]
+    {
+        norm_sq_scalar(row).sqrt()
     }
 }
 
-// ─── Norm and scale (fallback) ───────────────────────────────────────────────
+/// Reference reduction. Every SIMD path must reproduce it bit-for-bit —
+/// enforced by `norm_simd_matches_scalar_bit_exactly`.
+#[inline]
+fn norm_sq_scalar(row: &[f32]) -> f32 {
+    let mut chains = [0.0f32; NORM_CHAINS];
+    for (j, &x) in row.iter().enumerate() {
+        chains[j % NORM_CHAINS] += x * x;
+    }
+    combine_norm_chains(&chains)
+}
 
-#[cfg(not(target_arch = "aarch64"))]
+/// The frozen combine tree over the eight chains.
 #[inline(always)]
-fn simd_norm(row: &[f32]) -> f32 {
-    row.iter().map(|x| x * x).sum::<f32>().sqrt()
+fn combine_norm_chains(c: &[f32; NORM_CHAINS]) -> f32 {
+    ((c[0] + c[1]) + (c[2] + c[3])) + ((c[4] + c[5]) + (c[6] + c[7]))
+}
+
+/// AVX: the eight chains are the eight lanes of one `__m256`. `mul` then
+/// `add` as separate instructions — never `vfmadd` — so each element is
+/// rounded twice, matching the scalar reference.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx")]
+unsafe fn norm_sq_avx(row: &[f32]) -> f32 {
+    use std::arch::x86_64::*;
+    let n = row.len();
+    let mut acc = _mm256_setzero_ps();
+    let mut i = 0;
+    while i + NORM_CHAINS <= n {
+        let v = _mm256_loadu_ps(row.as_ptr().add(i));
+        acc = _mm256_add_ps(acc, _mm256_mul_ps(v, v));
+        i += NORM_CHAINS;
+    }
+    let mut chains = [0.0f32; NORM_CHAINS];
+    _mm256_storeu_ps(chains.as_mut_ptr(), acc);
+    // `dim` is a multiple of 8 on every index path, so this tail is dead
+    // there; it keeps the helper correct for arbitrary lengths.
+    while i < n {
+        let x = *row.get_unchecked(i);
+        chains[i % NORM_CHAINS] += x * x;
+        i += 1;
+    }
+    combine_norm_chains(&chains)
+}
+
+/// NEON: the eight chains are two `float32x4_t` accumulators. `vmulq` +
+/// `vaddq` rather than `vfmaq` — the fused form rounds once and would not
+/// match the scalar reference (this is #259 finding 1).
+#[cfg(target_arch = "aarch64")]
+#[target_feature(enable = "neon")]
+unsafe fn norm_sq_neon(row: &[f32]) -> f32 {
+    use std::arch::aarch64::*;
+    let n = row.len();
+    let mut acc_lo = vdupq_n_f32(0.0);
+    let mut acc_hi = vdupq_n_f32(0.0);
+    let mut i = 0;
+    while i + NORM_CHAINS <= n {
+        let lo = vld1q_f32(row.as_ptr().add(i));
+        let hi = vld1q_f32(row.as_ptr().add(i + 4));
+        acc_lo = vaddq_f32(acc_lo, vmulq_f32(lo, lo));
+        acc_hi = vaddq_f32(acc_hi, vmulq_f32(hi, hi));
+        i += NORM_CHAINS;
+    }
+    let mut chains = [0.0f32; NORM_CHAINS];
+    vst1q_f32(chains.as_mut_ptr(), acc_lo);
+    vst1q_f32(chains.as_mut_ptr().add(4), acc_hi);
+    while i < n {
+        let x = *row.get_unchecked(i);
+        chains[i % NORM_CHAINS] += x * x;
+        i += 1;
+    }
+    combine_norm_chains(&chains)
 }
 
 // ─── Fused quantize + scale + pack (aarch64) ────────────────────────────────
@@ -1069,6 +1169,51 @@ mod simd_identity_tests {
         run::<4>(1536);
         run::<2>(3072);
         run::<4>(3072);
+    }
+
+    /// The per-vector norm feeds `1/||v||` into the first rotation
+    /// gather, so its low bits reach every encoded byte: the SIMD
+    /// reduction must reproduce the frozen scalar chain order exactly.
+    /// A regression here is a silent cross-platform format divergence
+    /// (#259 finding 1), not a rounding nit.
+    #[test]
+    fn norm_simd_matches_scalar_bit_exactly() {
+        // Multiples of 8 (every index path) plus non-multiples and
+        // sub-chain lengths, which exercise the scalar tail.
+        for len in [8usize, 16, 24, 64, 200, 768, 1000, 1536, 3072, 1, 5, 7, 9, 15] {
+            for seed in [1u64, 0xD1536, 0xFFFF_FFFF] {
+                let row = pseudo_rows(1, len, seed);
+                let simd = simd_norm(&row);
+                let scalar = norm_sq_scalar(&row).sqrt();
+                assert_eq!(
+                    simd.to_bits(),
+                    scalar.to_bits(),
+                    "len={len} seed={seed}: norm {simd} != scalar {scalar}",
+                );
+            }
+        }
+    }
+
+    /// The frozen reduction order, pinned against hand-computed values.
+    /// Catches a change to `NORM_CHAINS` or to the combine tree — either
+    /// of which silently re-encodes every future index differently from
+    /// one built by an earlier build.
+    #[test]
+    fn norm_reduction_order_is_frozen() {
+        // 16 elements: chains are (j, j+8) pairs.
+        let row: Vec<f32> = (0..16).map(|i| (i as f32) + 1.0).collect();
+        let mut chains = [0.0f32; NORM_CHAINS];
+        for (j, &x) in row.iter().enumerate() {
+            chains[j % NORM_CHAINS] += x * x;
+        }
+        let expect =
+            (((chains[0] + chains[1]) + (chains[2] + chains[3]))
+                + ((chains[4] + chains[5]) + (chains[6] + chains[7])))
+                .sqrt();
+        assert_eq!(simd_norm(&row).to_bits(), expect.to_bits());
+        // sum of squares 1..16 = 1496; sqrt is exact enough to state.
+        assert_eq!(NORM_CHAINS, 8, "NORM_CHAINS is part of the encode contract");
+        assert!((simd_norm(&row) - 1496.0f32.sqrt()).abs() < 1e-3);
     }
 
     /// The vector validation predicate must agree with the scalar scan on

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -365,7 +365,7 @@ pub(crate) fn encode(
     let packed_old = packed_out.len();
     let scales_old = scales_out.len();
     {
-        // Every kernel — NEON, AVX-512, AVX2, and the scalar fallback —
+        // Every quantize kernel — NEON, AVX2, and the scalar fallback —
         // stores whole bytes (one store per plane per 8-coord chunk)
         // rather than OR-ing bits into a pre-zeroed row, so the
         // bytes_per_row * n zero-fill is dead work.
@@ -502,9 +502,10 @@ fn compute_tqplus_calibration(
             let d0 = tile_idx * tile_size;
             let tile = sh_tile.len();
             // The column scratch is fully written by the scatter below
-            // before anything reads it, so skip the zero-fill: at dim
-            // 1536 / n 100k this is a 300 MB memset (and its page-fault
-            // walk) per tile, paid purely to be overwritten.
+            // before anything reads it, so skip the zero-fill: at the
+            // 128-coordinate tile ceiling and n 100k this is a ~51 MB
+            // memset (and its page-fault walk) per tile, paid purely to
+            // be overwritten.
             // SAFETY: u32 has no invalid bit patterns, and every one of
             // the `tile * n` slots is assigned in the scatter loop.
             let mut cols: Vec<u32> = Vec::with_capacity(tile * n);
@@ -1238,11 +1239,12 @@ mod simd_identity_tests {
                         bytes_per_plane,
                     );
 
-                    // Every implementation this host can run, not just the
-                    // dispatched one: on a machine with AVX-512 the
-                    // dispatcher never selects the AVX2 kernel, so a
-                    // dispatch-only test leaves it unexercised on exactly
-                    // the CI runners that outrank it.
+                    // Every implementation this host can run, not just
+                    // the dispatched one. (Unlike the rotation, the
+                    // quantize dispatcher has no AVX-512 tier, so AVX2 is
+                    // what it picks here — but asserting each kernel
+                    // explicitly keeps the test honest if a tier is added,
+                    // and pins the scalar reference either way.)
                     let mut paths: Vec<(&str, Vec<u8>, f32)> = Vec::new();
                     {
                         let mut p = vec![0u8; bytes_per_row];

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -291,18 +291,30 @@ pub(crate) fn encode(
     // exactly the ops the kernel performed per element, so the
     // accumulated inner products — and the stored scales — are
     // bit-identical.
+    //
+    // Layout is **coordinate-major** (`table[d * n_codes + code]`). The
+    // kernel walks `d` in order and looks up one entry per coordinate, so
+    // coordinate-major makes those lookups a single sequential stream —
+    // 8 * n_codes * 8 bytes per chunk — instead of `n_codes` streams
+    // strided `dim * 8` bytes apart. At 4 bits that is 16 concurrent
+    // streams over a 2^bits * dim * 8 byte table (384 KB at dim 3072),
+    // which outruns the L1 and the prefetcher; coordinate-major touches
+    // each cache line once. Same values, so the encoded bytes are
+    // unchanged.
+    //
     // The table costs O(2^bits * dim) to build, so it only pays once the
     // batch is a few rows deep; below that the kernel computes the same
     // values inline (identical ops, identical results).
     const RECON_TABLE_MIN_ROWS: usize = 16;
+    let n_codes = 1usize << bit_width;
     let centroid_orig: Option<Vec<f64>> = (n >= RECON_TABLE_MIN_ROWS).then(|| {
-        let n_codes = 1usize << bit_width;
         let mut table = vec![0.0f64; n_codes * dim];
-        for c in 0..n_codes {
-            let row = &mut table[c * dim..(c + 1) * dim];
-            for d in 0..dim {
-                row[d] =
-                    (centroids[c] as f64) * (inv_scale_tq[d] as f64) - (shift[d] as f64);
+        for d in 0..dim {
+            let inv = inv_scale_tq[d] as f64;
+            let sh = shift[d] as f64;
+            let row = &mut table[d * n_codes..(d + 1) * n_codes];
+            for (c, slot) in row.iter_mut().enumerate() {
+                *slot = (centroids[c] as f64) * inv - sh;
             }
         }
         table
@@ -315,10 +327,11 @@ pub(crate) fn encode(
     // extend_from_slice copy afterwards.
     let packed_old = packed_out.len();
     let scales_old = scales_out.len();
-    #[cfg(target_arch = "aarch64")]
     {
-        // The NEON kernel stores every byte of each packed row (one store
-        // per plane per 8-coord chunk), so the zero-fill is dead work.
+        // Every kernel — NEON, AVX-512, AVX2, and the scalar fallback —
+        // stores whole bytes (one store per plane per 8-coord chunk)
+        // rather than OR-ing bits into a pre-zeroed row, so the
+        // bytes_per_row * n zero-fill is dead work.
         // SAFETY: u8 has no invalid bit patterns, and fused_quantize_
         // scale_pack overwrites all bytes_per_row bytes of every row
         // before the region is read.
@@ -328,10 +341,6 @@ pub(crate) fn encode(
             packed_out.set_len(packed_old + n * bytes_per_row);
         }
     }
-    // The scalar fallback ORs bits into the packed row, so it needs the
-    // zero-filled region.
-    #[cfg(not(target_arch = "aarch64"))]
-    packed_out.resize(packed_old + n * bytes_per_row, 0u8);
     scales_out.resize(scales_old + n, 0.0f32);
     let packed = &mut packed_out[packed_old..];
     let scales = &mut scales_out[scales_old..];
@@ -636,7 +645,7 @@ fn fused_quantize_scale_pack<const BITS: usize>(
                     for k in 0..8 {
                         let d = offset + k;
                         terms[k] = (rot_orig[d] as f64)
-                            * table[counts[k] as usize * dim + d];
+                            * table[d * (1 << BITS) + counts[k] as usize];
                     }
                 }
                 None => {
@@ -830,6 +839,23 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
         let mut counts32 = [0i32; 8];
         _mm256_storeu_si256(counts32.as_mut_ptr() as *mut __m256i, acc);
 
+        // Pack: bit-plane p of this 8-coord chunk is one byte whose bit
+        // (7 - k) is bit p of code k. `movemask_ps` gathers the sign bit
+        // of each lane into a bit *in lane order* (lane k -> bit k), so
+        // the lanes are reversed once up front; then each plane is a
+        // shift-to-sign-bit plus a movemask. Same bits, same positions as
+        // the scalar `byte |= ((code >> p) & 1) << (7 - k)` loop, minus
+        // the 8 read-modify-writes per byte.
+        let rev = _mm256_permutevar8x32_epi32(
+            acc,
+            _mm256_setr_epi32(7, 6, 5, 4, 3, 2, 1, 0),
+        );
+        for p in 0..BITS {
+            let bit = _mm256_sll_epi32(rev, _mm_cvtsi32_si128(31 - p as i32));
+            let m = _mm256_movemask_ps(_mm256_castsi256_ps(bit)) as u8;
+            *packed_row.get_unchecked_mut(p * bytes_per_plane + c) = m;
+        }
+
         // Reconstruction terms, then the four fixed f64 chains
         // (term j -> chain j % 4; a = {0,1}, b = {2,3}).
         let mut terms = [0.0f64; 8];
@@ -838,7 +864,7 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
                 for k in 0..8 {
                     let d = offset + k;
                     terms[k] = (rot_orig[d] as f64)
-                        * table[counts32[k] as usize * dim + d];
+                        * table[d * (1 << BITS) + counts32[k] as usize];
                 }
             }
             None => {
@@ -855,19 +881,6 @@ unsafe fn fused_quantize_scale_pack_avx2<const BITS: usize>(
         acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(2)));
         acc_a = _mm_add_pd(acc_a, _mm_loadu_pd(terms.as_ptr().add(4)));
         acc_b = _mm_add_pd(acc_b, _mm_loadu_pd(terms.as_ptr().add(6)));
-
-        // Pack (scalar OR into the zeroed row, as the scalar kernel).
-        for k in 0..8 {
-            let j = offset + k;
-            let code = counts32[k] as u8;
-            let byte_pos = j / 8;
-            let bit_pos = 7 - (j % 8);
-            for p in 0..BITS {
-                if code & (1 << p) != 0 {
-                    packed_row[p * bytes_per_plane + byte_pos] |= 1 << bit_pos;
-                }
-            }
-        }
     }
 
     // Fixed combine ((a0 + a1) + (b0 + b1)) — identical to the scalar
@@ -924,31 +937,44 @@ fn fused_quantize_scale_pack_scalar<const BITS: usize>(
     // combine ((c0 + c1) + (c2 + c3))).
     let mut chains = [0.0f64; 4];
 
-    for j in 0..dim {
-        let calib = (rot_orig[j] + shift[j]) * scale_tq[j];
-        let mut code = 0u8;
-        for bi in 0..(1usize << BITS) - 1 {
-            if calib > boundaries[bi] { code += 1; }
+    // One 8-coordinate chunk per iteration: the eight codes are resolved
+    // first, then each bit-plane byte is *stored* whole. The previous
+    // form OR-ed one bit at a time into a pre-zeroed row — 8 read-modify-
+    // writes per byte plus a batch-wide memset. Same bits land in the
+    // same positions, so the packed bytes are unchanged; `encode` no
+    // longer has to zero the region first.
+    let chunks = dim / 8;
+    for c in 0..chunks {
+        let offset = c * 8;
+        let mut codes = [0u8; 8];
+        for (k, code) in codes.iter_mut().enumerate() {
+            let j = offset + k;
+            let calib = (rot_orig[j] + shift[j]) * scale_tq[j];
+            let mut v = 0u8;
+            for bi in 0..(1usize << BITS) - 1 {
+                if calib > boundaries[bi] { v += 1; }
+            }
+            *code = v;
+            // Same table-or-inline split as the aarch64 kernel; identical
+            // ops either way, so results are bit-identical.
+            let centroid_in_orig = match centroid_orig {
+                Some(table) => table[j * (1 << BITS) + v as usize],
+                None => {
+                    (centroids[v as usize] as f64) * (inv_scale_tq[j] as f64)
+                        - (shift[j] as f64)
+                }
+            };
+            chains[j % 4] += (rot_orig[j] as f64) * centroid_in_orig;
         }
-        // Same table-or-inline split as the aarch64 kernel; identical
-        // ops either way, so results are bit-identical.
-        let centroid_in_orig = match centroid_orig {
-            Some(table) => table[code as usize * dim + j],
-            None => {
-                (centroids[code as usize] as f64) * (inv_scale_tq[j] as f64)
-                    - (shift[j] as f64)
-            }
-        };
-        chains[j % 4] += (rot_orig[j] as f64) * centroid_in_orig;
-
-        let byte_pos = j / 8;
-        let bit_pos = 7 - (j % 8);
         for p in 0..BITS {
-            if code & (1 << p) != 0 {
-                packed_row[p * bytes_per_plane + byte_pos] |= 1 << bit_pos;
+            let mut byte = 0u8;
+            for (k, &code) in codes.iter().enumerate() {
+                byte |= ((code >> p) & 1) << (7 - k);
             }
+            packed_row[p * bytes_per_plane + c] = byte;
         }
     }
+    // No tail loop: `encode` asserts dim % 8 == 0, so chunks * 8 == dim.
 
     let inner = (chains[0] + chains[1]) + (chains[2] + chains[3]);
     scale_from_inner(inner, norm)
@@ -991,7 +1017,8 @@ mod simd_identity_tests {
                 let mut t = vec![0.0f64; n_codes * dim];
                 for c in 0..n_codes {
                     for d in 0..dim {
-                        t[c * dim + d] = (centroids[c] as f64) * (inv_scale_tq[d] as f64)
+                        t[d * n_codes + c] = (centroids[c] as f64)
+                            * (inv_scale_tq[d] as f64)
                             - (shift[d] as f64);
                     }
                 }

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -121,6 +121,27 @@ impl Rotation {
     /// Build the rotation for `dim` (a positive multiple of 8).
     pub fn new(dim: usize) -> Self {
         assert!(dim > 0 && dim % 8 == 0, "rotation dim must be a positive multiple of 8");
+        // Bound `dim` here, not just at the index types. This module is
+        // public, so `Rotation::new` is reachable without going through
+        // `TurboQuantIndex` (which enforces the same bound) — and past
+        // this limit the SIMD gather stops being merely wrong and becomes
+        // unsound:
+        //
+        // * above 2^31, the permutation indices are handed to
+        //   `_mm{256,512}_i32gather_ps`, which treats them as *signed*
+        //   i32 — a large index sign-extends into a wild negative offset;
+        // * at 2^32 and above, `fisher_yates` truncates the permutation
+        //   into `u32` outright.
+        //
+        // Neither is reachable in a real deployment (2^31 coordinates is
+        // ~9 GB for one vector), and both were merely logic bugs before
+        // the gather existed. They are memory-unsafety now, so the guard
+        // is an assert rather than a comment.
+        assert!(
+            dim <= crate::MAX_DIM,
+            "rotation dim {dim} exceeds MAX_DIM ({})",
+            crate::MAX_DIM,
+        );
         let block = block_size(dim);
         let inv_sqrt_block = 1.0 / (block as f32).sqrt();
 
@@ -305,9 +326,14 @@ fn permute_gather<const MODE: usize>(
     inv: f32,
     dst: &mut [f32],
 ) {
-    debug_assert_eq!(src.len(), dst.len());
-    debug_assert_eq!(perm.len(), dst.len());
-    debug_assert_eq!(signs.len(), dst.len());
+    // Not `debug_assert`: the SIMD bodies below index `src` through a
+    // hardware gather and read `perm`/`signs` with `get_unchecked`, so a
+    // length mismatch is an out-of-bounds read in release, which is
+    // exactly the build where a `debug_assert` is absent. Three integer
+    // compares against work that is O(dim) gathers.
+    assert_eq!(src.len(), dst.len(), "permute_gather: src length must equal dst");
+    assert_eq!(perm.len(), dst.len(), "permute_gather: perm length must equal dst");
+    assert_eq!(signs.len(), dst.len(), "permute_gather: signs length must equal dst");
     #[cfg(target_arch = "x86_64")]
     {
         // Hardware gather replaces the per-element load-index/load-value
@@ -1015,11 +1041,14 @@ pub(crate) mod tests {
         // on every architecture, for every block-size regime the stage
         // scheduler has (8 = min block, 16/128/1024 = radix-4 tail,
         // 32/64/256/512 = other radix-8/leftover mixes).
-        for block in [8usize, 16, 32, 64, 128, 256, 512, 1024] {
+        // Up to MAX_DIM's largest block (16384), not just 1024: the
+        // radix-8/4/2 stage scheduler picks a different tail per regime
+        // and the wider blocks were previously only hand-checked.
+        for block in [8usize, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384] {
             let inv = 1.0 / (block as f32).sqrt();
             // Deterministic pseudo-random input.
             let mut x = 0x9E3779B97F4A7C15u64;
-            let mut buf: Vec<f32> = (0..block)
+            let buf: Vec<f32> = (0..block)
                 .map(|_| {
                     x ^= x << 13;
                     x ^= x >> 7;
@@ -1074,7 +1103,12 @@ pub(crate) mod tests {
     #[test]
     fn permute_gather_paths_match_scalar_bit_exactly() {
         require_simd_features();
-        for dim in [8usize, 16, 24, 64, 200, 1536] {
+        // 12 and 13 are not multiples of 8, so they are the only cases
+        // that reach the scalar tail loops after the 16- and 8-wide
+        // bodies — the ones that index with `get_unchecked`. Every index
+        // path uses a multiple of 8, so without these the unchecked tail
+        // is never executed by any test.
+        for dim in [8usize, 12, 13, 16, 24, 64, 200, 1536] {
             let mut x = 0x243F_6A88_85A3_08D3u64 ^ dim as u64;
             let mut next = || {
                 x ^= x << 13;

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -1103,12 +1103,18 @@ pub(crate) mod tests {
     #[test]
     fn permute_gather_paths_match_scalar_bit_exactly() {
         require_simd_features();
-        // 12 and 13 are not multiples of 8, so they are the only cases
-        // that reach the scalar tail loops after the 16- and 8-wide
-        // bodies — the ones that index with `get_unchecked`. Every index
-        // path uses a multiple of 8, so without these the unchecked tail
-        // is never executed by any test.
-        for dim in [8usize, 12, 13, 16, 24, 64, 200, 1536] {
+        // Non-multiples of 8 are the only cases that reach the scalar
+        // tail loops — the ones that index with `get_unchecked`. Every
+        // real index path uses a multiple of 8, so without these the
+        // unchecked tail is never executed by any test.
+        //
+        // The three sizes are not interchangeable: 12 and 13 are below
+        // 16, so the AVX-512 path skips its wide body entirely and falls
+        // to the 8-wide loop plus a scalar tail; 29 is the only one that
+        // runs all three stages in sequence (one 16-wide body, one
+        // 8-wide, then a 5-element scalar tail), which is the arrangement
+        // where an off-by-one in the stage hand-off would actually bite.
+        for dim in [8usize, 12, 13, 16, 24, 29, 64, 200, 1536] {
             let mut x = 0x243F_6A88_85A3_08D3u64 ^ dim as u64;
             let mut next = || {
                 x ^= x << 13;

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -312,7 +312,9 @@ fn permute_gather<const MODE: usize>(
     {
         // Hardware gather replaces the per-element load-index/load-value
         // pair; the surrounding multiplies are unchanged.
-        if std::arch::is_x86_feature_detected!("avx512f") {
+        if std::arch::is_x86_feature_detected!("avx512f")
+            && std::arch::is_x86_feature_detected!("avx2")
+        {
             unsafe { return permute_gather_avx512::<MODE>(src, perm, signs, inv, dst) }
         } else if std::arch::is_x86_feature_detected!("avx2") {
             unsafe { return permute_gather_avx2::<MODE>(src, perm, signs, inv, dst) }
@@ -379,8 +381,13 @@ unsafe fn permute_gather_avx2<const MODE: usize>(
     }
 }
 
+// `avx2` as well as `avx512f`: the sub-16 tail below gathers with
+// `_mm256_i32gather_ps`, which is an AVX2 instruction. Every real
+// AVX-512F implementation also has AVX2, but declaring only `avx512f`
+// while executing AVX2 would be a lie the compiler is entitled to act
+// on — and the dispatcher tests both features to match.
 #[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f", enable = "avx2")]
 unsafe fn permute_gather_avx512<const MODE: usize>(
     src: &[f32],
     perm: &[u32],
@@ -585,7 +592,9 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     // butterflies within a stage touch disjoint elements, so results are
     // bit-identical to the scalar loop (the same property the NEON path
     // relies on). is_x86_feature_detected caches after the first call.
-    if std::arch::is_x86_feature_detected!("avx512f") {
+    if std::arch::is_x86_feature_detected!("avx512f")
+        && std::arch::is_x86_feature_detected!("avx2")
+    {
         unsafe { wht_block_avx512(blk, block, inv_sqrt_block) }
     } else if std::arch::is_x86_feature_detected!("avx2") {
         unsafe { wht_block_avx2(blk, block, inv_sqrt_block) }
@@ -748,8 +757,11 @@ unsafe fn wht_block_avx2(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
 /// pairs, same expression trees, same f32 roundings as the scalar
 /// ladder — enforced against it by `wht_simd_matches_scalar_bit_exactly`
 /// at every block size.
+// `avx2` as well as `avx512f`: a block of 8 has no room for a 16-lane
+// register and is handed to the AVX2 kernel below. See the note on
+// `permute_gather_avx512` for why the declaration has to say so.
 #[cfg(target_arch = "x86_64")]
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f", enable = "avx2")]
 unsafe fn wht_block_avx512(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     use std::arch::x86_64::*;
     debug_assert!(block >= 8 && block.is_power_of_two());
@@ -994,7 +1006,9 @@ mod tests {
                     unsafe { wht_block_avx2(&mut b, block, inv) };
                     checked.push(("avx2", b));
                 }
-                if std::arch::is_x86_feature_detected!("avx512f") {
+                if std::arch::is_x86_feature_detected!("avx512f")
+                    && std::arch::is_x86_feature_detected!("avx2")
+                {
                     let mut b = buf.clone();
                     unsafe { wht_block_avx512(&mut b, block, inv) };
                     checked.push(("avx512", b));
@@ -1056,7 +1070,9 @@ mod tests {
                                        expect.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
                                        "dim {} mode {} avx2", dim, $mode);
                         }
-                        if std::arch::is_x86_feature_detected!("avx512f") {
+                        if std::arch::is_x86_feature_detected!("avx512f")
+                            && std::arch::is_x86_feature_detected!("avx2")
+                        {
                             let mut g = vec![0.0f32; dim];
                             unsafe {
                                 permute_gather_avx512::<$mode>(&src, &perm, &signs, inv, &mut g)

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -1033,7 +1033,7 @@ mod tests {
             // A real permutation, so the gather covers every source slot.
             let mut rng = ChaCha8Rng::from_seed(ROTATION_SEED);
             let perm = fisher_yates(dim, &mut rng);
-            let inv = 0.318_309_886_f32;
+            let inv = 0.812_5_f32;
 
             macro_rules! check_mode {
                 ($mode:literal) => {{

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -975,14 +975,102 @@ mod tests {
                 .collect();
             let mut expect = buf.clone();
             wht_block_scalar(&mut expect, block, inv);
-            wht_block(&mut buf, block, inv);
-            for (i, (a, b)) in buf.iter().zip(expect.iter()).enumerate() {
-                assert_eq!(
-                    a.to_bits(),
-                    b.to_bits(),
-                    "block {block} lane {i}: SIMD {a} != scalar {b}"
-                );
+
+            // Check *every* implementation this host can run, not just
+            // the one dispatch would pick. On a machine with AVX-512 the
+            // dispatcher never reaches the AVX2 kernel, so testing only
+            // the dispatched path leaves whichever kernels the CI runner
+            // outranks completely unexercised — and they are the ones
+            // most users run.
+            let mut checked = vec![("dispatch", {
+                let mut b = buf.clone();
+                wht_block(&mut b, block, inv);
+                b
+            })];
+            #[cfg(target_arch = "x86_64")]
+            {
+                if std::arch::is_x86_feature_detected!("avx2") {
+                    let mut b = buf.clone();
+                    unsafe { wht_block_avx2(&mut b, block, inv) };
+                    checked.push(("avx2", b));
+                }
+                if std::arch::is_x86_feature_detected!("avx512f") {
+                    let mut b = buf.clone();
+                    unsafe { wht_block_avx512(&mut b, block, inv) };
+                    checked.push(("avx512", b));
+                }
             }
+            for (name, got) in &checked {
+                for (i, (a, b)) in got.iter().zip(expect.iter()).enumerate() {
+                    assert_eq!(
+                        a.to_bits(),
+                        b.to_bits(),
+                        "block {block} lane {i}: {name} {a} != scalar {b}"
+                    );
+                }
+            }
+            buf.copy_from_slice(&expect);
+        }
+    }
+
+    /// The permutation gather has the same problem as the butterfly: the
+    /// dispatcher hides whichever paths the host outranks. Check them all
+    /// against the scalar reference, in every multiply mode.
+    #[test]
+    fn permute_gather_paths_match_scalar_bit_exactly() {
+        for dim in [8usize, 16, 24, 64, 200, 1536] {
+            let mut x = 0x243F_6A88_85A3_08D3u64 ^ dim as u64;
+            let mut next = || {
+                x ^= x << 13;
+                x ^= x >> 7;
+                x ^= x << 17;
+                x
+            };
+            let src: Vec<f32> =
+                (0..dim).map(|_| (next() as f64 / u64::MAX as f64) as f32 - 0.5).collect();
+            let signs: Vec<f32> =
+                (0..dim).map(|_| if next() & 1 == 1 { -1.0 } else { 1.0 }).collect();
+            // A real permutation, so the gather covers every source slot.
+            let mut rng = ChaCha8Rng::from_seed(ROTATION_SEED);
+            let perm = fisher_yates(dim, &mut rng);
+            let inv = 0.318_309_886_f32;
+
+            macro_rules! check_mode {
+                ($mode:literal) => {{
+                    let mut expect = vec![0.0f32; dim];
+                    permute_gather_scalar::<$mode>(&src, &perm, &signs, inv, &mut expect);
+
+                    let mut got = vec![0.0f32; dim];
+                    permute_gather::<$mode>(&src, &perm, &signs, inv, &mut got);
+                    assert_eq!(got.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                               expect.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                               "dim {} mode {} dispatch", dim, $mode);
+                    #[cfg(target_arch = "x86_64")]
+                    {
+                        if std::arch::is_x86_feature_detected!("avx2") {
+                            let mut g = vec![0.0f32; dim];
+                            unsafe {
+                                permute_gather_avx2::<$mode>(&src, &perm, &signs, inv, &mut g)
+                            };
+                            assert_eq!(g.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                                       expect.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                                       "dim {} mode {} avx2", dim, $mode);
+                        }
+                        if std::arch::is_x86_feature_detected!("avx512f") {
+                            let mut g = vec![0.0f32; dim];
+                            unsafe {
+                                permute_gather_avx512::<$mode>(&src, &perm, &signs, inv, &mut g)
+                            };
+                            assert_eq!(g.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                                       expect.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                                       "dim {} mode {} avx512", dim, $mode);
+                        }
+                    }
+                }};
+            }
+            check_mode!(0);
+            check_mode!(1);
+            check_mode!(2);
         }
     }
 

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -200,13 +200,7 @@ impl Rotation {
         };
 
         // Round 0: fused scale + sign in the gather.
-        for ((d, &p), &s) in scratch
-            .iter_mut()
-            .zip(self.perms[0].iter())
-            .zip(self.signs[0].iter())
-        {
-            *d = (src[p as usize] * inv) * s;
-        }
+        permute_gather::<2>(src, &self.perms[0], &self.signs[0], inv, scratch);
         wht(scratch);
         // Apply round 1's sign at the source positions (see
         // `signs1_pre`): `(x * 1/sqrtB) * sign` happens in the same
@@ -217,9 +211,7 @@ impl Rotation {
         }
 
         // Round 1: scratch -> dst (sign already applied above).
-        for (d, &p) in dst.iter_mut().zip(self.perms[1].iter()) {
-            *d = scratch[p as usize];
-        }
+        permute_gather::<0>(scratch, &self.perms[1], &self.signs1_pre, 1.0, dst);
         wht(dst);
     }
 
@@ -260,11 +252,7 @@ impl Rotation {
             //    coordinates across blocks.
             let perm = &self.perms[round];
             let sign_row = &self.signs[round];
-            for ((dst, &src), &s) in
-                output.iter_mut().zip(perm.iter()).zip(sign_row.iter())
-            {
-                *dst = input[src as usize] * s;
-            }
+            permute_gather::<1>(input, perm, sign_row, 1.0, output);
 
             // 3. Normalized Walsh-Hadamard per B-block. The butterfly is
             //    the unnormalized transform (adds/subtracts only, fixed
@@ -289,6 +277,155 @@ impl Rotation {
             // This round's output feeds the next round's gather.
             std::mem::swap(&mut input, &mut output);
         }
+    }
+}
+
+/// One permutation round: `dst[i] = src[perm[i]]`, optionally scaled.
+///
+/// `MODE` selects the multiplies that ride the gather, in the order the
+/// scalar loop performed them:
+///
+/// * `0` — plain move (`signs`/`inv` unused).
+/// * `1` — `src[perm[i]] * signs[i]`.
+/// * `2` — `(src[perm[i]] * inv) * signs[i]`.
+///
+/// The permutation is a bijection over `0..dim` and `dst` is disjoint
+/// from `src`, so lane-parallel execution reads and writes exactly the
+/// elements the scalar loop did; the multiplies are the same IEEE ops in
+/// the same order, so the output is bit-identical (pinned by the
+/// golden-bytes tests in `tests/rotation_determinism.rs`).
+///
+/// Panics if `perm`, `signs`, `src`, and `dst` are not all the same
+/// length.
+#[inline(always)]
+fn permute_gather<const MODE: usize>(
+    src: &[f32],
+    perm: &[u32],
+    signs: &[f32],
+    inv: f32,
+    dst: &mut [f32],
+) {
+    debug_assert_eq!(src.len(), dst.len());
+    debug_assert_eq!(perm.len(), dst.len());
+    debug_assert_eq!(signs.len(), dst.len());
+    #[cfg(target_arch = "x86_64")]
+    {
+        // Hardware gather replaces the per-element load-index/load-value
+        // pair; the surrounding multiplies are unchanged.
+        if std::arch::is_x86_feature_detected!("avx512f") {
+            unsafe { return permute_gather_avx512::<MODE>(src, perm, signs, inv, dst) }
+        } else if std::arch::is_x86_feature_detected!("avx2") {
+            unsafe { return permute_gather_avx2::<MODE>(src, perm, signs, inv, dst) }
+        }
+    }
+    permute_gather_scalar::<MODE>(src, perm, signs, inv, dst)
+}
+
+#[inline(always)]
+fn permute_gather_scalar<const MODE: usize>(
+    src: &[f32],
+    perm: &[u32],
+    signs: &[f32],
+    inv: f32,
+    dst: &mut [f32],
+) {
+    for ((d, &p), &s) in dst.iter_mut().zip(perm.iter()).zip(signs.iter()) {
+        let v = src[p as usize];
+        *d = match MODE {
+            0 => v,
+            1 => v * s,
+            _ => (v * inv) * s,
+        };
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn permute_gather_avx2<const MODE: usize>(
+    src: &[f32],
+    perm: &[u32],
+    signs: &[f32],
+    inv: f32,
+    dst: &mut [f32],
+) {
+    use std::arch::x86_64::*;
+    let n = dst.len();
+    let base = src.as_ptr();
+    let invv = _mm256_set1_ps(inv);
+    let mut i = 0;
+    while i + 8 <= n {
+        let idx = _mm256_loadu_si256(perm.as_ptr().add(i) as *const __m256i);
+        let mut v = _mm256_i32gather_ps::<4>(base, idx);
+        if MODE == 2 {
+            v = _mm256_mul_ps(v, invv);
+        }
+        if MODE != 0 {
+            v = _mm256_mul_ps(v, _mm256_loadu_ps(signs.as_ptr().add(i)));
+        }
+        _mm256_storeu_ps(dst.as_mut_ptr().add(i), v);
+        i += 8;
+    }
+    // `dim` is always a multiple of 8, so this tail is dead on every
+    // index path; kept so the helper is correct for any length.
+    while i < n {
+        let v = *src.get_unchecked(*perm.get_unchecked(i) as usize);
+        let s = *signs.get_unchecked(i);
+        *dst.get_unchecked_mut(i) = match MODE {
+            0 => v,
+            1 => v * s,
+            _ => (v * inv) * s,
+        };
+        i += 1;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f")]
+unsafe fn permute_gather_avx512<const MODE: usize>(
+    src: &[f32],
+    perm: &[u32],
+    signs: &[f32],
+    inv: f32,
+    dst: &mut [f32],
+) {
+    use std::arch::x86_64::*;
+    let n = dst.len();
+    let base = src.as_ptr();
+    let invv = _mm512_set1_ps(inv);
+    let mut i = 0;
+    while i + 16 <= n {
+        let idx = _mm512_loadu_si512(perm.as_ptr().add(i) as *const __m512i);
+        let mut v = _mm512_i32gather_ps::<4>(idx, base);
+        if MODE == 2 {
+            v = _mm512_mul_ps(v, invv);
+        }
+        if MODE != 0 {
+            v = _mm512_mul_ps(v, _mm512_loadu_ps(signs.as_ptr().add(i)));
+        }
+        _mm512_storeu_ps(dst.as_mut_ptr().add(i), v);
+        i += 16;
+    }
+    while i + 8 <= n {
+        let idx = _mm256_loadu_si256(perm.as_ptr().add(i) as *const __m256i);
+        let mut v = _mm256_i32gather_ps::<4>(src.as_ptr(), idx);
+        if MODE == 2 {
+            v = _mm256_mul_ps(v, _mm256_set1_ps(inv));
+        }
+        if MODE != 0 {
+            v = _mm256_mul_ps(v, _mm256_loadu_ps(signs.as_ptr().add(i)));
+        }
+        _mm256_storeu_ps(dst.as_mut_ptr().add(i), v);
+        i += 8;
+    }
+    while i < n {
+        let v = *src.get_unchecked(*perm.get_unchecked(i) as usize);
+        let s = *signs.get_unchecked(i);
+        *dst.get_unchecked_mut(i) = match MODE {
+            0 => v,
+            1 => v * s,
+            _ => (v * inv) * s,
+        };
+        i += 1;
     }
 }
 
@@ -443,22 +580,33 @@ fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
 #[cfg(target_arch = "x86_64")]
 #[inline(always)]
 fn wht_block(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
-    // Runtime dispatch: AVX2 executes the identical per-element adds,
-    // subtracts, and multiplies 8 (or 4) lanes at a time — butterflies
-    // within a stage touch disjoint elements, so results are
+    // Runtime dispatch: the SIMD paths execute the identical per-element
+    // adds, subtracts, and multiplies 16 or 8 lanes at a time —
+    // butterflies within a stage touch disjoint elements, so results are
     // bit-identical to the scalar loop (the same property the NEON path
     // relies on). is_x86_feature_detected caches after the first call.
-    if std::arch::is_x86_feature_detected!("avx2") {
+    if std::arch::is_x86_feature_detected!("avx512f") {
+        unsafe { wht_block_avx512(blk, block, inv_sqrt_block) }
+    } else if std::arch::is_x86_feature_detected!("avx2") {
         unsafe { wht_block_avx2(blk, block, inv_sqrt_block) }
     } else {
         wht_block_scalar(blk, block, inv_sqrt_block)
     }
 }
 
-/// AVX2 Walsh-Hadamard: stage pairs (j, j+len) processed 8-wide for
-/// len >= 8, 4-wide (SSE) for len == 4, and via in-register shuffles for
-/// len 1 and 2 — every output is the same (a ± b) with the same f32
-/// rounding as the scalar butterfly.
+/// AVX2 Walsh-Hadamard.
+///
+/// The stage schedule mirrors the NEON path: the three lowest stages
+/// (len = 1, 2, 4) are a full 8-point Hadamard resolved inside one
+/// register, then higher stages run as radix-8 passes (three stages per
+/// memory pass) with radix-4 / radix-2 tails for whatever remains. At
+/// block = 512 (dim 1536) that is 3 passes over the block instead of the
+/// 9 a radix-2 ladder needs.
+///
+/// Every output is the same `(((a±b)±(c±d))±((e±f)±(g±h)))` expression
+/// tree, evaluated on the same operands with the same f32 roundings, as
+/// the sequential scalar stages it replaces — reassociation is
+/// impossible because butterflies within a stage are independent.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn wht_block_avx2(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
@@ -466,52 +614,109 @@ unsafe fn wht_block_avx2(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
     debug_assert!(block >= 8 && block.is_power_of_two());
     let p = blk.as_mut_ptr();
 
-    // Stage len=1: adjacent pairs, resolved with SSE shuffles per 4
-    // floats: [a0 b0 a1 b1] -> sums [a0+b0, a1+b1], diffs [a0-b0, a1-b1],
-    // re-interleaved.
+    // Stages len = 1, 2, 4 fused: each 8-float group is fully resolved in
+    // registers by three shuffle/add/sub/blend triples.
     let mut j = 0;
     while j < block {
-        let v = _mm_loadu_ps(p.add(j)); // [a0 b0 a1 b1]
-        let a = _mm_shuffle_ps::<0b10_10_00_00>(v, v); // [a0 a0 a1 a1]
-        let b = _mm_shuffle_ps::<0b11_11_01_01>(v, v); // [b0 b0 b1 b1]
-        let s = _mm_add_ps(a, b);
-        let d = _mm_sub_ps(a, b);
-        // out = [s0 d0 s1 d1]: take lanes (s0, d1?) — blend s/d on odd lanes.
-        let out = _mm_blend_ps::<0b1010>(s, d);
-        _mm_storeu_ps(p.add(j), out);
-        j += 4;
-    }
-
-    // Stage len=2: per 8 floats [a0 a1 b0 b1 | a2 a3 b2 b3].
-    let mut j = 0;
-    while j < block {
-        let lo = _mm_loadu_ps(p.add(j)); // [a0 a1 b0 b1]
-        let hi = _mm_loadu_ps(p.add(j + 4)); // [a2 a3 b2 b3]
-        let a = _mm_movelh_ps(lo, hi); // [a0 a1 a2 a3]
-        let b = _mm_movehl_ps(hi, lo); // [b0 b1 b2 b3]
-        let s = _mm_add_ps(a, b);
-        let d = _mm_sub_ps(a, b);
-        _mm_storeu_ps(p.add(j), _mm_movelh_ps(s, d)); // [s0 s1 d0 d1]
-        _mm_storeu_ps(p.add(j + 4), _mm_movehl_ps(d, s)); // [s2 s3 d2 d3]
+        let v = _mm256_loadu_ps(p.add(j));
+        // len=1: pairs (0,1) (2,3) (4,5) (6,7).
+        let a = _mm256_shuffle_ps::<0b10_10_00_00>(v, v);
+        let b = _mm256_shuffle_ps::<0b11_11_01_01>(v, v);
+        let r1 = _mm256_blend_ps::<0b1010_1010>(
+            _mm256_add_ps(a, b),
+            _mm256_sub_ps(a, b),
+        );
+        // len=2: pairs (0,2) (1,3) (4,6) (5,7).
+        let a = _mm256_shuffle_ps::<0b01_00_01_00>(r1, r1);
+        let b = _mm256_shuffle_ps::<0b11_10_11_10>(r1, r1);
+        let r2 = _mm256_blend_ps::<0b1100_1100>(
+            _mm256_add_ps(a, b),
+            _mm256_sub_ps(a, b),
+        );
+        // len=4: pairs (k, k+4) — across the two 128-bit halves.
+        let a = _mm256_permute2f128_ps::<0x00>(r2, r2);
+        let b = _mm256_permute2f128_ps::<0x11>(r2, r2);
+        let r4 = _mm256_blend_ps::<0b1111_0000>(
+            _mm256_add_ps(a, b),
+            _mm256_sub_ps(a, b),
+        );
+        _mm256_storeu_ps(p.add(j), r4);
         j += 8;
     }
 
-    // Stage len=4: disjoint 4-float operand groups.
-    if block > 4 {
-        let len = 4;
+    // Stages len >= 8: radix-8 passes (three stages each) while at least
+    // three stages remain, then a radix-4 pass if two remain, then a
+    // single radix-2 stage if one does.
+    let mut len = 8;
+    while 4 * len < block {
+        let oct = 8 * len;
         let mut i = 0;
         while i < block {
-            let a = _mm_loadu_ps(p.add(i));
-            let b = _mm_loadu_ps(p.add(i + len));
-            _mm_storeu_ps(p.add(i), _mm_add_ps(a, b));
-            _mm_storeu_ps(p.add(i + len), _mm_sub_ps(a, b));
-            i += 2 * len;
+            let mut j = i;
+            while j < i + len {
+                let a = _mm256_loadu_ps(p.add(j));
+                let b = _mm256_loadu_ps(p.add(j + len));
+                let c = _mm256_loadu_ps(p.add(j + 2 * len));
+                let d = _mm256_loadu_ps(p.add(j + 3 * len));
+                let e = _mm256_loadu_ps(p.add(j + 4 * len));
+                let f = _mm256_loadu_ps(p.add(j + 5 * len));
+                let g = _mm256_loadu_ps(p.add(j + 6 * len));
+                let h = _mm256_loadu_ps(p.add(j + 7 * len));
+                let apb = _mm256_add_ps(a, b);
+                let amb = _mm256_sub_ps(a, b);
+                let cpd = _mm256_add_ps(c, d);
+                let cmd = _mm256_sub_ps(c, d);
+                let epf = _mm256_add_ps(e, f);
+                let emf = _mm256_sub_ps(e, f);
+                let gph = _mm256_add_ps(g, h);
+                let gmh = _mm256_sub_ps(g, h);
+                let s0 = _mm256_add_ps(apb, cpd);
+                let s1 = _mm256_add_ps(amb, cmd);
+                let s2 = _mm256_sub_ps(apb, cpd);
+                let s3 = _mm256_sub_ps(amb, cmd);
+                let s4 = _mm256_add_ps(epf, gph);
+                let s5 = _mm256_add_ps(emf, gmh);
+                let s6 = _mm256_sub_ps(epf, gph);
+                let s7 = _mm256_sub_ps(emf, gmh);
+                _mm256_storeu_ps(p.add(j), _mm256_add_ps(s0, s4));
+                _mm256_storeu_ps(p.add(j + len), _mm256_add_ps(s1, s5));
+                _mm256_storeu_ps(p.add(j + 2 * len), _mm256_add_ps(s2, s6));
+                _mm256_storeu_ps(p.add(j + 3 * len), _mm256_add_ps(s3, s7));
+                _mm256_storeu_ps(p.add(j + 4 * len), _mm256_sub_ps(s0, s4));
+                _mm256_storeu_ps(p.add(j + 5 * len), _mm256_sub_ps(s1, s5));
+                _mm256_storeu_ps(p.add(j + 6 * len), _mm256_sub_ps(s2, s6));
+                _mm256_storeu_ps(p.add(j + 7 * len), _mm256_sub_ps(s3, s7));
+                j += 8;
+            }
+            i += oct;
         }
+        len <<= 3;
     }
-
-    // Stages len >= 8: 8-wide.
-    let mut len = 8;
-    while len < block {
+    if 2 * len < block {
+        let quad = 4 * len;
+        let mut i = 0;
+        while i < block {
+            let mut j = i;
+            while j < i + len {
+                let a = _mm256_loadu_ps(p.add(j));
+                let b = _mm256_loadu_ps(p.add(j + len));
+                let c = _mm256_loadu_ps(p.add(j + 2 * len));
+                let d = _mm256_loadu_ps(p.add(j + 3 * len));
+                let apb = _mm256_add_ps(a, b);
+                let amb = _mm256_sub_ps(a, b);
+                let cpd = _mm256_add_ps(c, d);
+                let cmd = _mm256_sub_ps(c, d);
+                _mm256_storeu_ps(p.add(j), _mm256_add_ps(apb, cpd));
+                _mm256_storeu_ps(p.add(j + len), _mm256_add_ps(amb, cmd));
+                _mm256_storeu_ps(p.add(j + 2 * len), _mm256_sub_ps(apb, cpd));
+                _mm256_storeu_ps(p.add(j + 3 * len), _mm256_sub_ps(amb, cmd));
+                j += 8;
+            }
+            i += quad;
+        }
+        len <<= 2;
+    }
+    if len < block {
         let mut i = 0;
         while i < block {
             let mut j = i;
@@ -524,19 +729,170 @@ unsafe fn wht_block_avx2(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
             }
             i += 2 * len;
         }
-        len <<= 1;
     }
 
     // Orthonormalization scale.
     let sv = _mm256_set1_ps(inv_sqrt_block);
     let mut j = 0;
-    while j + 8 <= block {
+    while j < block {
         _mm256_storeu_ps(p.add(j), _mm256_mul_ps(_mm256_loadu_ps(p.add(j)), sv));
         j += 8;
     }
+}
+
+/// AVX-512 Walsh-Hadamard — the AVX2 schedule at 16 lanes.
+///
+/// The four lowest stages (len = 1, 2, 4, 8) become a full 16-point
+/// Hadamard inside one zmm register, so block = 512 and block = 1024
+/// (dims 1536 and 3072) each need just 3 memory passes. Same operand
+/// pairs, same expression trees, same f32 roundings as the scalar
+/// ladder — enforced against it by `wht_simd_matches_scalar_bit_exactly`
+/// at every block size.
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx512f")]
+unsafe fn wht_block_avx512(blk: &mut [f32], block: usize, inv_sqrt_block: f32) {
+    use std::arch::x86_64::*;
+    debug_assert!(block >= 8 && block.is_power_of_two());
+    let p = blk.as_mut_ptr();
+
+    // A block of 8 has only the three lowest stages and no room for a
+    // 16-lane register — hand it to the AVX2 kernel, which is written
+    // for exactly that case.
+    if block < 16 {
+        return wht_block_avx2(blk, block, inv_sqrt_block);
+    }
+
+    // Stages len = 1, 2, 4, 8 fused: 16-point Hadamard in registers.
+    let mut j = 0;
     while j < block {
-        *p.add(j) *= inv_sqrt_block;
-        j += 1;
+        let v = _mm512_loadu_ps(p.add(j));
+        // len=1: pairs (k, k+1) inside each 128-bit lane.
+        let a = _mm512_shuffle_ps::<0b10_10_00_00>(v, v);
+        let b = _mm512_shuffle_ps::<0b11_11_01_01>(v, v);
+        let r1 = _mm512_mask_blend_ps(
+            0b1010_1010_1010_1010,
+            _mm512_add_ps(a, b),
+            _mm512_sub_ps(a, b),
+        );
+        // len=2: pairs (k, k+2) inside each 128-bit lane.
+        let a = _mm512_shuffle_ps::<0b01_00_01_00>(r1, r1);
+        let b = _mm512_shuffle_ps::<0b11_10_11_10>(r1, r1);
+        let r2 = _mm512_mask_blend_ps(
+            0b1100_1100_1100_1100,
+            _mm512_add_ps(a, b),
+            _mm512_sub_ps(a, b),
+        );
+        // len=4: pairs across adjacent 128-bit lanes (0↔1, 2↔3).
+        let a = _mm512_shuffle_f32x4::<0b10_10_00_00>(r2, r2);
+        let b = _mm512_shuffle_f32x4::<0b11_11_01_01>(r2, r2);
+        let r4 = _mm512_mask_blend_ps(
+            0b1111_0000_1111_0000,
+            _mm512_add_ps(a, b),
+            _mm512_sub_ps(a, b),
+        );
+        // len=8: pairs across the two 256-bit halves (lane 0↔2, 1↔3).
+        let a = _mm512_shuffle_f32x4::<0b01_00_01_00>(r4, r4);
+        let b = _mm512_shuffle_f32x4::<0b11_10_11_10>(r4, r4);
+        let r8 = _mm512_mask_blend_ps(
+            0b1111_1111_0000_0000,
+            _mm512_add_ps(a, b),
+            _mm512_sub_ps(a, b),
+        );
+        _mm512_storeu_ps(p.add(j), r8);
+        j += 16;
+    }
+
+    // Stages len >= 16: radix-8, then radix-4 / radix-2 tails.
+    let mut len = 16;
+    while 4 * len < block {
+        let oct = 8 * len;
+        let mut i = 0;
+        while i < block {
+            let mut j = i;
+            while j < i + len {
+                let a = _mm512_loadu_ps(p.add(j));
+                let b = _mm512_loadu_ps(p.add(j + len));
+                let c = _mm512_loadu_ps(p.add(j + 2 * len));
+                let d = _mm512_loadu_ps(p.add(j + 3 * len));
+                let e = _mm512_loadu_ps(p.add(j + 4 * len));
+                let f = _mm512_loadu_ps(p.add(j + 5 * len));
+                let g = _mm512_loadu_ps(p.add(j + 6 * len));
+                let h = _mm512_loadu_ps(p.add(j + 7 * len));
+                let apb = _mm512_add_ps(a, b);
+                let amb = _mm512_sub_ps(a, b);
+                let cpd = _mm512_add_ps(c, d);
+                let cmd = _mm512_sub_ps(c, d);
+                let epf = _mm512_add_ps(e, f);
+                let emf = _mm512_sub_ps(e, f);
+                let gph = _mm512_add_ps(g, h);
+                let gmh = _mm512_sub_ps(g, h);
+                let s0 = _mm512_add_ps(apb, cpd);
+                let s1 = _mm512_add_ps(amb, cmd);
+                let s2 = _mm512_sub_ps(apb, cpd);
+                let s3 = _mm512_sub_ps(amb, cmd);
+                let s4 = _mm512_add_ps(epf, gph);
+                let s5 = _mm512_add_ps(emf, gmh);
+                let s6 = _mm512_sub_ps(epf, gph);
+                let s7 = _mm512_sub_ps(emf, gmh);
+                _mm512_storeu_ps(p.add(j), _mm512_add_ps(s0, s4));
+                _mm512_storeu_ps(p.add(j + len), _mm512_add_ps(s1, s5));
+                _mm512_storeu_ps(p.add(j + 2 * len), _mm512_add_ps(s2, s6));
+                _mm512_storeu_ps(p.add(j + 3 * len), _mm512_add_ps(s3, s7));
+                _mm512_storeu_ps(p.add(j + 4 * len), _mm512_sub_ps(s0, s4));
+                _mm512_storeu_ps(p.add(j + 5 * len), _mm512_sub_ps(s1, s5));
+                _mm512_storeu_ps(p.add(j + 6 * len), _mm512_sub_ps(s2, s6));
+                _mm512_storeu_ps(p.add(j + 7 * len), _mm512_sub_ps(s3, s7));
+                j += 16;
+            }
+            i += oct;
+        }
+        len <<= 3;
+    }
+    if 2 * len < block {
+        let quad = 4 * len;
+        let mut i = 0;
+        while i < block {
+            let mut j = i;
+            while j < i + len {
+                let a = _mm512_loadu_ps(p.add(j));
+                let b = _mm512_loadu_ps(p.add(j + len));
+                let c = _mm512_loadu_ps(p.add(j + 2 * len));
+                let d = _mm512_loadu_ps(p.add(j + 3 * len));
+                let apb = _mm512_add_ps(a, b);
+                let amb = _mm512_sub_ps(a, b);
+                let cpd = _mm512_add_ps(c, d);
+                let cmd = _mm512_sub_ps(c, d);
+                _mm512_storeu_ps(p.add(j), _mm512_add_ps(apb, cpd));
+                _mm512_storeu_ps(p.add(j + len), _mm512_add_ps(amb, cmd));
+                _mm512_storeu_ps(p.add(j + 2 * len), _mm512_sub_ps(apb, cpd));
+                _mm512_storeu_ps(p.add(j + 3 * len), _mm512_sub_ps(amb, cmd));
+                j += 16;
+            }
+            i += quad;
+        }
+        len <<= 2;
+    }
+    if len < block {
+        let mut i = 0;
+        while i < block {
+            let mut j = i;
+            while j < i + len {
+                let a = _mm512_loadu_ps(p.add(j));
+                let b = _mm512_loadu_ps(p.add(j + len));
+                _mm512_storeu_ps(p.add(j), _mm512_add_ps(a, b));
+                _mm512_storeu_ps(p.add(j + len), _mm512_sub_ps(a, b));
+                j += 16;
+            }
+            i += 2 * len;
+        }
+    }
+
+    // Orthonormalization scale.
+    let sv = _mm512_set1_ps(inv_sqrt_block);
+    let mut j = 0;
+    while j < block {
+        _mm512_storeu_ps(p.add(j), _mm512_mul_ps(_mm512_loadu_ps(p.add(j)), sv));
+        j += 16;
     }
 }
 

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -952,8 +952,49 @@ fn fisher_yates(dim: usize, rng: &mut ChaCha8Rng) -> Vec<u32> {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
+
+    /// Opt-in SIMD coverage gate.
+    ///
+    /// The identity tests below check every implementation the *host* can
+    /// run and silently skip the rest. That is right for a laptop and
+    /// wrong for CI: a runner without AVX-512 exercises neither AVX-512
+    /// kernel, the tests still pass, and nobody learns that the paths
+    /// went uncovered. GitHub-hosted x86 runners are not guaranteed to
+    /// have AVX-512 at all.
+    ///
+    /// Setting `TURBOVEC_REQUIRE_SIMD` to a comma-separated feature list
+    /// (e.g. `TURBOVEC_REQUIRE_SIMD=avx2,avx512f`) turns a missing
+    /// feature into a test failure, so a machine that is *supposed* to
+    /// cover a kernel proves it did.
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn require_simd_features() {
+        let Ok(list) = std::env::var("TURBOVEC_REQUIRE_SIMD") else {
+            return;
+        };
+        for feat in list.split(',').map(str::trim).filter(|f| !f.is_empty()) {
+            let present = match feat {
+                "avx" => std::arch::is_x86_feature_detected!("avx"),
+                "avx2" => std::arch::is_x86_feature_detected!("avx2"),
+                "avx512f" => std::arch::is_x86_feature_detected!("avx512f"),
+                "avx512bw" => std::arch::is_x86_feature_detected!("avx512bw"),
+                "avx512vbmi" => std::arch::is_x86_feature_detected!("avx512vbmi"),
+                other => panic!(
+                    "TURBOVEC_REQUIRE_SIMD lists unknown feature {other:?}"
+                ),
+            };
+            assert!(
+                present,
+                "TURBOVEC_REQUIRE_SIMD demands {feat:?} but this host does \
+                 not have it — the kernels gated on it would be skipped, \
+                 leaving them untested rather than failing",
+            );
+        }
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    pub(crate) fn require_simd_features() {}
 
     #[test]
     fn block_size_is_largest_power_of_two_divisor() {
@@ -968,6 +1009,7 @@ mod tests {
 
     #[test]
     fn wht_simd_matches_scalar_bit_exactly() {
+        require_simd_features();
         // The format contract requires the SIMD butterfly to reproduce
         // the scalar expression trees bit-for-bit. Enforce it directly,
         // on every architecture, for every block-size regime the stage
@@ -1023,7 +1065,6 @@ mod tests {
                     );
                 }
             }
-            buf.copy_from_slice(&expect);
         }
     }
 
@@ -1032,6 +1073,7 @@ mod tests {
     /// against the scalar reference, in every multiply mode.
     #[test]
     fn permute_gather_paths_match_scalar_bit_exactly() {
+        require_simd_features();
         for dim in [8usize, 16, 24, 64, 200, 1536] {
             let mut x = 0x243F_6A88_85A3_08D3u64 ^ dim as u64;
             let mut next = || {

--- a/turbovec/tests/codebook_determinism.rs
+++ b/turbovec/tests/codebook_determinism.rs
@@ -1,0 +1,147 @@
+//! Golden pin for the Lloyd-Max codebook.
+//!
+//! The codebook is baked into every encoded vector: `boundaries` decides
+//! each coordinate's code and `centroids` sets the reconstruction the
+//! stored per-vector scale is computed against. It is *not* a frozen
+//! table — it is recomputed at runtime from `statrs`'s Beta cdf/pdf,
+//! which bottom out in `ln`/`exp`.
+//!
+//! Two different things can move it, and they need two different
+//! defences:
+//!
+//! * **Across platforms**, for one build — different libms, different
+//!   rounding. That is what the cross-OS fingerprint CI leg checks, and
+//!   `codebook::lloyd_max` now derives boundaries from the already-
+//!   rounded f32 centroids so the fragile step is gone.
+//! * **Across builds**, on one platform — a `statrs` release that
+//!   changes its special functions by an ulp, or a libm update. The
+//!   fingerprint leg cannot see this: it compares three OSes *within a
+//!   single locked build*, so a drift that moves every platform together
+//!   passes it silently. `rand_chacha` is exact-pinned (`=0.3.1`)
+//!   precisely because the rotation's byte stream is format-frozen;
+//!   `statrs` is a caret range, so this test is the equivalent guard for
+//!   the codebook.
+//!
+//! The constants below are not local observations — they are the values
+//! Linux, macOS and Windows independently agreed on in the
+//! `Encode fingerprint` CI legs, cross-checked against
+//! `examples/encode_hash`, which uses this same hash over these same
+//! cells.
+//!
+//! If this test fails, encoded bytes have moved for identical input.
+//! That is a format change, not a rounding nit: decide it deliberately
+//! and re-freeze, don't paper over it.
+
+/// A minimal populated index for `dim`/`bits`.
+///
+/// The codebook is a pure function of `(bit_width, dim)` — the data does
+/// not enter it — but `codebook_for_write` returns all-zero placeholders
+/// for an *empty* index, so the index has to have something in it or the
+/// assertions below hash zeros and pass vacuously. (They did, on the
+/// first run of this test.) `assert_not_placeholder` is the standing
+/// guard against that.
+fn populated(dim: usize, bits: usize) -> turbovec::TurboQuantIndex {
+    let mut index = turbovec::TurboQuantIndex::new(dim, bits).unwrap();
+    let mut state = 0x9E37_79B9_7F4A_7C15u64 ^ dim as u64;
+    let vectors: Vec<f32> = (0..8 * dim)
+        .map(|_| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            ((state >> 32) as u32 as f64 / 2_147_483_648.0 - 1.0) as f32
+        })
+        .collect();
+    index.add(&vectors);
+    index
+}
+
+/// Fail loudly on the placeholder codebook rather than hashing it.
+fn assert_not_placeholder(boundaries: &[f32], centroids: &[f32], dim: usize, bits: usize) {
+    assert!(
+        centroids.iter().any(|c| *c != 0.0) && boundaries.iter().any(|b| *b != 0.0),
+        "dim={dim} bits={bits}: got the all-zero placeholder codebook — the \
+         index under test is empty, so this assertion would pass vacuously",
+    );
+}
+
+/// FNV-1a 64 over the f32 bit patterns — byte-for-byte identical to
+/// `examples/encode_hash`, so a failure here and a divergence there name
+/// the same numbers.
+fn fnv1a_f32(values: &[f32]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for v in values {
+        for &b in v.to_bits().to_le_bytes().iter() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    h
+}
+
+/// `(dim, bit_width, boundaries_hash, centroids_hash)`.
+///
+/// Same six cells as `examples/encode_hash`: the rotation's block-size
+/// regimes (`8·odd` → B=8, a pure power of two, the two production dims)
+/// across a range of Beta shape parameters.
+const GOLDEN: &[(usize, usize, u64, u64)] = &[
+    (200, 2, 0x4fb0_378d_c1d8_6d75, 0xd43f_f871_2da1_9915),
+    (768, 4, 0x2727_3d87_5c56_0161, 0x0970_4dad_5b65_a00d),
+    (1024, 3, 0xd9ee_efae_66c3_4fd1, 0xfcf5_342e_5aef_b105),
+    (1536, 2, 0xb1a9_7993_603c_7dcd, 0x1348_c9ae_60bb_dc3d),
+    (1536, 4, 0x05f7_a92f_87ab_a9a1, 0x84f2_c25c_ecbf_6761),
+    (3072, 4, 0x9a1b_3dca_8251_faad, 0x6a56_a173_8e12_e62d),
+];
+
+#[test]
+fn codebook_bytes_are_frozen() {
+    for &(dim, bits, want_boundaries, want_centroids) in GOLDEN {
+        // Reached through the public surface: `codebook::codebook` is
+        // crate-internal, but an index exposes the codebook it encoded
+        // against, which is the thing that actually has to stay put.
+        let index = populated(dim, bits);
+        let (boundaries, centroids) = index.codebook_for_write();
+
+        assert_eq!(boundaries.len(), (1 << bits) - 1);
+        assert_eq!(centroids.len(), 1 << bits);
+        assert_not_placeholder(&boundaries, &centroids, dim, bits);
+        assert_eq!(
+            fnv1a_f32(&centroids),
+            want_centroids,
+            "dim={dim} bits={bits}: Lloyd-Max centroids drifted. Every \
+             stored scale is computed against these, so this re-encodes \
+             every future vector differently from earlier builds. A \
+             `statrs` upgrade or a libm change is the likely cause — the \
+             cross-OS fingerprint leg cannot catch it, because it moves \
+             all platforms together.",
+        );
+        assert_eq!(
+            fnv1a_f32(&boundaries),
+            want_boundaries,
+            "dim={dim} bits={bits}: codebook boundaries drifted. These \
+             decide every coordinate's code. See the centroid note above.",
+        );
+    }
+}
+
+/// The property that makes the codebook cross-platform reproducible:
+/// boundaries are derived from the f32 centroids, not from the f64 ones.
+///
+/// Duplicated from the unit test in `codebook.rs` on purpose — this one
+/// runs against the public surface, so it also covers the path an
+/// embedder reaches through `codebook_for_write`.
+#[test]
+fn boundaries_are_midpoints_of_the_published_centroids() {
+    for &(dim, bits, _, _) in GOLDEN {
+        let index = populated(dim, bits);
+        let (boundaries, centroids) = index.codebook_for_write();
+        assert_not_placeholder(&boundaries, &centroids, dim, bits);
+        for (i, b) in boundaries.iter().enumerate() {
+            let expect = (centroids[i] + centroids[i + 1]) * 0.5;
+            assert_eq!(
+                b.to_bits(),
+                expect.to_bits(),
+                "dim={dim} bits={bits} boundary {i}",
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Related issue

Closes #273. Closes #275. Closes #259 — both findings, not just the CI leg it asks for.

Rebased onto `main` after #276; 20 suites pass on the combination and the encode fingerprint is byte-identical (that PR moved the load/search path, this one moves encode).

## Summary

**x86 insertion (#273).** The x86 encode path had a NEON-shaped hole in it — four places where the aarch64 kernel had been optimized and x86 had not:

| | before | after |
|---|---|---|
| Walsh-Hadamard butterfly | radix-2 ladder, 9 memory passes at dim 1536 | fused low stages + radix-8, 3 passes; AVX-512 variant at 16 lanes |
| permutation gather | scalar load-index/load-value | `vgatherdps`, 8 or 16 lanes |
| bit-packing | one bit OR-ed at a time into a pre-zeroed row | one `movemask` per plane, whole-byte stores, no memset |
| reconstruction operand | hoisted f64 table, streamed in full per row (up to 384 KB) | lane permute over `centroids` + two f32 arrays, in registers |

Plus the TQ+ calibration fit, the single largest term in cold bulk insert (690 ms of a 1.29 s load): its column scratch was zero-filled before being overwritten, its transpose kept 768 destination cache lines live against a 32 KB L1, and quantile selection ran a `partial_cmp` closure handling an unordered case that cannot occur.

**Encode determinism (#259).** Two separate defects, both reaching every encoded byte:

1. `simd_norm` was two different reductions — aarch64 accumulated four chains through `vfmaq_f32`, everything else summed serially. `1/||v||` rides the first rotation gather, so the last-ulp disagreement propagated everywhere. Now one frozen order on every architecture (and ~6x faster on x86, since eight independent chains hide the add latency a single accumulator serialized on).
2. **The codebook differed on all three OSes** — found by the new CI leg on its first run, which is what it was for.

**Also in here**

- `examples/encode_hash` + a CI leg that fails unless all three OSes produce the same per-stage encode fingerprint.
- `speed_persist_*` benchmark cells (#275): write warm vs write after a mutation, load vs load → first search, and the full mutate→save→load→search round-trip, against FAISS.
- Every SIMD identity test now exercises *all* implementations the host can run, plus an opt-in `TURBOVEC_REQUIRE_SIMD` gate that turns a missing feature into a failure instead of a silent skip. Previously the tests called the dispatcher, so on any AVX-512 machine the AVX2 kernels were completely unexercised.
- **The declared MSRV was wrong on `main`**: the AVX-512 search kernel needs Rust 1.89, but both packages declared 1.83, where `cargo check` fails with 67 `stdarch_x86_avx512` errors. Corrected, plus a CI leg that builds on whatever the manifest declares so it can't drift again.
- `turbovec-python/dist/` was not gitignored, so building a wheel and running `git add -A` commits a multi-megabyte binary. (I did exactly that and had to rewrite it back out.)

## What the fingerprint leg found

It went red on its first run. The per-stage split made the result sharper than a single hash would have:

| stage | ubuntu | macos | windows |
|---|---|---|---|
| codebook | differ | differ | differ |
| calibration / codes / scales | ✅ | ✅ | ✅ |

Every platform computed a different codebook and still produced identical codes and scales from it.

Diagnosed by measurement, not inspection. The f64 Lloyd-Max iteration isn't bit-reproducible: `statrs`'s Beta cdf/pdf bottom out in `ln`/`exp`, which differ by ~1 ulp between libms, and the adaptive-Simpson recursion then branches differently. At 4 bits the loop additionally **exhausts `max_iter` without reaching `tol`** (200 iterations, final max change ~1e-8).

Casting a centroid to f32 absorbs all of that — a sensitivity sweep shows the f32 centroids invariant under pdf perturbations up to 1e-10 relative. The fragile step was the **boundary**: computed as an f64 midpoint and cast once, it lands on an f32 rounding knife-edge by construction, and a 1e-15 perturbation flipped it at every cell tested. Boundaries now come from the already-rounded f32 centroids, where `f32 add` is correctly rounded and `* 0.5` is exact.

**Precision about what that buys**, since it's a determinism claim: **by construction from the centroids down; by observation above them.** The centroids rely on the f32 cast swallowing ~1e-12 of libm noise against ~6e-8 of resolution — a 4–5 order of magnitude margin, not a proof. Two independent checks cover it: the fingerprint leg for platform drift, and `tests/codebook_determinism.rs` for build drift (a `statrs` bump moves every platform together, which the fingerprint leg cannot see). The genuinely by-construction fix is precomputing the codebook, which #259 names and which is its own piece of work.

## Test plan

- [x] `cargo test -p turbovec --release --locked` — 20 suites
- [x] `pytest turbovec-python/tests/` — 648 passed, all four integration extras installed
- [x] Downstream consumer smoke test
- [x] `cargo check` clean for `aarch64-unknown-linux-gnu` and `riscv64gc-unknown-linux-gnu` (generic scalar fallback)
- [x] MSRV verified against installed 1.83 (fails, as it should) and 1.89 (clean, 20 suites pass)
- [x] Clippy: lib warnings 95 → 51, no errors

### Bit-exactness

Every performance change is a layout or scheduling change, not an arithmetic one, enforced against the scalar reference on **every SIMD path the host can run**: `wht_simd_matches_scalar_bit_exactly`, `permute_gather_paths_match_scalar_bit_exactly` (new), `quantize_kernel_matches_scalar_bit_exactly`, `norm_simd_matches_scalar_bit_exactly`. Golden-bytes tests in `tests/rotation_determinism.rs` unchanged.

Discrimination verified by injection in both directions on a host with both feature sets: flipping one blend lane in the AVX2 low-stage fusion fails the AVX2 assertion while the dispatched AVX-512 path stays green; flipping one in the AVX-512 fusion fails the dispatched path and the golden dim=128 rotation.

### Speed

Interleaved A/B against the pre-branch base, 2 reps per cell, same harness both sides, synthetic corpora (50k × 1536 / 25k × 3072).

| cell | cold bulk | warm append | single add |
|---|---|---|---|
| d1536 2-bit ST | 24.5–26.9k → 43.1–45.2k (**+72%**) | 38.8–41.5k → 88.7–92.4k (**+2.2x**) | 24.5–25.1 → 8.5 µs (**−66%**) |
| d1536 2-bit MT | 89.0–89.6k → 133.7–141.4k (+53%) | 127–131k → 174–199k (+45%) | −66% |
| d1536 4-bit ST | 19.6–20.0k → 37.4–38.1k (+91%) | 28.1k → 89.8–90.3k (**+3.2x**) | 37.9–40.3 → 9.7–10.7 µs (−74%) |
| d1536 4-bit MT | 61.0–63.3k → 98.4–112.4k (+67%) | 96–98k → 234–270k (+2.6x) | −74% |
| d3072 2-bit ST | 11.8–12.5k → 18.0–21.0k (+61%) | 20.9–22.1k → 56.7–62.2k (+2.8x) | 45.2–46.7 → 16.1–17.1 µs (−64%) |
| d3072 2-bit MT | 45.9–46.8k → 63.8–67.2k (+42%) | 81–84k → 210–217k (+2.6x) | −64% |
| d3072 4-bit ST | 9.2k → 16.1k (+75%) | 14.6k → 50.9k (**+3.5x**) | 70.4 → 19.3 µs (−73%) |
| d3072 4-bit MT | 29.3–30.4k → 48.4–48.6k (+63%) | 52.1–54.2k → 178–185k (+3.4x) | 67.2–72.3 → 19.9–20.9 µs (−71%) |

**Removal is unchanged.** `swap_remove` was already an O(1) swap-and-pop and nothing here touches it; the ±10% in the remove columns is noise. The real removal cost is separate: every mutation replaces the whole blocked-layout `OnceLock`, so the next search pays a full O(n·dim) rebuild. Patching it in place is the remaining piece of #273 and the shared root cause with #274's cold-save repack — deliberately out of this PR.

### Recall

The norm and boundary changes move stored scales and boundaries by ~1 ULP, so recall needed checking rather than asserting. Same corpus and queries, both builds, brute-force ground truth:

| | R@1 | R@4 | R@16 | R@64 |
|---|---|---|---|---|
| d1536 2-bit | 0.42200 / 0.42200 | 0.49500 / 0.49500 | 0.53838 / 0.53838 | 0.58634 / 0.58637 |
| d1536 4-bit | 0.78600 / 0.78600 | 0.81700 / 0.81700 | 0.84937 / 0.84937 | 0.86934 / 0.86934 |
| d3072 4-bit | 0.77200 / 0.77200 | 0.80700 / 0.80700 | 0.84113 / 0.84137 | 0.86797 / 0.86794 |

(base / new. Absolute values are low because the fixture is uniform-random on the sphere — the hardest case; only the comparison matters.) R@1 and R@4 identical everywhere; largest movement anywhere 2.4e-4, i.e. a couple of near-ties reordering, exactly what a last-ulp change predicts.

## Things review should know

**The measurements are not from the official x86 environment.** This ran on a Cascade Lake Xeon with 4 vCPUs, not the GCP `c3-standard-8` Sapphire Rapids instance the published cells use. The baseline reproduces the committed x86 numbers closely (bulk 28.8k vs the published 29.5k, warm 45.1k vs 45.4k, single add 24.1 vs 23.3 µs), so the deltas should carry — but I have deliberately **not** touched `benchmarks/results/*.json`, `docs/x86_*.svg`, or the README's x86 cells. Those need a run on the official instance, and **the published insert numbers are stale-low until then.** Cascade Lake also lacks the VBMI/VBMI2 that Sapphire Rapids has, so there may be more on the table.

**Treat the AVX-512 paths as single-machine-verified.** GitHub-hosted runners are not guaranteed to have AVX-512, so the two AVX-512 kernels are likely compile-checked but not executed in CI. `TURBOVEC_REQUIRE_SIMD=avx2,avx512f` makes that measurable rather than invisible; a designated runner or an Intel SDE leg is the real follow-up.

**The `speed_persist_*` cells ship without results** — they need the real OpenAI corpus and both official environments.

**Encoded bytes change relative to earlier unreleased builds** — ~1 ULP in the stored scale, and at an exact boundary tie one code. Both v5 and v6 are unreleased, so nothing published is affected, but it is a real change and the CHANGELOG says so.

**`clippy::manual_is_multiple_of` now fires on nine pre-existing `% n == 0` sites**, un-gated by the MSRV bump. Left alone as scope creep — happy to fix in a follow-up.

**Commits are one logical change each**, each perf commit carrying its own measured before/after, so a hypothesis that doesn't hold up on the official instance can be reverted individually.

## Adversarial review

@q-turbovec-bot reviewed and found six issues; all were real and all are fixed in the last commit. The two worth knowing about:

- **`faiss.omp_set_num_threads(0)` in the 8 MT persistence cells.** I wrote 0 meaning "default"; libgomp clamps it to one thread. Every MT FAISS comparator would have been single-threaded against multi-threaded turbovec — a silent skew flattering us, in scripts whose whole purpose is publishable comparisons.
- **The codebook was pinned across platforms but not across builds.** Fixed with the golden test described above. Worth noting that my first version of that test *passed vacuously* — `codebook_for_write` returns an all-zero placeholder for an empty index, so it was hashing zeros; it only surfaced because I asserted against the CI-observed constants, which it then failed.

## Follow-ups I'd file rather than smuggle in

- Precompute/pin the codebook — the genuinely by-construction fix for the last determinism gap (#259 names it; non-trivial since `dim` is user-chosen).
- **4-bit Lloyd-Max never converges**: `max_iter = 200`, `tol = 1e-12`, final max change ~1e-8 at dim 768/1536/3072. Harmless for the format, but that codebook isn't the converged optimum; raising the cap moves it and needs a recall check.
- Incremental blocked-cache patching on mutation (the removal item above, shared with #274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XD4wYtSwU5SRSq6TNuhRJ5