### PR TITLE
perf: save-path hill-climb + optional fast-durability writes (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ appears under each surface it touches.
 
 #### Added
 
+- **Optional fast-durability writes (#274).** `write` stays fully durable
+  by default (temp file, fsync, atomic rename, and now a parent-directory
+  fsync so the rename itself is on stable storage — closing a gap between
+  the documented power-loss guarantee and the implementation). New
+  `TurboQuantIndex::write_with_durability` / `IdMapIndex::write_with_durability`
+  take an `io::Durability`: `Fast` keeps the temp-file + atomic-rename
+  protocol — the destination can never hold a torn index and the previous
+  file survives a process crash — but skips fsync (not power-loss-safe;
+  documented). Byte-identical output either way. Measured on the 200k ×
+  768 4-bit reference workload: x86 386 → 286 ms, ARM 191 → 119 ms.
+- **Save-path performance (#274).** Mutations now maintain the SIMD-blocked
+  cache incrementally (only touched blocks recompute), so a mutate-then-save
+  no longer pays the full O(n·dim) repack: post-mutation saves dropped from
+  1037 → 391 ms (x86) and 495 → 131 ms (ARM), equal to warm saves — also
+  resolving the mutate-then-save item tracked in #273. On x86, path writes
+  use parallel positioned writes for the codes section (small additional
+  win; ARM keeps the streamed writer, where the same technique regresses).
+  Temp files now carry a per-process sequence number so concurrent saves to
+  one path cannot interleave.
+
 - **File format v6 for `.tv` / `.tvim`: the file *is* the search-ready
   index — loads skip the first-search rebuild entirely (#68).** The code
   payload is now stored in the arch-neutral *sequential blocked* layout
@@ -376,6 +396,10 @@ appears under each surface it touches.
 ### turbovec — Python package
 
 #### Added
+
+- `write(path, durable=False)` on `TurboQuantIndex` and `IdMapIndex`:
+  keeps atomic-replace semantics but skips fsync (not power-loss-safe) —
+  see the Rust-surface entry for details and measurements (#274).
 
 - **Per-store similarity modes for all four integration stores**
   (LangChain, Haystack, LlamaIndex, Agno), fixed at construction and

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -451,13 +451,24 @@ impl TurboQuantIndex {
         Ok((scores, indices))
     }
 
-    fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+    /// Persist the index. ``durable=True`` (the default) fsyncs before
+    /// the atomic rename, surviving power loss; ``durable=False`` keeps
+    /// the temp-file + atomic-rename protocol (the destination can never
+    /// hold a torn index and the previous file survives a process crash)
+    /// but skips fsync — faster, not power-loss-safe.
+    #[pyo3(signature = (path, *, durable = true))]
+    fn write(&self, py: Python<'_>, path: &str, durable: bool) -> PyResult<()> {
+        let durability = if durable {
+            turbovec_core::io::Durability::Durable
+        } else {
+            turbovec_core::io::Durability::Fast
+        };
         // Lock on the calling thread, never inside `with_pool` (see its
         // invariant); the v6 write path parallelizes the layout
         // transform, so it must run in the fork-safe pool.
         py.detach(|| {
             let guard = lock_read(&self.inner);
-            with_pool(|| guard.write(path))
+            with_pool(|| guard.write_with_durability(path, durability))
         })?
         .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
@@ -869,13 +880,24 @@ impl IdMapIndex {
     }
 
     /// Serialize the index and id-map side-tables to a `.tvim` file.
-    fn write(&self, py: Python<'_>, path: &str) -> PyResult<()> {
+    /// Persist the index. ``durable=True`` (the default) fsyncs before
+    /// the atomic rename, surviving power loss; ``durable=False`` keeps
+    /// the temp-file + atomic-rename protocol (the destination can never
+    /// hold a torn index and the previous file survives a process crash)
+    /// but skips fsync — faster, not power-loss-safe.
+    #[pyo3(signature = (path, *, durable = true))]
+    fn write(&self, py: Python<'_>, path: &str, durable: bool) -> PyResult<()> {
+        let durability = if durable {
+            turbovec_core::io::Durability::Durable
+        } else {
+            turbovec_core::io::Durability::Fast
+        };
         // Lock on the calling thread, never inside `with_pool` (see its
         // invariant); the v6 write path parallelizes the layout
         // transform, so it must run in the fork-safe pool.
         py.detach(|| {
             let guard = lock_read(&self.inner);
-            with_pool(|| guard.write(path))
+            with_pool(|| guard.write_with_durability(path, durability))
         })?
         .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -345,9 +345,19 @@ impl IdMapIndex {
     /// Serialize to a `.tvim` file — the inner quantized index plus the
     /// id-map side-tables. Round-trips exactly through [`Self::load`].
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        self.write_with_durability(path, io::Durability::Durable)
+    }
+
+    /// [`Self::write`] with an explicit [`io::Durability`] level (see
+    /// [`TurboQuantIndex::write_with_durability`]).
+    pub fn write_with_durability(
+        &self,
+        path: impl AsRef<Path>,
+        durability: io::Durability,
+    ) -> std::io::Result<()> {
         // Mirror TurboQuantIndex::write: dim=0 means lazy-uninitialized.
         let (boundaries, centroids) = self.inner.codebook_for_write();
-        io::write_id_map(
+        io::write_id_map_with_durability(
             path,
             self.inner.bit_width(),
             self.inner.dim_opt().unwrap_or(0),
@@ -359,6 +369,7 @@ impl IdMapIndex {
             self.inner.tqplus_shift(),
             self.inner.tqplus_scale(),
             &self.slot_to_id,
+            durability,
         )
     }
 

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -73,6 +73,27 @@ const REBUILD_HINT: &str =
      block-Hadamard transform, which changes every encoded byte; there is no \
      in-place migration.";
 
+/// Durability level for path-based writes.
+///
+/// * [`Durability::Durable`] (the default everywhere): write to a
+///   sibling temp file, `fsync` it (`F_FULLFSYNC` on macOS), then
+///   atomically rename over the destination. Survives process crashes
+///   AND power loss: the destination always holds a complete old or
+///   complete new index, and a completed save is on stable storage.
+/// * [`Durability::Fast`]: identical temp-file + atomic-rename protocol
+///   but no fsync. The destination still can never hold a torn index
+///   and a process crash cannot lose the previous file — but a power
+///   loss or kernel panic shortly after a "completed" save may lose or
+///   truncate the new file. Choose this only when the index is
+///   reproducible or durability is handled elsewhere (e.g. the file is
+///   about to be uploaded or the filesystem is transient).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Durability {
+    #[default]
+    Durable,
+    Fast,
+}
+
 /// The code bytes a load produced, tagged with the layout the file
 /// stored them in. v6 files carry the arch-neutral sequential blocked
 /// layout; v5 files carry per-vector bit-plane rows. The caller
@@ -128,10 +149,32 @@ pub fn write(
     // Validate before any file is created so a violation cannot destroy
     // a previous good index at `path`. (`write_to` re-asserts —
     // harmlessly — for its direct callers.)
+    write_with_durability(
+        path, bit_width, dim, n_vectors, codes_blocked_seq,
+        codebook_boundaries, codebook_centroids, scales,
+        tqplus_shift, tqplus_scale, Durability::Durable,
+    )
+}
+
+/// [`write`] with an explicit [`Durability`] level.
+#[allow(clippy::too_many_arguments)]
+pub fn write_with_durability(
+    path: impl AsRef<Path>,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    codes_blocked_seq: &[u8],
+    codebook_boundaries: &[f32],
+    codebook_centroids: &[f32],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    durability: Durability,
+) -> io::Result<()> {
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
     #[cfg(target_arch = "x86_64")]
     {
-        return write_atomic_parallel(path.as_ref(), TV_MAGIC, TV_VERSION, |head| {
+        return write_atomic_parallel(path.as_ref(), durability, TV_MAGIC, TV_VERSION, |head| {
             head_core(head, bit_width, dim, n_vectors, codebook_boundaries, codebook_centroids)
         }, codes_blocked_seq, |tail| {
             tail_core(tail, scales, tqplus_shift, tqplus_scale);
@@ -139,7 +182,7 @@ pub fn write(
         });
     }
     #[cfg(not(target_arch = "x86_64"))]
-    write_atomic(path.as_ref(), |f| {
+    write_atomic(path.as_ref(), durability, |f| {
         write_to(
             f, bit_width, dim, n_vectors, codes_blocked_seq,
             codebook_boundaries, codebook_centroids, scales,
@@ -277,9 +320,40 @@ pub fn write_id_map(
     );
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
 
+    write_id_map_with_durability(
+        path, bit_width, dim, n_vectors, codes_blocked_seq,
+        codebook_boundaries, codebook_centroids, scales,
+        tqplus_shift, tqplus_scale, slot_to_id, Durability::Durable,
+    )
+}
+
+/// [`write_id_map`] with an explicit [`Durability`] level.
+#[allow(clippy::too_many_arguments)]
+pub fn write_id_map_with_durability(
+    path: impl AsRef<Path>,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    codes_blocked_seq: &[u8],
+    codebook_boundaries: &[f32],
+    codebook_centroids: &[f32],
+    scales: &[f32],
+    tqplus_shift: &[f32],
+    tqplus_scale: &[f32],
+    slot_to_id: &[u64],
+    durability: Durability,
+) -> io::Result<()> {
+    assert_eq!(
+        slot_to_id.len(),
+        n_vectors,
+        "slot_to_id length {} does not match n_vectors {}",
+        slot_to_id.len(),
+        n_vectors,
+    );
+    assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
     #[cfg(target_arch = "x86_64")]
     {
-        return write_atomic_parallel(path.as_ref(), TVIM_MAGIC, TVIM_VERSION, |head| {
+        return write_atomic_parallel(path.as_ref(), durability, TVIM_MAGIC, TVIM_VERSION, |head| {
             head_core(head, bit_width, dim, n_vectors, codebook_boundaries, codebook_centroids)
         }, codes_blocked_seq, |tail| {
             tail_core(tail, scales, tqplus_shift, tqplus_scale);
@@ -290,7 +364,7 @@ pub fn write_id_map(
         });
     }
     #[cfg(not(target_arch = "x86_64"))]
-    write_atomic(path.as_ref(), |f| {
+    write_atomic(path.as_ref(), durability, |f| {
         write_id_map_to(
             f, bit_width, dim, n_vectors, codes_blocked_seq,
             codebook_boundaries, codebook_centroids, scales,
@@ -486,6 +560,7 @@ fn tail_core(tail: &mut Vec<u8>, scales: &[f32], tqplus_shift: &[f32], tqplus_sc
 /// fsync, then atomic rename. Small payloads take one serial write.
 fn write_atomic_parallel(
     path: &Path,
+    durability: Durability,
     magic: &[u8; 4],
     version: u8,
     head_fn: impl FnOnce(&mut Vec<u8>) -> io::Result<()>,
@@ -549,7 +624,9 @@ fn write_atomic_parallel(
                 return Err(e);
             }
         }
-        f.sync_all()?;
+        if durability == Durability::Durable {
+            f.sync_all()?;
+        }
         std::fs::rename(&tmp, path)
     })();
     if result.is_err() {
@@ -577,6 +654,7 @@ fn write_all_at(f: &File, mut buf: &[u8], mut off: u64) -> io::Result<()> {
 
 fn write_atomic(
     path: &Path,
+    durability: Durability,
     write_payload: impl FnOnce(&mut BufWriter<&File>) -> io::Result<()>,
 ) -> io::Result<()> {
     let tmp: PathBuf = {
@@ -593,7 +671,9 @@ fn write_atomic(
         write_payload(&mut w)?;
         w.flush()?;
         drop(w);
-        f.sync_all()?;
+        if durability == Durability::Durable {
+            f.sync_all()?;
+        }
         std::fs::rename(&tmp, path)
     })();
     if result.is_err() {

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -129,6 +129,16 @@ pub fn write(
     // a previous good index at `path`. (`write_to` re-asserts —
     // harmlessly — for its direct callers.)
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
+    #[cfg(target_arch = "x86_64")]
+    {
+        return write_atomic_parallel(path.as_ref(), TV_MAGIC, TV_VERSION, |head| {
+            head_core(head, bit_width, dim, n_vectors, codebook_boundaries, codebook_centroids)
+        }, codes_blocked_seq, |tail| {
+            tail_core(tail, scales, tqplus_shift, tqplus_scale);
+            Ok(())
+        });
+    }
+    #[cfg(not(target_arch = "x86_64"))]
     write_atomic(path.as_ref(), |f| {
         write_to(
             f, bit_width, dim, n_vectors, codes_blocked_seq,
@@ -267,6 +277,19 @@ pub fn write_id_map(
     );
     assert_tqplus_calibration(dim, tqplus_shift, tqplus_scale);
 
+    #[cfg(target_arch = "x86_64")]
+    {
+        return write_atomic_parallel(path.as_ref(), TVIM_MAGIC, TVIM_VERSION, |head| {
+            head_core(head, bit_width, dim, n_vectors, codebook_boundaries, codebook_centroids)
+        }, codes_blocked_seq, |tail| {
+            tail_core(tail, scales, tqplus_shift, tqplus_scale);
+            for &id in slot_to_id {
+                tail.extend_from_slice(&id.to_le_bytes());
+            }
+            Ok(())
+        });
+    }
+    #[cfg(not(target_arch = "x86_64"))]
     write_atomic(path.as_ref(), |f| {
         write_id_map_to(
             f, bit_width, dim, n_vectors, codes_blocked_seq,
@@ -415,6 +438,143 @@ fn assert_tqplus_calibration(dim: usize, tqplus_shift: &[f32], tqplus_scale: &[f
 /// over the destination (atomic on POSIX). On any failure the previous
 /// file at `path` is left untouched and the temp file is removed
 /// (best effort), so a reader never observes a partial index.
+/// Serialize the fixed head (post-magic/version core header + codebook)
+/// into a buffer.
+fn head_core(
+    head: &mut Vec<u8>,
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    codebook_boundaries: &[f32],
+    codebook_centroids: &[f32],
+) -> io::Result<()> {
+    let n_levels = 1usize << bit_width;
+    assert_eq!(codebook_boundaries.len(), n_levels - 1, "codebook boundaries length");
+    assert_eq!(codebook_centroids.len(), n_levels, "codebook centroids length");
+    head.push(bit_width as u8);
+    head.extend_from_slice(&(dim as u32).to_le_bytes());
+    head.extend_from_slice(&(n_vectors as u64).to_le_bytes());
+    for &b in codebook_boundaries {
+        head.extend_from_slice(&b.to_le_bytes());
+    }
+    for &c in codebook_centroids {
+        head.extend_from_slice(&c.to_le_bytes());
+    }
+    Ok(())
+}
+
+/// Serialize the post-codes tail sections (scales + TQ+ trailer).
+fn tail_core(tail: &mut Vec<u8>, scales: &[f32], tqplus_shift: &[f32], tqplus_scale: &[f32]) {
+    for &s in scales {
+        tail.extend_from_slice(&s.to_le_bytes());
+    }
+    tail.extend_from_slice(&(tqplus_shift.len() as u32).to_le_bytes());
+    for &s in tqplus_shift {
+        tail.extend_from_slice(&s.to_le_bytes());
+    }
+    for &s in tqplus_scale {
+        tail.extend_from_slice(&s.to_le_bytes());
+    }
+}
+
+/// Atomic path write with the large codes section written by parallel
+/// positioned writes (mirror of the load-side fast path): head and tail
+/// serialize into small buffers and pwrite at their computed offsets;
+/// the codes span is split across scoped threads. Byte-identical output
+/// to the streamed writer (same sections, same order on disk), and the
+/// durability protocol is unchanged: everything lands in the temp file,
+/// fsync, then atomic rename. Small payloads take one serial write.
+fn write_atomic_parallel(
+    path: &Path,
+    magic: &[u8; 4],
+    version: u8,
+    head_fn: impl FnOnce(&mut Vec<u8>) -> io::Result<()>,
+    codes: &[u8],
+    tail_fn: impl FnOnce(&mut Vec<u8>) -> io::Result<()>,
+) -> io::Result<()> {
+    let mut head = Vec::with_capacity(4096);
+    head.extend_from_slice(magic);
+    head.push(version);
+    head_fn(&mut head)?;
+    let mut tail = Vec::new();
+    tail_fn(&mut tail)?;
+
+    let tmp: PathBuf = {
+        let mut name = path
+            .file_name()
+            .map(std::ffi::OsStr::to_os_string)
+            .unwrap_or_default();
+        name.push(format!(".tmp.{}", std::process::id()));
+        path.with_file_name(name)
+    };
+    let result = (|| {
+        let f = File::create(&tmp)?;
+        const PAR_MIN: usize = 8 * 1024 * 1024;
+        let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+        if codes.len() < PAR_MIN || n_threads < 2 {
+            let mut w = BufWriter::new(&f);
+            w.write_all(&head)?;
+            w.write_all(codes)?;
+            w.write_all(&tail)?;
+            w.flush()?;
+            drop(w);
+        } else {
+            f.set_len((head.len() + codes.len() + tail.len()) as u64)?;
+            write_all_at(&f, &head, 0)?;
+            write_all_at(&f, &tail, (head.len() + codes.len()) as u64)?;
+            let base = head.len() as u64;
+            let chunk = codes.len().div_ceil(n_threads).max(PAR_MIN).next_multiple_of(4096);
+            let n_chunks = codes.len().div_ceil(chunk);
+            let next = std::sync::atomic::AtomicUsize::new(0);
+            let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
+            std::thread::scope(|s| {
+                for _ in 0..n_threads.min(n_chunks) {
+                    s.spawn(|| loop {
+                        let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if i >= n_chunks {
+                            break;
+                        }
+                        let off = i * chunk;
+                        let this = chunk.min(codes.len() - off);
+                        if let Err(e) =
+                            write_all_at(&f, &codes[off..off + this], base + off as u64)
+                        {
+                            *err.lock().expect("err lock") = Some(e);
+                            break;
+                        }
+                    });
+                }
+            });
+            if let Some(e) = err.into_inner().expect("err lock") {
+                return Err(e);
+            }
+        }
+        f.sync_all()?;
+        std::fs::rename(&tmp, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
+#[cfg(unix)]
+fn write_all_at(f: &File, buf: &[u8], off: u64) -> io::Result<()> {
+    use std::os::unix::fs::FileExt;
+    f.write_all_at(buf, off)
+}
+
+#[cfg(windows)]
+fn write_all_at(f: &File, mut buf: &[u8], mut off: u64) -> io::Result<()> {
+    use std::os::windows::fs::FileExt;
+    while !buf.is_empty() {
+        let n = f.seek_write(buf, off)?;
+        buf = &buf[n..];
+        off += n as u64;
+    }
+    Ok(())
+}
+
 fn write_atomic(
     path: &Path,
     write_payload: impl FnOnce(&mut BufWriter<&File>) -> io::Result<()>,

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -510,7 +510,7 @@ fn write_atomic_parallel(
     let result = (|| {
         let f = File::create(&tmp)?;
         const PAR_MIN: usize = 8 * 1024 * 1024;
-        let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+        let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1).min(4);
         if codes.len() < PAR_MIN || n_threads < 2 {
             let mut w = BufWriter::new(&f);
             w.write_all(&head)?;

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -507,11 +507,50 @@ fn assert_tqplus_calibration(dim: usize, tqplus_shift: &[f32], tqplus_scale: &[f
     );
 }
 
-/// Atomically replace `path` with a freshly-written payload: write to a
-/// sibling temp file in the same directory, flush + fsync, then rename
-/// over the destination (atomic on POSIX). On any failure the previous
-/// file at `path` is left untouched and the temp file is removed
-/// (best effort), so a reader never observes a partial index.
+/// Process-wide counter distinguishing concurrent saves to the same
+/// path from one process: `.tmp.{pid}` alone would interleave two
+/// threads' writes into one temp file and rename the corruption into
+/// place, defeating the torn-index guarantee.
+static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn tmp_sibling(path: &Path) -> PathBuf {
+    let mut name = path
+        .file_name()
+        .map(std::ffi::OsStr::to_os_string)
+        .unwrap_or_default();
+    name.push(format!(
+        ".tmp.{}.{}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
+    path.with_file_name(name)
+}
+
+/// In `Durable` mode, fsync the parent directory after the rename so the
+/// rename itself — not just the new file's contents — is on stable
+/// storage; without it, power loss can roll the rename back to the
+/// previous file. (That older state is still a complete index either
+/// way; this closes the gap between the documented guarantee and the
+/// implementation.) Windows has no directory-fsync equivalent; rename
+/// durability there follows NTFS metadata journaling.
+fn sync_parent_dir(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        if let Some(parent) = path.parent() {
+            let dir = if parent.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                parent
+            };
+            File::open(dir)?.sync_all()?;
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
 /// Serialize the fixed head (post-magic/version core header + codebook)
 /// into a buffer.
 fn head_core(
@@ -537,6 +576,7 @@ fn head_core(
     Ok(())
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Serialize the post-codes tail sections (scales + TQ+ trailer).
 fn tail_core(tail: &mut Vec<u8>, scales: &[f32], tqplus_shift: &[f32], tqplus_scale: &[f32]) {
     for &s in scales {
@@ -551,6 +591,7 @@ fn tail_core(tail: &mut Vec<u8>, scales: &[f32], tqplus_shift: &[f32], tqplus_sc
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Atomic path write with the large codes section written by parallel
 /// positioned writes (mirror of the load-side fast path): head and tail
 /// serialize into small buffers and pwrite at their computed offsets;
@@ -574,14 +615,7 @@ fn write_atomic_parallel(
     let mut tail = Vec::new();
     tail_fn(&mut tail)?;
 
-    let tmp: PathBuf = {
-        let mut name = path
-            .file_name()
-            .map(std::ffi::OsStr::to_os_string)
-            .unwrap_or_default();
-        name.push(format!(".tmp.{}", std::process::id()));
-        path.with_file_name(name)
-    };
+    let tmp: PathBuf = tmp_sibling(path);
     let result = (|| {
         let f = File::create(&tmp)?;
         const PAR_MIN: usize = 8 * 1024 * 1024;
@@ -601,10 +635,14 @@ fn write_atomic_parallel(
             let chunk = codes.len().div_ceil(n_threads).max(PAR_MIN).next_multiple_of(4096);
             let n_chunks = codes.len().div_ceil(chunk);
             let next = std::sync::atomic::AtomicUsize::new(0);
+            let failed = std::sync::atomic::AtomicBool::new(false);
             let err: std::sync::Mutex<Option<io::Error>> = std::sync::Mutex::new(None);
             std::thread::scope(|s| {
                 for _ in 0..n_threads.min(n_chunks) {
                     s.spawn(|| loop {
+                        if failed.load(std::sync::atomic::Ordering::Relaxed) {
+                            break;
+                        }
                         let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         if i >= n_chunks {
                             break;
@@ -614,6 +652,7 @@ fn write_atomic_parallel(
                         if let Err(e) =
                             write_all_at(&f, &codes[off..off + this], base + off as u64)
                         {
+                            failed.store(true, std::sync::atomic::Ordering::Relaxed);
                             *err.lock().expect("err lock") = Some(e);
                             break;
                         }
@@ -627,7 +666,11 @@ fn write_atomic_parallel(
         if durability == Durability::Durable {
             f.sync_all()?;
         }
-        std::fs::rename(&tmp, path)
+        std::fs::rename(&tmp, path)?;
+        if durability == Durability::Durable {
+            sync_parent_dir(path)?;
+        }
+        Ok(())
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&tmp);
@@ -635,13 +678,13 @@ fn write_atomic_parallel(
     result
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, target_arch = "x86_64"))]
 fn write_all_at(f: &File, buf: &[u8], off: u64) -> io::Result<()> {
     use std::os::unix::fs::FileExt;
     f.write_all_at(buf, off)
 }
 
-#[cfg(windows)]
+#[cfg(all(windows, target_arch = "x86_64"))]
 fn write_all_at(f: &File, mut buf: &[u8], mut off: u64) -> io::Result<()> {
     use std::os::windows::fs::FileExt;
     while !buf.is_empty() {
@@ -652,19 +695,20 @@ fn write_all_at(f: &File, mut buf: &[u8], mut off: u64) -> io::Result<()> {
     Ok(())
 }
 
+/// Atomically replace `path` with a freshly-written payload: write to a
+/// sibling temp file in the same directory, flush + fsync (in `Durable`
+/// mode), then rename over the destination (atomic on POSIX). On any
+/// failure the previous file at `path` is left untouched and the temp
+/// file is removed (best effort), so a reader never observes a partial
+/// index. Non-x86 streamed-path counterpart of
+/// [`write_atomic_parallel`].
+#[cfg(not(target_arch = "x86_64"))]
 fn write_atomic(
     path: &Path,
     durability: Durability,
     write_payload: impl FnOnce(&mut BufWriter<&File>) -> io::Result<()>,
 ) -> io::Result<()> {
-    let tmp: PathBuf = {
-        let mut name = path
-            .file_name()
-            .map(std::ffi::OsStr::to_os_string)
-            .unwrap_or_default();
-        name.push(format!(".tmp.{}", std::process::id()));
-        path.with_file_name(name)
-    };
+    let tmp: PathBuf = tmp_sibling(path);
     let result = (|| {
         let f = File::create(&tmp)?;
         let mut w = BufWriter::new(&f);
@@ -674,7 +718,11 @@ fn write_atomic(
         if durability == Durability::Durable {
             f.sync_all()?;
         }
-        std::fs::rename(&tmp, path)
+        std::fs::rename(&tmp, path)?;
+        if durability == Durability::Durable {
+            sync_parent_dir(path)?;
+        }
+        Ok(())
     })();
     if result.is_err() {
         let _ = std::fs::remove_file(&tmp);

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -453,13 +453,31 @@ impl TurboQuantIndex {
             self.tqplus_scale = scale_tq;
         }
         // else: tqplus_shift/scale unchanged — locked by the first add.
+        let old_n = self.n_vectors;
         self.n_vectors += n;
 
-        // Invalidate the blocked cache — it was derived from the old
-        // `packed_codes` and no longer matches the extended vector set.
-        // Rotation, boundaries, and centroids remain valid (they only depend
-        // on `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
-        self.blocked = OnceLock::new();
+        // Maintain the blocked cache incrementally instead of discarding
+        // it: appended rows only affect the (possibly partial) tail block
+        // and the new blocks after it, so recompute exactly those from
+        // the packed rows. A cold cache stays cold (first search builds
+        // it). Rotation, boundaries, and centroids remain valid (they
+        // only depend on `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
+        if let Some(cache) = self.blocked.get_mut() {
+            let (new_n_blocks, n_byte_groups, _) =
+                pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
+            let block_bytes = n_byte_groups * BLOCK;
+            let first_block = old_n / BLOCK;
+            cache.data.truncate(first_block * block_bytes);
+            cache.data.extend_from_slice(&pack::repack_block_range(
+                self.packed_codes.get().expect("packed materialized in add"),
+                self.n_vectors,
+                self.bit_width,
+                dim,
+                first_block,
+                new_n_blocks,
+            ));
+            cache.n_blocks = new_n_blocks;
+        }
     }
 
     /// Add `vectors` of dimension `dim`. On a lazy index this locks the
@@ -1273,8 +1291,31 @@ impl TurboQuantIndex {
         self.scales.truncate(last);
         self.n_vectors -= 1;
 
-        // Invalidate the blocked cache since it was derived from the old layout.
-        self.blocked = OnceLock::new();
+        // Maintain the blocked cache incrementally: only the block that
+        // received the moved row and the (now shorter) tail block
+        // changed. The tail must be recomputed even though kernels mask
+        // lanes >= n_vectors, because serialization copies the cache
+        // verbatim — stale padding lanes would break byte determinism.
+        if let Some(cache) = self.blocked.get_mut() {
+            let (new_n_blocks, n_byte_groups, _) =
+                pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
+            let block_bytes = n_byte_groups * BLOCK;
+            cache.data.truncate(new_n_blocks * block_bytes);
+            cache.n_blocks = new_n_blocks;
+            let packed = self.packed_codes.get().expect("packed materialized in swap_remove");
+            let mut redo = |b: usize| {
+                if b < new_n_blocks {
+                    let patch = pack::repack_block_range(
+                        packed, self.n_vectors, self.bit_width, dim, b, b + 1,
+                    );
+                    cache.data[b * block_bytes..(b + 1) * block_bytes].copy_from_slice(&patch);
+                }
+            };
+            redo(idx / BLOCK);
+            if new_n_blocks > 0 {
+                redo(new_n_blocks - 1);
+            }
+        }
 
         last
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -735,13 +735,27 @@ impl TurboQuantIndex {
     }
 
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
+        self.write_with_durability(path, io::Durability::Durable)
+    }
+
+    /// [`Self::write`] with an explicit [`io::Durability`] level:
+    /// `Durable` (the default) fsyncs before the atomic rename; `Fast`
+    /// keeps the temp-file + atomic-rename protocol (the destination can
+    /// never hold a torn index and the previous file survives a process
+    /// crash) but skips fsync, so a power loss shortly after a completed
+    /// save may lose the new file.
+    pub fn write_with_durability(
+        &self,
+        path: impl AsRef<Path>,
+        durability: io::Durability,
+    ) -> std::io::Result<()> {
         // Sentinel: dim=0 in the file header means "lazy index, dim never
         // committed". The loader interprets dim=0 + n_vectors=0 as a
         // freshly-constructed lazy state. dim=0 is otherwise meaningless
         // (the constructor asserts dim % 8 == 0 with dim >= 8), so this
         // doesn't collide with any valid eager index.
         let (boundaries, centroids) = self.codebook_for_write();
-        io::write(
+        io::write_with_durability(
             path,
             self.bit_width,
             self.dim.unwrap_or(0),
@@ -752,6 +766,7 @@ impl TurboQuantIndex {
             &self.scales,
             &self.tqplus_shift,
             &self.tqplus_scale,
+            durability,
         )
     }
 

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -285,6 +285,10 @@ pub(crate) fn repack_block_range(
     let n_byte_groups = dim / codes_per_byte;
     let first_vec = block_start * BLOCK;
     let end_vec = (block_end * BLOCK).min(n_vectors);
+    debug_assert!(
+        first_vec <= n_vectors,
+        "repack_block_range: block range starts beyond n_vectors"
+    );
     let n_range = end_vec.saturating_sub(first_vec);
     // Extract only the range's rows (indices relative to the range).
     let bytes_per_plane = dim / 8;

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -267,6 +267,35 @@ pub(crate) fn seq_into_native(seq: Vec<u8>) -> Vec<u8> {
     }
 }
 
+/// Rebuild the *native* blocked layout for blocks `[block_start,
+/// block_end)` from the packed bit-plane rows — the incremental-cache
+/// primitive: a mutation recomputes only the blocks it touched instead
+/// of discarding the whole cache. Lanes at or beyond `n_vectors` are
+/// zero (matching the full repack exactly, so serialized bytes stay
+/// deterministic).
+pub(crate) fn repack_block_range(
+    packed_codes: &[u8],
+    n_vectors: usize,
+    bits: usize,
+    dim: usize,
+    block_start: usize,
+    block_end: usize,
+) -> Vec<u8> {
+    let codes_per_byte = 8 / bits;
+    let n_byte_groups = dim / codes_per_byte;
+    let first_vec = block_start * BLOCK;
+    let end_vec = (block_end * BLOCK).min(n_vectors);
+    let n_range = end_vec.saturating_sub(first_vec);
+    // Extract only the range's rows (indices relative to the range).
+    let bytes_per_plane = dim / 8;
+    let bytes_per_row = bits * bytes_per_plane;
+    let sub_packed = &packed_codes[first_vec * bytes_per_row..end_vec * bytes_per_row];
+    let codes_flat = extract_codes_flat(sub_packed, n_range, bits, dim);
+    let range_blocks = block_end - block_start;
+    let blocked_size = range_blocks * n_byte_groups * BLOCK;
+    pack_blocked(n_range, range_blocks, n_byte_groups, blocked_size, &codes_flat, &PERM0)
+}
+
 /// Native search layout → sequential blocked layout — [`seq_into_native`]'s
 /// inverse. Lets the write path serialize a warm in-memory blocked cache
 /// without a full O(n·dim) repack from bit-planes.

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -349,3 +349,32 @@ fn empty_index_prepare_skips_rotation_build() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// Fast-durability writes keep the atomic protocol: byte-identical
+/// output to durable writes, previous file preserved on failure, no
+/// temp strays — only the fsync is skipped.
+#[test]
+fn fast_durability_write_is_atomic_and_byte_identical() {
+    use turbovec::io::Durability;
+    let dir = temp_dir("fast-durability");
+    let p_durable = dir.join("d.tv");
+    let p_fast = dir.join("f.tv");
+    let mut idx = TurboQuantIndex::new(32, 4).unwrap();
+    let v: Vec<f32> = (0..64 * 32).map(|i| (i % 97) as f32 / 97.0 - 0.5).collect();
+    idx.add(&v);
+    idx.write(&p_durable).unwrap();
+    idx.write_with_durability(&p_fast, Durability::Fast).unwrap();
+    assert_eq!(
+        std::fs::read(&p_durable).unwrap(),
+        std::fs::read(&p_fast).unwrap(),
+        "fast writes must be byte-identical to durable writes",
+    );
+    // Overwrite with fast mode; loads fine, no temp strays.
+    idx.write_with_durability(&p_fast, Durability::Fast).unwrap();
+    TurboQuantIndex::load(&p_fast).unwrap();
+    assert!(
+        dir_entries(&dir).iter().all(|n| !n.contains(".tmp.")),
+        "no temp strays after fast writes",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -351,8 +351,9 @@ fn empty_index_prepare_skips_rotation_build() {
 }
 
 /// Fast-durability writes keep the atomic protocol: byte-identical
-/// output to durable writes, previous file preserved on failure, no
-/// temp strays — only the fsync is skipped.
+/// output to durable writes and no temp strays — only the fsync is
+/// skipped. (Failure-path preservation is covered by the panicking-
+/// write tests above.)
 #[test]
 fn fast_durability_write_is_atomic_and_byte_identical() {
     use turbovec::io::Durability;
@@ -375,6 +376,53 @@ fn fast_durability_write_is_atomic_and_byte_identical() {
     assert!(
         dir_entries(&dir).iter().all(|n| !n.contains(".tmp.")),
         "no temp strays after fast writes",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The parallel-pwrite branch of the x86 path writer engages only for
+/// codes >= 8 MiB; every other test uses tiny indexes and exercises the
+/// serial fallback. This covers the branch that runs on real saves:
+/// large synthetic sections, both durability modes, byte parity with
+/// the streamed writer, and a successful load.
+#[test]
+fn large_payload_write_matches_streamed_writer_in_both_durability_modes() {
+    use turbovec::io::{self, Durability};
+    let dir = temp_dir("large-parallel-write");
+    let (bit_width, dim, n_vectors) = (4usize, 768usize, 90_000usize);
+    let blocked = {
+        let len = n_vectors.div_ceil(32) * 32 * (dim / 2);
+        let mut s = 0x00D1_CEu64;
+        (0..len)
+            .map(|_| {
+                s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                (s >> 33) as u8
+            })
+            .collect::<Vec<u8>>()
+    };
+    let cb = test_codebook(bit_width);
+    let scales = vec![1.0f32; n_vectors];
+
+    let mut streamed = Vec::new();
+    io::write_to(&mut streamed, bit_width, dim, n_vectors, &blocked, &cb.0, &cb.1, &scales, &[], &[])
+        .unwrap();
+
+    for (name, durability) in [("durable", Durability::Durable), ("fast", Durability::Fast)] {
+        let p = dir.join(format!("{name}.tv"));
+        io::write_with_durability(
+            &p, bit_width, dim, n_vectors, &blocked, &cb.0, &cb.1, &scales, &[], &[], durability,
+        )
+        .unwrap();
+        assert_eq!(
+            std::fs::read(&p).unwrap(),
+            streamed,
+            "{name}: parallel path writer must be byte-identical to the streamed writer",
+        );
+        io::load(&p).unwrap();
+    }
+    assert!(
+        dir_entries(&dir).iter().all(|n| !n.contains(".tmp.")),
+        "no temp strays",
     );
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/turbovec/tests/io_v6.rs
+++ b/turbovec/tests/io_v6.rs
@@ -459,3 +459,55 @@ fn tvim_v5_file_loads_and_searches_identically() {
     assert_eq!(scores_before, scores_after);
     assert_eq!(ids_before, ids_after);
 }
+
+/// The incrementally-maintained blocked cache must be indistinguishable
+/// from a cold rebuild: after a mixed sequence of adds and removes on a
+/// warm-cached index, serialization must be byte-identical to the same
+/// logical index serialized with a cold cache (full repack path), and
+/// search results must match. Guards the #274 incremental-maintenance
+/// change (stale padding lanes or unpatched blocks would diverge here).
+#[test]
+fn incremental_blocked_cache_serializes_identically_to_cold_rebuild() {
+    let dim = 64usize;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    idx.add(&lcg_vectors(100, dim, 0xA11CE));
+    idx.prepare(); // warm the cache so mutations take the patch path
+
+    let mut step = 0u64;
+    for round in 0..6 {
+        // Adds of varied sizes, crossing block boundaries both ways.
+        let n_add = [1usize, 31, 32, 33, 7, 64][round];
+        idx.add(&lcg_vectors(n_add, dim, 0xBEEF + step));
+        step += 1;
+        // Removes from the front, middle, tail.
+        let len = idx.len();
+        idx.swap_remove(0);
+        idx.swap_remove(len / 2 - 1);
+        idx.swap_remove(idx.len() - 1);
+        idx.prepare(); // keep the cache warm through every round
+    }
+
+    let warm_bytes = idx.to_bytes();
+
+    // Cold rebuild of the same logical index: round-trip through parts,
+    // whose cache starts empty, forcing the full repack on write.
+    let cold = TurboQuantIndex::from_parts(
+        Some(dim),
+        idx.bit_width(),
+        idx.len(),
+        idx.packed_codes().to_vec(),
+        idx.scales().to_vec(),
+        idx.tqplus_shift().to_vec(),
+        idx.tqplus_scale().to_vec(),
+    )
+    .unwrap();
+    let cold_bytes = cold.to_bytes();
+    assert_eq!(warm_bytes, cold_bytes, "incremental cache diverged from cold rebuild");
+
+    // Search parity between the warm-cached index and its cold twin.
+    let q = lcg_vectors(1, dim, 0x5EED);
+    let a = idx.search(&q, 10);
+    let b = cold.search(&q, 10);
+    assert_eq!(a.indices, b.indices);
+    assert_eq!(a.scores, b.scores);
+}


### PR DESCRIPTION
## Summary

The save-side companion to the cold-load hill-climb (#276), per the method in #274: settled baselines on both official environments, hypothesis loop with one commit per confirmed win and every failure logged, and the durability floor (fsync + atomic rename) explicitly preserved — plus the requested opt-out flag for callers who want speed over power-loss safety.

## Results (200k × 768 4-bit, 79 MB, settled medians)

| regime | before | after | |
|---|---|---|---|
| x86 post-mutation save | **1037 ms** | **391 ms** | 2.7× |
| ARM post-mutation save | **495 ms** | **131 ms** | 3.8× |
| x86 warm save | 391 ms | 388 ms | at fsync floor |
| ARM warm save | 132 ms | ~126 ms | at durability floor |

**vs FAISS** (precision-matched): on x86, FAISS's `write_index` with **no** durability costs 436 ms — turbovec now saves faster (388 ms) *with* full crash-safety. On ARM the remaining gap to FAISS's 63 ms is precisely the kept durability premium (rename + F_FULLFSYNC).

## The wins

- **S1 — incremental blocked-cache maintenance** (the structural one): `add()`/`swap_remove()` patch only the blocks they touch (new `pack::repack_block_range`) instead of discarding the SIMD cache, so mutate-then-save no longer pays the O(n·dim) repack. Post-mutation saves now cost the same as warm saves on both platforms. Byte-determinism is guarded by a new test serializing a warm mutated index against a cold rebuild across block-boundary adds and front/middle/tail removes. **This also closes the shared root cause of the mutate-then-save item in #273.**
- **S12 + S13 — parallel positioned writes, x86-gated**: head/tail pwrite at computed offsets, codes span across ≤4 scoped threads; a small metronome-consistent win (8/8 settled comparisons twice over) on the VM. Gated off ARM where the same technique measurably regresses (APFS).

## New feature: optional fast-durability writes

`write()` stays fully durable by default. `write_with_durability(path, Durability::Fast)` (Rust) / `write(path, durable=False)` (Python) keeps the temp-file + atomic-rename protocol — the destination can never hold a torn index, and the previous file survives a process crash — but skips fsync: **not power-loss-safe**, documented as such. Byte-identical output either way (tested). Measured: x86 386→286 ms, ARM 191→119 ms.

## Measurement integrity notes (in the hypothesis log)

- An order-swap diagnostic exposed the original x86 warm baseline (438 ms) as fsync queue-backlog artifact; the harness now settles between reps and all baselines were re-recorded with pre-change code under the fixed harness. Comparisons throughout use same-session (often A/B/A/B) controls.
- 16 hypotheses tested so far: 3 wins committed, 13 duds reverted with measurements recorded (including one verdict re-annotated after the environment was caught lying). The hill-climb loop for #274 is still running per its termination protocol; further confirmed wins would arrive as follow-up commits.

## Verification

Full Rust suites green on ARM and x86 (including the new invariant tests), fork-safety 15/15 on Linux x86, Python 634 passed (known local llama-index quirk). Durability protocol unchanged by default; the existing panicking-write atomicity tests still pass. Rebased onto main post-#276.

Closes #274's feature ask; hill-climb portion per #274's method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
