### PR TITLE
chore: summarize skill outputs 1–2 paragraphs instead of 2–3

### DIFF
--- a/.claude/skills/summarize/SKILL.md
+++ b/.claude/skills/summarize/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: summarize
-description: Write a short, plain-English summary of whatever it's attached to — an issue, a pull request, or a diff. Two or three paragraphs, no jargon, aimed at a non-expert. Use when asked to summarize or explain something simply.
+description: Write a short, plain-English summary of whatever it's attached to — an issue, a pull request, or a diff. One or two paragraphs, no jargon, aimed at a non-expert. Use when asked to summarize or explain something simply.
 ---
 
 # Summarize (plain English)
 
 Summarize whatever this is attached to — the issue, pull request, or diff.
 
-- Two or three short paragraphs. No headers, no bullet points.
+- One or two short paragraphs. No headers, no bullet points.
 - Plain English, simple enough for a non-expert. Say what it does and why
   it matters; skip the implementation and format details.
 - Direct and matter-of-fact. No hype, no marketing language.


### PR DESCRIPTION
Shortens the /summarize skill's target length from two-or-three paragraphs to one-or-two, in both the skill description and the instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)