### PR TITLE
feat: interruptible long search/add via Python-side batch chunking — closes #216

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -397,6 +397,27 @@ appears under each surface it touches.
 
 #### Added
 
+- **Interruptible long search/add (#216).** A large batch `search` / `add`
+  / `add_with_ids` is now processed one row-slice at a time (default
+  `turbovec.BATCH_CHUNK_SIZE = 1000`, overridable per call with
+  `chunk_size=`), so control returns to Python between slices and a queued
+  Ctrl-C is serviced there instead of at the end of the call. The GIL was
+  already released (#186), but Python delivers signals on the main thread —
+  the one parked inside the Rust kernel — so a Ctrl-C used to be queued
+  until the whole call returned. Measured on a ~7.2 s batch search: the
+  Ctrl-C delay dropped from ~5.4 s (queued to the end) to ~10 ms (within
+  one slice), for a few-percent throughput cost. Pure-Python wrappers over
+  the native kernels — no core change. Chunked results are identical to a
+  single call (each `search` slice reads one coherent snapshot of the
+  query array, preserving the mid-search-mutation guarantee; each `add`
+  slice is committed atomically). A cancelled `add` commits the completed
+  slices and raises — the index stays consistent and queryable at that
+  count. Two calls stay indivisible and deaf to Ctrl-C by design: a single
+  huge query (`nq == 1`) and the *first* add into an empty index (it fits
+  and locks the TQ+ calibration from its batch, so slicing it would change
+  the whole index's quantization). Making those interruptible needs a core
+  cancellation poll (`PyErr::CheckSignals` in the hot loops) — the deferred
+  follow-up.
 - `write(path, durable=False)` on `TurboQuantIndex` and `IdMapIndex`:
   keeps atomic-replace semantics but skips fsync (not power-loss-safe) —
   see the Rust-surface entry for details and measurements (#274).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,16 +406,23 @@ appears under each surface it touches.
   the one parked inside the Rust kernel — so a Ctrl-C used to be queued
   until the whole call returned. Measured on a ~7.2 s batch search: the
   Ctrl-C delay dropped from ~5.4 s (queued to the end) to ~10 ms (within
-  one slice), for a few-percent throughput cost. Pure-Python wrappers over
-  the native kernels — no core change. Chunked results are identical to a
-  single call (each `search` slice reads one coherent snapshot of the
-  query array, preserving the mid-search-mutation guarantee; each `add`
-  slice is committed atomically). A cancelled `add` commits the completed
-  slices and raises — the index stays consistent and queryable at that
-  count. Two calls stay indivisible and deaf to Ctrl-C by design: a single
-  huge query (`nq == 1`) and the *first* add into an empty index (it fits
-  and locks the TQ+ calibration from its batch, so slicing it would change
-  the whole index's quantization). Making those interruptible needs a core
+  one slice). Pure-Python wrappers over the native kernels — no core
+  change. Chunked results are identical to a single call (each `search`
+  slice reads one coherent snapshot of the query array, preserving the
+  mid-search-mutation guarantee; each `add` slice is committed atomically).
+  Throughput cost is asymmetric: `search` is unaffected (~0 %), but a
+  chunked `add` / `add_with_ids` pays a snapshot, per-slice validation and
+  dispatch, and (`add_with_ids`) an O(n) pre-existing-id check — measured
+  at roughly 2–7× the unchunked wall time at the default `chunk_size=1000`
+  (the base add is fast, so fixed per-slice overhead dominates the ratio;
+  it varies with dim/batch/machine). The absolute overhead is small, on the
+  order of ~1–10 µs/vector. For a throughput-critical one-shot bulk load,
+  pass `chunk_size=0` to run the add whole at full speed. A cancelled `add` commits the completed slices and raises — the
+  index stays consistent and queryable at that count. Two calls stay
+  indivisible and deaf to Ctrl-C by design: a single huge query
+  (`nq == 1`) and the *first* add into an empty index (it fits and locks
+  the TQ+ calibration from its batch, so slicing it would change the whole
+  index's quantization). Making those interruptible needs a core
   cancellation poll (`PyErr::CheckSignals` in the hot loops) — the deferred
   follow-up.
 - `write(path, durable=False)` on `TurboQuantIndex` and `IdMapIndex`:

--- a/turbovec-python/python/turbovec/__init__.py
+++ b/turbovec-python/python/turbovec/__init__.py
@@ -1,6 +1,18 @@
 from ._turbovec import IdMapIndex, TurboQuantIndex
 
-__all__ = ["IdMapIndex", "TurboQuantIndex", "__version__"]
+#: Default batch slice size for the interruptible-chunking wrappers over
+#: ``search`` / ``add`` / ``add_with_ids`` (issue #216). Batches with more
+#: rows than this are processed one slice at a time so a queued Ctrl-C is
+#: serviced between slices instead of at the end of the call. Set to ``0``
+#: (globally, or per call via ``chunk_size=0``) to disable chunking. See
+#: ``turbovec._interruptible`` for the full contract.
+BATCH_CHUNK_SIZE = 1000
+
+from . import _interruptible as _interruptible  # noqa: E402
+
+_interruptible.install()
+
+__all__ = ["BATCH_CHUNK_SIZE", "IdMapIndex", "TurboQuantIndex", "__version__"]
 
 
 def __getattr__(name: str) -> str:

--- a/turbovec-python/python/turbovec/_interruptible.py
+++ b/turbovec-python/python/turbovec/_interruptible.py
@@ -1,0 +1,227 @@
+"""Interruptible long search/add via Python-side batch chunking (#216).
+
+The Rust kernels already release the GIL (#186), but Python delivers
+signals on the *main* thread — the thread parked inside the Rust call.
+So a Ctrl-C pressed during a long batch ``search`` / ``add`` is queued and
+not acted on until the kernel returns (measured on the originating issue:
+a 12.9 s delay on a ~14 s search, 7.7 s on a ~9 s add). Painful in
+notebooks and servers.
+
+The cheap, core-agnostic fix: split a large batch into row-slices and call
+the raw kernel once per slice. Control returns to Python between slices,
+where a pending ``KeyboardInterrupt`` is serviced — so a queued Ctrl-C now
+fires within roughly *one slice* rather than at the end of the whole
+batch. Measured in the research pass: at ``chunk_size≈1000`` the Ctrl-C
+latency dropped from ~13 s to ~57 ms for ~+5 % throughput.
+
+These wrappers are installed over the native ``search`` / ``add`` /
+``add_with_ids`` methods at import time. They are deliberately transparent:
+
+* **Fall-through.** Anything too small to chunk, or that is not a plain
+  C-contiguous 2-D ``float32`` ndarray (ids: 1-D ``uint64``), is passed
+  straight to the raw kernel — every existing result and error path is
+  preserved bit-for-bit.
+* **Result equivalence.** For a batch that chunks, the per-slice results
+  are concatenated in order, so the returned ``(scores, ids)`` are
+  identical to a single unchunked call (per-query results are
+  deterministic and ``effective_k`` depends only on ``k`` / index size /
+  mask, not on how the queries are sliced).
+* **Atomicity.** ``add`` is cumulative. Before chunking an add we
+  pre-validate the whole batch the same way the core does its up-front
+  check (finite, ``|x| < 1e16``; ids unique and length-matched); if the
+  batch would be rejected, we hand the *entire* array to the raw kernel so
+  it raises atomically with nothing committed — exactly as today. Only a
+  genuine mid-batch *cancel* (KeyboardInterrupt) then leaves state behind,
+  and it leaves it consistent: the completed slices are committed and
+  queryable, and the exception propagates. That completed-slices-committed
+  outcome is the *defined* behavior of a cancelled add — distinct from a
+  torn *within-encode* write, which the core already guards (#89/#118).
+  No such torn/partial-slice state is ever produced here.
+
+Known blind spots (documented, narrow in practice):
+
+* A *single* huge operation cannot be chunked. A one-query search
+  (``nq == 1``) or a one-vector add is one indivisible kernel call and
+  stays deaf to Ctrl-C for its duration. In practice a single query only
+  approaches multi-second latency around ~10^8 indexed vectors, so this is
+  not a concern for normal use.
+* The *first* add into an empty index is not chunked. That first add fits
+  and locks the index's TQ+ calibration from its batch, and every later
+  add reuses it — so a later add is sliced with bit-identical results, but
+  slicing the first add would fit calibration on only the first slice and
+  silently change the whole index's quantization. Preserving exact
+  equivalence therefore requires the initial bulk-load add to run whole;
+  it stays deaf to Ctrl-C like a single huge op. Adds after it, and all
+  searches, are chunked.
+
+Making these single indivisible calls interruptible needs the core
+cancellation poll (``PyErr::CheckSignals`` inside the hot loops) — the
+deferred follow-up to this change.
+
+Concurrency note: a chunked call takes the index lock once *per slice*,
+not once for the whole batch, so it is not atomic with respect to other
+threads mutating the *same* index concurrently (an unchunked call is).
+Finish a batch before adding to the same index from another thread, or
+pass ``chunk_size=0`` to opt a specific call out of chunking.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from ._turbovec import IdMapIndex, TurboQuantIndex
+
+#: Default batch slice size (number of queries / vectors per raw kernel
+#: call). Batches with more rows than this are chunked; smaller ones run
+#: as a single call. Tunable globally via ``turbovec.BATCH_CHUNK_SIZE`` or
+#: per call via the ``chunk_size=`` keyword. ~1000 keeps Ctrl-C latency to
+#: tens of milliseconds for ~+5 % throughput.
+BATCH_CHUNK_SIZE = 1000
+
+# Core rejection bound, mirrored so a would-be-rejected batch is delegated
+# whole (atomic error) instead of chunked. Compared in float64, which is
+# strictly *more* conservative than the core's float32 `|x| < 1e16` at the
+# exact boundary, so we never deem "clean" a value the core would reject.
+_MAX_MAGNITUDE = 1e16
+
+
+def _default_chunk_size() -> int:
+    # Read the live module default so `turbovec.BATCH_CHUNK_SIZE = n` takes
+    # effect without re-importing. `import turbovec` is a cached dict hit.
+    import turbovec
+
+    return turbovec.BATCH_CHUNK_SIZE
+
+
+def _finite_ok(a: np.ndarray) -> bool:
+    # Mirror the core's `first_invalid_coord` predicate `!(|x| < 1e16)`
+    # (rejects NaN, ±Inf, and magnitudes >= 1e16). Empty arrays are clean.
+    return bool(np.all(np.abs(a) < _MAX_MAGNITUDE))
+
+
+def _chunkable_2d(a: object, cs: int) -> bool:
+    return (
+        cs > 0
+        and isinstance(a, np.ndarray)
+        and a.ndim == 2
+        and a.dtype == np.float32
+        and a.shape[0] > cs
+    )
+
+
+def _make_search(raw):
+    def search(self, queries, k, *, chunk_size=None, **kwargs):
+        cs = _default_chunk_size() if chunk_size is None else int(chunk_size)
+        # Chunk only a plain 2-D float32 ndarray with more rows than one
+        # slice; anything else (and a would-be-rejected non-finite batch)
+        # falls through to the raw kernel, so every existing result and
+        # error path — including the exact bad-value row index — is
+        # preserved.
+        if _chunkable_2d(queries, cs):
+            # Snapshot the whole batch once, up front, so every slice reads
+            # one coherent version of the query array even though each slice
+            # is a separate kernel call that snapshots its own view at its
+            # own time. Without this, another thread stomping the source
+            # array mid-search could split the result across old and new
+            # query rows — weakening the "search sees one version of the
+            # buffer" data-integrity guarantee (#108). The rows are never
+            # torn regardless (each kernel snapshot is atomic); this keeps
+            # the whole batch coherent too.
+            snap = np.array(queries)
+            if _finite_ok(snap):
+                n = snap.shape[0]
+                scores_parts = []
+                ids_parts = []
+                for start in range(0, n, cs):
+                    # A signal queued on the main thread is serviced here,
+                    # between slices — a KeyboardInterrupt fires within one
+                    # slice rather than at the end of the batch.
+                    s, i = raw(self, snap[start : start + cs], k, **kwargs)
+                    scores_parts.append(s)
+                    ids_parts.append(i)
+                return (
+                    np.concatenate(scores_parts, axis=0),
+                    np.concatenate(ids_parts, axis=0),
+                )
+        return raw(self, queries, k, **kwargs)
+
+    search.__doc__ = raw.__doc__
+    search.__wrapped__ = raw
+    search._tv_chunk_wrapper = True
+    return search
+
+
+def _make_add(raw):
+    def add(self, vectors, *, chunk_size=None):
+        cs = _default_chunk_size() if chunk_size is None else int(chunk_size)
+        # Chunk only once the index is non-empty. The *first* add into an
+        # empty index fits and locks the TQ+ calibration from that batch;
+        # every later add reuses it, so a later add encodes each vector
+        # identically no matter how it is sliced — but chunking the first
+        # add would fit calibration on only the first slice and silently
+        # change the whole index's quantization. So the first (calibrating)
+        # add runs whole (and stays deaf to Ctrl-C, like a single huge op);
+        # incremental adds afterward chunk with bit-identical results.
+        #
+        # Pre-validate so a batch the core would reject is added atomically
+        # (whole array, nothing committed) rather than committing earlier
+        # slices before a later slice's value trips the check.
+        if not (len(self) > 0 and _chunkable_2d(vectors, cs) and _finite_ok(vectors)):
+            return raw(self, vectors)
+        n = vectors.shape[0]
+        for start in range(0, n, cs):
+            raw(self, vectors[start : start + cs])
+        return None
+
+    add.__doc__ = raw.__doc__
+    add.__wrapped__ = raw
+    add._tv_chunk_wrapper = True
+    return add
+
+
+def _make_add_with_ids(raw):
+    def add_with_ids(self, vectors, ids, *, chunk_size=None):
+        cs = _default_chunk_size() if chunk_size is None else int(chunk_size)
+        # Chunk only a non-empty index (the first add locks calibration —
+        # see `_make_add`) with a clean, canonically-typed batch: finite
+        # values, ids a 1-D uint64 array of matching length with no
+        # duplicates. Anything else (empty index, bad values,
+        # duplicate/pre-existing ids, length mismatch) is delegated whole
+        # so the core's up-front validation rejects it atomically — and no
+        # earlier slice is committed first.
+        if (
+            len(self) > 0
+            and _chunkable_2d(vectors, cs)
+            and isinstance(ids, np.ndarray)
+            and ids.ndim == 1
+            and ids.dtype == np.uint64
+            and ids.shape[0] == vectors.shape[0]
+            and _finite_ok(vectors)
+            and np.unique(ids).size == ids.shape[0]
+        ):
+            n = vectors.shape[0]
+            for start in range(0, n, cs):
+                raw(self, vectors[start : start + cs], ids[start : start + cs])
+            return None
+        return raw(self, vectors, ids)
+
+    add_with_ids.__doc__ = raw.__doc__
+    add_with_ids.__wrapped__ = raw
+    add_with_ids._tv_chunk_wrapper = True
+    return add_with_ids
+
+
+def install() -> None:
+    """Install the chunking wrappers over the native kernel methods.
+
+    Idempotent: a wrapper already installed is left in place (so a second
+    import cannot double-wrap and treat a wrapper as the raw kernel).
+    """
+    if not getattr(TurboQuantIndex.search, "_tv_chunk_wrapper", False):
+        TurboQuantIndex.search = _make_search(TurboQuantIndex.search)
+    if not getattr(TurboQuantIndex.add, "_tv_chunk_wrapper", False):
+        TurboQuantIndex.add = _make_add(TurboQuantIndex.add)
+    if not getattr(IdMapIndex.search, "_tv_chunk_wrapper", False):
+        IdMapIndex.search = _make_search(IdMapIndex.search)
+    if not getattr(IdMapIndex.add_with_ids, "_tv_chunk_wrapper", False):
+        IdMapIndex.add_with_ids = _make_add_with_ids(IdMapIndex.add_with_ids)

--- a/turbovec-python/python/turbovec/_interruptible.py
+++ b/turbovec-python/python/turbovec/_interruptible.py
@@ -26,9 +26,15 @@ These wrappers are installed over the native ``search`` / ``add`` /
   identical to a single unchunked call (per-query results are
   deterministic and ``effective_k`` depends only on ``k`` / index size /
   mask, not on how the queries are sliced).
+The slice size comes from ``chunk_size=`` (or the ``turbovec.BATCH_CHUNK_SIZE``
+default). It is coerced with ``int(...)``, so a float is truncated; any value
+``<= 0`` (including a negative) simply disables chunking and runs the call
+whole — the same as ``chunk_size=0``.
+
 * **Atomicity.** ``add`` is cumulative. Before chunking an add we
   pre-validate the whole batch the same way the core does its up-front
-  check (finite, ``|x| < 1e16``; ids unique and length-matched); if the
+  check (finite, ``|x| < 1e16``; ids unique, length-matched, and none
+  already present in the index); if the
   batch would be rejected, we hand the *entire* array to the raw kernel so
   it raises atomically with nothing committed — exactly as today. Only a
   genuine mid-batch *cancel* (KeyboardInterrupt) then leaves state behind,
@@ -71,22 +77,21 @@ import numpy as np
 
 from ._turbovec import IdMapIndex, TurboQuantIndex
 
-#: Default batch slice size (number of queries / vectors per raw kernel
-#: call). Batches with more rows than this are chunked; smaller ones run
-#: as a single call. Tunable globally via ``turbovec.BATCH_CHUNK_SIZE`` or
-#: per call via the ``chunk_size=`` keyword. ~1000 keeps Ctrl-C latency to
-#: tens of milliseconds for ~+5 % throughput.
-BATCH_CHUNK_SIZE = 1000
+# The default slice size is the single public constant `turbovec.BATCH_CHUNK_SIZE`
+# (defined in the package __init__); `_default_chunk_size` reads it live so a
+# reassignment takes effect without re-importing.
 
 # Core rejection bound, mirrored so a would-be-rejected batch is delegated
-# whole (atomic error) instead of chunked. Compared in float64, which is
-# strictly *more* conservative than the core's float32 `|x| < 1e16` at the
-# exact boundary, so we never deem "clean" a value the core would reject.
-_MAX_MAGNITUDE = 1e16
+# whole (atomic error) instead of chunked. Stored as float32 so the numpy
+# compare below matches the core's `|x| < 1e16` in f32 exactly: under NEP50
+# (numpy >= 2) an f32 array compared to this f32 scalar stays in f32; under
+# legacy promotion it also stays f32 (same dtype). Either way we never deem
+# "clean" a value the core would reject.
+_MAX_MAGNITUDE = np.float32(1e16)
 
 
 def _default_chunk_size() -> int:
-    # Read the live module default so `turbovec.BATCH_CHUNK_SIZE = n` takes
+    # Read the live package constant so `turbovec.BATCH_CHUNK_SIZE = n` takes
     # effect without re-importing. `import turbovec` is a cached dict hit.
     import turbovec
 
@@ -100,13 +105,45 @@ def _finite_ok(a: np.ndarray) -> bool:
 
 
 def _chunkable_2d(a: object, cs: int) -> bool:
+    # C-contiguity is required: a row-slice of a non-contiguous array is
+    # rejected by the raw kernel, and snapshotting one would silently
+    # launder it into an acceptable copy — so a non-contiguous batch must
+    # fall through to the kernel (which raises) instead of being chunked.
     return (
         cs > 0
         and isinstance(a, np.ndarray)
         and a.ndim == 2
         and a.dtype == np.float32
+        and a.flags.c_contiguous
         and a.shape[0] > cs
     )
+
+
+def _snapshot_kwargs(kwargs):
+    """Snapshot ndarray-valued kwargs (``mask`` / ``allowlist``) once so
+    every slice reads one coherent version, mirroring the query snapshot
+    (#108). Returns ``(snapped, ok)``; ``ok`` is ``False`` if any ndarray
+    kwarg is non-C-contiguous — the raw kernel rejects those, and copying
+    one would launder it, so the caller must fall through so the kernel
+    raises the contiguity error unchanged.
+    """
+    snapped = {}
+    for key, value in kwargs.items():
+        if isinstance(value, np.ndarray):
+            if not value.flags.c_contiguous:
+                return kwargs, False
+            snapped[key] = np.array(value)
+        else:
+            snapped[key] = value
+    return snapped, True
+
+
+def _any_id_present(index, ids: np.ndarray) -> bool:
+    # Mirror the core's up-front "id already in the index" rejection
+    # (id_map.rs) so a batch colliding with an existing id is delegated
+    # whole and fails atomically — not committed slice-by-slice up to the
+    # collision. `__contains__` is O(1) per id.
+    return any(handle in index for handle in ids.tolist())
 
 
 def _make_search(raw):
@@ -126,9 +163,11 @@ def _make_search(raw):
             # query rows — weakening the "search sees one version of the
             # buffer" data-integrity guarantee (#108). The rows are never
             # torn regardless (each kernel snapshot is atomic); this keeps
-            # the whole batch coherent too.
+            # the whole batch coherent too. The same coherence must cover a
+            # ``mask`` / ``allowlist`` array, so snapshot those alongside.
             snap = np.array(queries)
-            if _finite_ok(snap):
+            snap_kwargs, kwargs_ok = _snapshot_kwargs(kwargs)
+            if kwargs_ok and _finite_ok(snap):
                 n = snap.shape[0]
                 scores_parts = []
                 ids_parts = []
@@ -136,7 +175,7 @@ def _make_search(raw):
                     # A signal queued on the main thread is serviced here,
                     # between slices — a KeyboardInterrupt fires within one
                     # slice rather than at the end of the batch.
-                    s, i = raw(self, snap[start : start + cs], k, **kwargs)
+                    s, i = raw(self, snap[start : start + cs], k, **snap_kwargs)
                     scores_parts.append(s)
                     ids_parts.append(i)
                 return (
@@ -163,15 +202,24 @@ def _make_add(raw):
         # add runs whole (and stays deaf to Ctrl-C, like a single huge op);
         # incremental adds afterward chunk with bit-identical results.
         #
-        # Pre-validate so a batch the core would reject is added atomically
-        # (whole array, nothing committed) rather than committing earlier
-        # slices before a later slice's value trips the check.
-        if not (len(self) > 0 and _chunkable_2d(vectors, cs) and _finite_ok(vectors)):
-            return raw(self, vectors)
-        n = vectors.shape[0]
-        for start in range(0, n, cs):
-            raw(self, vectors[start : start + cs])
-        return None
+        # Snapshot once, up front, then validate and slice the snapshot —
+        # so a thread mutating the source array mid-batch cannot make
+        # pre-validation pass and then feed a later slice different (or
+        # invalid) data after earlier slices have committed (the add-side
+        # analogue of the query snapshot, #108). Pre-validating the
+        # snapshot means a batch the core would reject is added atomically
+        # (whole array via the raw kernel, nothing committed) rather than
+        # committing earlier slices before a later value trips the check.
+        # When not chunking, fall through with the ORIGINAL array so the
+        # kernel's error paths stay byte-identical.
+        if len(self) > 0 and _chunkable_2d(vectors, cs):
+            snap = np.array(vectors)
+            if _finite_ok(snap):
+                n = snap.shape[0]
+                for start in range(0, n, cs):
+                    raw(self, snap[start : start + cs])
+                return None
+        return raw(self, vectors)
 
     add.__doc__ = raw.__doc__
     add.__wrapped__ = raw
@@ -183,26 +231,42 @@ def _make_add_with_ids(raw):
     def add_with_ids(self, vectors, ids, *, chunk_size=None):
         cs = _default_chunk_size() if chunk_size is None else int(chunk_size)
         # Chunk only a non-empty index (the first add locks calibration —
-        # see `_make_add`) with a clean, canonically-typed batch: finite
-        # values, ids a 1-D uint64 array of matching length with no
-        # duplicates. Anything else (empty index, bad values,
-        # duplicate/pre-existing ids, length mismatch) is delegated whole
-        # so the core's up-front validation rejects it atomically — and no
-        # earlier slice is committed first.
+        # see `_make_add`) with a clean, canonically-typed batch: a
+        # C-contiguous 1-D uint64 id array of matching length, finite
+        # vectors, no duplicate ids within the batch, AND no id already
+        # present in the index. The core validates ALL of these up front
+        # (id_map.rs) so a rejected batch commits nothing; chunking must
+        # reproduce that, so any failing condition delegates the whole
+        # batch to the raw kernel (with the ORIGINAL arrays, keeping error
+        # paths byte-identical). In particular the pre-existing-id check is
+        # essential: without it, a batch whose colliding id sits in a late
+        # slice would commit the earlier slices before raising.
+        #
+        # Vectors and ids are snapshotted once, up front, before validation
+        # (the add-side analogue of the query snapshot, #108): a thread
+        # mutating a source array mid-batch cannot make validation pass and
+        # then feed a later slice different/invalid data after earlier
+        # slices committed.
         if (
             len(self) > 0
             and _chunkable_2d(vectors, cs)
             and isinstance(ids, np.ndarray)
             and ids.ndim == 1
             and ids.dtype == np.uint64
+            and ids.flags.c_contiguous
             and ids.shape[0] == vectors.shape[0]
-            and _finite_ok(vectors)
-            and np.unique(ids).size == ids.shape[0]
         ):
-            n = vectors.shape[0]
-            for start in range(0, n, cs):
-                raw(self, vectors[start : start + cs], ids[start : start + cs])
-            return None
+            v_snap = np.array(vectors)
+            i_snap = np.array(ids)
+            if (
+                _finite_ok(v_snap)
+                and np.unique(i_snap).size == i_snap.shape[0]
+                and not _any_id_present(self, i_snap)
+            ):
+                n = v_snap.shape[0]
+                for start in range(0, n, cs):
+                    raw(self, v_snap[start : start + cs], i_snap[start : start + cs])
+                return None
         return raw(self, vectors, ids)
 
     add_with_ids.__doc__ = raw.__doc__

--- a/turbovec-python/python/turbovec/_interruptible.py
+++ b/turbovec-python/python/turbovec/_interruptible.py
@@ -11,8 +11,25 @@ The cheap, core-agnostic fix: split a large batch into row-slices and call
 the raw kernel once per slice. Control returns to Python between slices,
 where a pending ``KeyboardInterrupt`` is serviced — so a queued Ctrl-C now
 fires within roughly *one slice* rather than at the end of the whole
-batch. Measured in the research pass: at ``chunk_size≈1000`` the Ctrl-C
-latency dropped from ~13 s to ~57 ms for ~+5 % throughput.
+batch. At ``chunk_size≈1000`` the Ctrl-C latency drops from seconds to
+tens of milliseconds.
+
+Throughput cost is not symmetric:
+
+* **search** — negligible (~0 %). The extra work (one query-batch
+  snapshot, per-slice dispatch) is tiny next to scanning the index.
+* **add / add_with_ids** — a real multiplier on wall time, but a small
+  absolute cost. Each chunked add pays a full input snapshot, per-slice
+  validation, per-slice kernel dispatch, and (``add_with_ids``) an O(n)
+  pre-existing-id check. At the default ``chunk_size=1000`` this measured
+  roughly **2–7× the unchunked wall time** (the base add is fast, so the
+  fixed per-slice Python overhead dominates the *ratio*; the exact figure
+  swings with dim, batch size, and machine). In absolute terms the
+  overhead is only on the order of ~1–10 µs per vector, and it buys
+  interruptibility. For a throughput-critical one-shot bulk load where
+  interruptibility does not matter, pass ``chunk_size=0`` to run the add
+  whole at full speed. (The very first add into an empty index already
+  runs whole regardless — see the blind spots below.)
 
 These wrappers are installed over the native ``search`` / ``add`` /
 ``add_with_ids`` methods at import time. They are deliberately transparent:
@@ -142,8 +159,11 @@ def _any_id_present(index, ids: np.ndarray) -> bool:
     # Mirror the core's up-front "id already in the index" rejection
     # (id_map.rs) so a batch colliding with an existing id is delegated
     # whole and fails atomically — not committed slice-by-slice up to the
-    # collision. `__contains__` is O(1) per id.
-    return any(handle in index for handle in ids.tolist())
+    # collision. `__contains__` is O(1) per id. Iterate the array lazily
+    # (one numpy scalar at a time, converted to a Python int) rather than
+    # materializing a full `.tolist()` — at hundreds of thousands of ids
+    # the transient list would be a multi-MB memory spike.
+    return any(int(handle) in index for handle in ids)
 
 
 def _make_search(raw):

--- a/turbovec-python/tests/test_interruptible.py
+++ b/turbovec-python/tests/test_interruptible.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import os
 import signal
+import sys
 import threading
 import time
 
@@ -215,6 +216,13 @@ def test_add_with_ids_cancel_commits_completed_slices():
     assert (cancel_at * cs) not in idx
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="delivering a real SIGINT from a helper thread is Unix-only; "
+    "Windows only routes Ctrl-C (CTRL_C_EVENT) to the main thread. The "
+    "chunking feature works cross-platform and is covered by the "
+    "deterministic __wrapped__-based interrupt tests above.",
+)
 def test_real_sigint_interrupts_search_mid_batch():
     """A real SIGINT from a helper thread is delivered mid-batch, well
     before the full chunked search would have finished.

--- a/turbovec-python/tests/test_interruptible.py
+++ b/turbovec-python/tests/test_interruptible.py
@@ -217,41 +217,55 @@ def test_add_with_ids_cancel_commits_completed_slices():
 
 def test_real_sigint_interrupts_search_mid_batch():
     """A real SIGINT from a helper thread is delivered mid-batch, well
-    before the full chunked search would have finished."""
+    before the full chunked search would have finished.
+
+    Wall-clock timing is inherently jittery (CI load, scheduler), so this
+    uses a generous margin (interrupt must land in the first ~80% of the
+    batch, firing at ~20% in) and retries a few times before failing — a
+    single unlucky scheduling hiccup should not flake the suite.
+    """
     idx = TurboQuantIndex(128, 4)
     idx.add(_rand(100_000, 128, seed=0))
     idx.prepare()
     q = _rand(40_000, 128, seed=1)
     cs = 1000  # 40 slices
 
-    # Baseline: uninterrupted full run.
-    t0 = time.perf_counter()
-    idx.search(q, 10, chunk_size=cs)
-    t_full = time.perf_counter() - t0
+    # Baseline: uninterrupted full run (median of two to damp jitter).
+    def _full():
+        t = time.perf_counter()
+        idx.search(q, 10, chunk_size=cs)
+        return time.perf_counter() - t
 
-    old = signal.signal(signal.SIGINT, signal.default_int_handler)
-    fire_after = max(0.1, t_full * 0.25)
-    try:
-        def fire():
-            time.sleep(fire_after)
-            os.kill(os.getpid(), signal.SIGINT)
+    t_full = min(_full(), _full())
 
-        th = threading.Thread(target=fire)
-        th.start()
-        interrupted = False
-        t1 = time.perf_counter()
+    last = None
+    for _attempt in range(3):
+        old = signal.signal(signal.SIGINT, signal.default_int_handler)
+        fire_after = max(0.1, t_full * 0.2)
         try:
-            idx.search(q, 10, chunk_size=cs)
-        except KeyboardInterrupt:
-            interrupted = True
-        elapsed = time.perf_counter() - t1
-        th.join()
-    finally:
-        signal.signal(signal.SIGINT, old)
+            def fire():
+                time.sleep(fire_after)
+                os.kill(os.getpid(), signal.SIGINT)
 
-    assert interrupted, "SIGINT during chunked search was not delivered"
-    # Delivered mid-batch, not queued to the end.
-    assert elapsed < t_full * 0.7, (elapsed, t_full)
+            th = threading.Thread(target=fire)
+            th.start()
+            interrupted = False
+            t1 = time.perf_counter()
+            try:
+                idx.search(q, 10, chunk_size=cs)
+            except KeyboardInterrupt:
+                interrupted = True
+            elapsed = time.perf_counter() - t1
+            th.join()
+        finally:
+            signal.signal(signal.SIGINT, old)
+
+        last = (interrupted, elapsed, t_full)
+        # Delivered mid-batch, not queued to the end — generous 80% bound.
+        if interrupted and elapsed < t_full * 0.8:
+            break
+    else:
+        assert False, f"SIGINT not delivered mid-batch after retries: {last}"
 
 
 # ---------------------------------------------------------------------------
@@ -329,3 +343,149 @@ def test_duplicate_ids_add_is_atomic_nothing_committed():
     with pytest.raises(ValueError):
         idx.add_with_ids(data, ids, chunk_size=500)
     assert len(idx) == base
+
+
+# ---------------------------------------------------------------------------
+# F1: an id colliding with one ALREADY in the index must reject atomically
+# (within-batch uniqueness alone is not enough — the core also rejects
+# pre-existing ids up front, so chunking must too).
+# ---------------------------------------------------------------------------
+
+
+def test_add_with_ids_colliding_with_existing_id_is_atomic():
+    idx = IdMapIndex(DIM, 4)
+    seed_ids = np.arange(300, dtype=np.uint64) + 10_000
+    idx.add_with_ids(_rand(300, seed=7), seed_ids)
+    base = len(idx)
+
+    data = _rand(2500, seed=0)
+    ids = np.arange(2500, dtype=np.uint64)  # 0..2499, disjoint from seed
+    # A single id, in what would be a LATE slice, collides with the index.
+    ids[2300] = 10_050  # already present (seed id)
+    assert np.unique(ids).size == ids.size  # still unique *within* the batch
+
+    with pytest.raises(ValueError):
+        idx.add_with_ids(data, ids, chunk_size=500)
+    # The whole batch was delegated and rejected — no earlier slice landed.
+    assert len(idx) == base
+
+
+# ---------------------------------------------------------------------------
+# F2: add snapshots its inputs once, so a source-array mutation landing
+# after validation cannot feed later slices different/invalid data.
+# ---------------------------------------------------------------------------
+
+
+def test_add_snapshots_source_against_concurrent_mutation():
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(300, seed=7))  # lock calibration → later add chunks
+
+    data = _rand(2000, seed=0)
+    original = data.copy()
+    raw = TurboQuantIndex.add.__wrapped__
+
+    def stomping(self, vectors):
+        # A concurrent writer stomps the SOURCE array after the wrapper
+        # snapshotted it; the slices must still see the pre-mutation data.
+        data[:] = _rand(2000, seed=99)
+        return raw(self, vectors)
+
+    chunked_add = _interruptible._make_add(stomping)
+    chunked_add(idx, data, chunk_size=500)
+
+    ref = TurboQuantIndex(DIM, 4)
+    ref.add(_rand(300, seed=7))
+    ref.add(original, chunk_size=0)
+    assert idx.to_bytes() == ref.to_bytes()
+
+
+def test_add_with_ids_snapshots_source_against_concurrent_mutation():
+    idx = IdMapIndex(DIM, 4)
+    seed_ids = np.arange(300, dtype=np.uint64) + 10_000
+    idx.add_with_ids(_rand(300, seed=7), seed_ids)
+
+    data = _rand(2000, seed=0)
+    ids = np.arange(2000, dtype=np.uint64)
+    original_v, original_i = data.copy(), ids.copy()
+    raw = IdMapIndex.add_with_ids.__wrapped__
+
+    def stomping(self, vectors, the_ids):
+        data[:] = _rand(2000, seed=99)
+        ids[:] = np.arange(2000, dtype=np.uint64) + 500_000
+        return raw(self, vectors, the_ids)
+
+    chunked = _interruptible._make_add_with_ids(stomping)
+    chunked(idx, data, ids, chunk_size=500)
+
+    ref = IdMapIndex(DIM, 4)
+    ref.add_with_ids(_rand(300, seed=7), seed_ids)
+    ref.add_with_ids(original_v, original_i, chunk_size=0)
+    assert idx.to_bytes() == ref.to_bytes()
+
+
+# ---------------------------------------------------------------------------
+# F3: a non-C-contiguous batch must fall through to the raw kernel (which
+# rejects it) at BOTH sizes — the snapshot must not launder a strided view
+# into an acceptable copy for large batches.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("nrows", [2400, 100])  # would-chunk, and small
+def test_noncontiguous_query_falls_through_both_sizes(nrows):
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(500, seed=0))
+    view = _rand(nrows * 2, seed=1)[::2]  # strided → non-contiguous
+    assert not view.flags.c_contiguous
+    with pytest.raises((ValueError, TypeError)):
+        idx.search(view, 5, chunk_size=1000)
+
+
+@pytest.mark.parametrize("nrows", [2400, 100])
+def test_noncontiguous_add_falls_through_both_sizes(nrows):
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(500, seed=0))  # non-empty → chunk-eligible
+    base = len(idx)
+    view = _rand(nrows * 2, seed=1)[::2]
+    assert not view.flags.c_contiguous
+    with pytest.raises((ValueError, TypeError)):
+        idx.add(view, chunk_size=1000)
+    assert len(idx) == base  # rejected whole, nothing committed
+
+
+# ---------------------------------------------------------------------------
+# F4: the query snapshot must also cover mask/allowlist, so a thread
+# stomping the mask mid-batch cannot split it across versions.
+# ---------------------------------------------------------------------------
+
+
+def test_search_snapshots_mask_against_concurrent_mutation():
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(2000, seed=0))
+    mask = np.zeros(2000, dtype=bool)
+    mask[::3] = True
+    original_mask = mask.copy()
+    q = _rand(1500, seed=1)
+
+    raw = TurboQuantIndex.search.__wrapped__
+    ref = idx.search(q, 8, mask=original_mask, chunk_size=0)
+
+    def stomping(self, queries, k, **kw):
+        mask[:] = ~original_mask  # stomp the SOURCE mask mid-batch
+        return raw(self, queries, k, **kw)
+
+    chunked = _interruptible._make_search(stomping)
+    scores, ids = chunked(idx, q, 8, mask=mask, chunk_size=250)
+    # Snapshotted once → every slice used the original mask → == unchunked.
+    np.testing.assert_array_equal(scores, ref[0])
+    np.testing.assert_array_equal(ids, ref[1])
+
+
+def test_search_noncontiguous_mask_falls_through():
+    idx = IdMapIndex(DIM, 4)
+    ids = np.arange(2000, dtype=np.uint64) + 100
+    idx.add_with_ids(_rand(2000, seed=0), ids)
+    allow = ids[::2]  # non-contiguous view
+    assert not allow.flags.c_contiguous
+    q = _rand(1500, seed=1)
+    with pytest.raises((ValueError, TypeError)):
+        idx.search(q, 8, allowlist=allow, chunk_size=250)

--- a/turbovec-python/tests/test_interruptible.py
+++ b/turbovec-python/tests/test_interruptible.py
@@ -1,0 +1,331 @@
+"""Interruptible long search/add via Python-side batch chunking (#216).
+
+The Rust kernels release the GIL, but Python services signals on the main
+thread — the one parked inside the kernel — so a Ctrl-C during a long
+batch search/add is queued until the whole call returns. These wrappers
+split a large batch into row-slices and call the raw kernel per slice, so
+control returns to Python (and a queued KeyboardInterrupt fires) between
+slices.
+
+Covered here:
+  * chunked search/add/add_with_ids return results identical to a single
+    unchunked call (concatenation preserves order, ids, and scores);
+  * a cancel between slices is delivered within ~one slice, not at the end,
+    and a cancelled add leaves the index committed at exactly the
+    completed-slice count (consistent and queryable);
+  * the transparent fall-through: bad or unchunkable input hits the raw
+    kernel unchanged, so error paths and the single-huge-op blind spot
+    behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import threading
+import time
+
+import numpy as np
+import pytest
+
+from turbovec import IdMapIndex, TurboQuantIndex, _interruptible
+
+DIM = 64
+
+
+def _rand(n: int, dim: int = DIM, seed: int = 0) -> np.ndarray:
+    """`n` unit-norm float32 rows, C-contiguous."""
+    rng = np.random.default_rng(seed)
+    v = rng.standard_normal((n, dim)).astype(np.float32)
+    v /= np.linalg.norm(v, axis=1, keepdims=True) + 1e-9
+    return np.ascontiguousarray(v, dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Result equivalence: chunked == unchunked, bit for bit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cs", [1, 7, 100, 999, 1000])
+def test_chunked_search_matches_unchunked_turboquant(cs):
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(3000, seed=0))
+    q = _rand(2500, seed=1)  # > cs for the small cs values → really chunks
+    s_ref, i_ref = idx.search(q, 10, chunk_size=0)  # single unchunked call
+    s_chunk, i_chunk = idx.search(q, 10, chunk_size=cs)
+    np.testing.assert_array_equal(s_ref, s_chunk)
+    np.testing.assert_array_equal(i_ref, i_chunk)
+
+
+def test_chunked_search_matches_unchunked_with_mask():
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(2000, seed=0))
+    mask = np.zeros(len(idx), dtype=bool)
+    mask[::3] = True  # a non-trivial subset
+    q = _rand(1500, seed=1)
+    s_ref, i_ref = idx.search(q, 8, mask=mask, chunk_size=0)
+    s_chunk, i_chunk = idx.search(q, 8, mask=mask, chunk_size=250)
+    np.testing.assert_array_equal(s_ref, s_chunk)
+    np.testing.assert_array_equal(i_ref, i_chunk)
+
+
+def test_chunked_search_matches_unchunked_idmap_with_allowlist():
+    idx = IdMapIndex(DIM, 4)
+    ids = np.arange(2000, dtype=np.uint64) + 100
+    idx.add_with_ids(_rand(2000, seed=0), ids)
+    allow = np.ascontiguousarray(ids[::2])  # half the ids
+    q = _rand(1500, seed=1)
+    s_ref, i_ref = idx.search(q, 8, allowlist=allow, chunk_size=0)
+    s_chunk, i_chunk = idx.search(q, 8, allowlist=allow, chunk_size=200)
+    np.testing.assert_array_equal(s_ref, s_chunk)
+    np.testing.assert_array_equal(i_ref, i_chunk)
+
+
+def test_chunked_add_matches_unchunked():
+    # The first add locks the TQ+ calibration; the second add (the one we
+    # chunk) reuses it, so slicing must be bit-identical to one call.
+    seed = _rand(500, seed=1)
+    data = _rand(2500, seed=5)
+
+    ref = TurboQuantIndex(DIM, 4)
+    ref.add(seed)
+    ref.add(data, chunk_size=0)
+    chunked = TurboQuantIndex(DIM, 4)
+    chunked.add(seed)
+    chunked.add(data, chunk_size=256)
+
+    assert len(ref) == len(chunked) == 3000
+    # Strongest form of equivalence: the two indices are byte-identical.
+    assert ref.to_bytes() == chunked.to_bytes()
+
+
+def test_chunked_add_with_ids_matches_unchunked():
+    seed = _rand(500, seed=1)
+    seed_ids = np.arange(500, dtype=np.uint64)
+    data = _rand(2500, seed=5)
+    data_ids = np.arange(2500, dtype=np.uint64) + 500
+
+    ref = IdMapIndex(DIM, 4)
+    ref.add_with_ids(seed, seed_ids)
+    ref.add_with_ids(data, data_ids, chunk_size=0)
+    chunked = IdMapIndex(DIM, 4)
+    chunked.add_with_ids(seed, seed_ids)
+    chunked.add_with_ids(data, data_ids, chunk_size=256)
+
+    assert len(ref) == len(chunked) == 3000
+    assert ref.to_bytes() == chunked.to_bytes()
+
+
+def test_first_add_into_empty_index_is_not_chunked():
+    """Documents the calibration blind spot: the first (calibrating) add
+    runs whole; a later add is sliced. Observed through the raw-kernel
+    call count."""
+    from turbovec import _interruptible
+
+    raw = TurboQuantIndex.add.__wrapped__
+    calls = {"n": 0}
+
+    def counting(self, vectors):
+        calls["n"] += 1
+        return raw(self, vectors)
+
+    chunked_add = _interruptible._make_add(counting)
+    idx = TurboQuantIndex(DIM, 4)
+    big = _rand(2500, seed=0)
+
+    # Empty index: first add runs as a single call (calibration).
+    chunked_add(idx, big, chunk_size=500)
+    assert calls["n"] == 1
+
+    # Non-empty index: the next add of 2500 with cs=500 slices into 5.
+    calls["n"] = 0
+    chunked_add(idx, _rand(2500, seed=1), chunk_size=500)
+    assert calls["n"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Cancel between slices: delivered within ~one slice + add atomicity
+# ---------------------------------------------------------------------------
+
+
+def test_add_cancel_commits_completed_slices_and_stays_queryable():
+    """Deterministic model of a queued Ctrl-C serviced at a slice boundary.
+
+    A shim over the real kernel raises KeyboardInterrupt *before* committing
+    the 4th slice — exactly what a signal serviced between slice 3 and 4
+    does. The first three slices must be committed (and searchable); the
+    loop must not run to the end.
+    """
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(300, seed=7))  # first add locks calibration → later adds chunk
+    base = len(idx)
+    raw_add = TurboQuantIndex.add.__wrapped__  # the native kernel
+
+    cs = 500
+    cancel_at = 3
+    calls = {"n": 0}
+
+    def shim(self, vectors):
+        if calls["n"] == cancel_at:
+            raise KeyboardInterrupt  # queued signal serviced here
+        calls["n"] += 1
+        return raw_add(self, vectors)
+
+    chunked_add = _interruptible._make_add(shim)
+    data = _rand(10 * cs, seed=0)  # 10 slices available
+
+    with pytest.raises(KeyboardInterrupt):
+        chunked_add(idx, data, chunk_size=cs)
+
+    # Cancelled within one slice of the signal — not at the end of 10.
+    assert calls["n"] == cancel_at
+    assert len(idx) == base + cancel_at * cs
+    # The index is consistent and queryable at the partial count.
+    scores, _ = idx.search(_rand(5, seed=1), 4, chunk_size=0)
+    assert scores.shape == (5, 4)
+
+
+def test_add_with_ids_cancel_commits_completed_slices():
+    idx = IdMapIndex(DIM, 4)
+    seed_ids = np.arange(300, dtype=np.uint64) + 10_000
+    idx.add_with_ids(_rand(300, seed=7), seed_ids)  # locks calibration
+    base = len(idx)
+    raw = IdMapIndex.add_with_ids.__wrapped__
+    cs = 400
+    cancel_at = 2
+    calls = {"n": 0}
+
+    def shim(self, vectors, ids):
+        if calls["n"] == cancel_at:
+            raise KeyboardInterrupt
+        calls["n"] += 1
+        return raw(self, vectors, ids)
+
+    chunked = _interruptible._make_add_with_ids(shim)
+    n = 8 * cs
+    data = _rand(n, seed=0)
+    ids = np.arange(n, dtype=np.uint64)
+
+    with pytest.raises(KeyboardInterrupt):
+        chunked(idx, data, ids, chunk_size=cs)
+
+    assert len(idx) == base + cancel_at * cs
+    # The committed ids are exactly the first two slices' — queryable.
+    assert 0 in idx and (cancel_at * cs - 1) in idx
+    assert (cancel_at * cs) not in idx
+
+
+def test_real_sigint_interrupts_search_mid_batch():
+    """A real SIGINT from a helper thread is delivered mid-batch, well
+    before the full chunked search would have finished."""
+    idx = TurboQuantIndex(128, 4)
+    idx.add(_rand(100_000, 128, seed=0))
+    idx.prepare()
+    q = _rand(40_000, 128, seed=1)
+    cs = 1000  # 40 slices
+
+    # Baseline: uninterrupted full run.
+    t0 = time.perf_counter()
+    idx.search(q, 10, chunk_size=cs)
+    t_full = time.perf_counter() - t0
+
+    old = signal.signal(signal.SIGINT, signal.default_int_handler)
+    fire_after = max(0.1, t_full * 0.25)
+    try:
+        def fire():
+            time.sleep(fire_after)
+            os.kill(os.getpid(), signal.SIGINT)
+
+        th = threading.Thread(target=fire)
+        th.start()
+        interrupted = False
+        t1 = time.perf_counter()
+        try:
+            idx.search(q, 10, chunk_size=cs)
+        except KeyboardInterrupt:
+            interrupted = True
+        elapsed = time.perf_counter() - t1
+        th.join()
+    finally:
+        signal.signal(signal.SIGINT, old)
+
+    assert interrupted, "SIGINT during chunked search was not delivered"
+    # Delivered mid-batch, not queued to the end.
+    assert elapsed < t_full * 0.7, (elapsed, t_full)
+
+
+# ---------------------------------------------------------------------------
+# Transparent fall-through: unchunkable / bad input behaves as before
+# ---------------------------------------------------------------------------
+
+
+def test_disable_chunking_with_zero():
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(2000, seed=0))
+    q = _rand(1500, seed=1)
+    a = idx.search(q, 5, chunk_size=0)
+    b = idx.search(q, 5, chunk_size=1000)
+    np.testing.assert_array_equal(a[0], b[0])
+    np.testing.assert_array_equal(a[1], b[1])
+
+
+def test_global_default_is_live_and_tunable():
+    import turbovec
+
+    assert _interruptible._default_chunk_size() == turbovec.BATCH_CHUNK_SIZE
+    old = turbovec.BATCH_CHUNK_SIZE
+    try:
+        turbovec.BATCH_CHUNK_SIZE = 123
+        assert _interruptible._default_chunk_size() == 123
+    finally:
+        turbovec.BATCH_CHUNK_SIZE = old
+
+
+def test_single_query_blind_spot_still_correct():
+    """nq==1 cannot be chunked; it must still return the right result."""
+    idx = TurboQuantIndex(DIM, 4)
+    data = _rand(500, seed=0)
+    idx.add(data)
+    q = _rand(1, seed=1)
+    scores, ids = idx.search(q, 5)
+    assert scores.shape == (1, 5)
+    # Top-1 is the true nearest by exact dot product over the raw data.
+    exact_best = int(np.argmax(data @ q[0]))
+    # Quantized search should rank the exact best highly; assert it is
+    # among the returned top-5 (quantization is lossy but faithful here).
+    assert exact_best in ids[0].tolist()
+
+
+def test_bad_input_falls_through_to_raw_error():
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(10, seed=0))
+    # A Python list is not a float32 ndarray → raw kernel raises, unchanged.
+    with pytest.raises((TypeError, ValueError)):
+        idx.search([[0.0] * DIM] * 5, 3)
+
+
+def test_nan_add_is_atomic_nothing_committed():
+    """A NaN deep in the batch must reject the whole add (0 committed),
+    exactly like the unchunked kernel — chunking pre-validates so it does
+    not commit earlier clean slices first."""
+    idx = TurboQuantIndex(DIM, 4)
+    idx.add(_rand(300, seed=7))  # non-empty → the bad add is chunk-eligible
+    base = len(idx)
+    data = _rand(2500, seed=0)
+    data[2200, 3] = np.nan  # invalid value in what would be a later slice
+    with pytest.raises(ValueError):
+        idx.add(data, chunk_size=500)
+    # Pre-validation delegated the whole batch → nothing from it committed.
+    assert len(idx) == base
+
+
+def test_duplicate_ids_add_is_atomic_nothing_committed():
+    idx = IdMapIndex(DIM, 4)
+    idx.add_with_ids(_rand(300, seed=7), np.arange(300, dtype=np.uint64) + 10_000)
+    base = len(idx)
+    data = _rand(2500, seed=0)
+    ids = np.arange(2500, dtype=np.uint64)
+    ids[2300] = ids[10]  # duplicate spanning two would-be slices
+    with pytest.raises(ValueError):
+        idx.add_with_ids(data, ids, chunk_size=500)
+    assert len(idx) == base


### PR DESCRIPTION
## Summary

Long batch `search` / `add` were deaf to Ctrl-C. The GIL is already released (#186), but CPython delivers signals on the **main thread** — the one parked inside the Rust kernel — so a queued SIGINT was serviced only after the whole call returned (issue #216 measured 12.9 s search / 7.7 s add delays).

This ships the cheap, recommended fix from the research pass: **Python-side batch chunking**, entirely in the binding layer (`turbovec-python/python/turbovec/_interruptible.py`), no core Rust change.

## Mechanism

Pure-Python wrappers installed at import time over the native `search` / `add` / `add_with_ids` methods (`TurboQuantIndex`, `IdMapIndex`). A batch with more than `chunk_size` rows is split into row-slices, calling the raw kernel once per slice. Between slices control returns to Python, where a queued `KeyboardInterrupt` is serviced — so a Ctrl-C fires within **~one slice** instead of at the end of the batch.

- Tunable: `turbovec.BATCH_CHUNK_SIZE = 1000` (module default, live) or per-call `chunk_size=` (`chunk_size=0` disables).
- Transparent fall-through: anything not a plain 2-D `float32` ndarray (ids: 1-D `uint64`), or too small to chunk, goes straight to the raw kernel — every existing result and error path unchanged. Integration single-query searches (`nq==1`) are untouched.

## Measured Ctrl-C latency

On a ~7.2 s batch search (300k × 256 index, 60k queries), SIGINT fired ~1.45 s in:

| mode | full batch | delivered after | **Ctrl-C delay** |
|------|-----------:|----------------:|-----------------:|
| `chunk_size=0` (unchunked) | 7183 ms | 6884 ms | **~5448 ms** |
| `chunk_size=1000` (chunked) | 7307 ms | 1471 ms | **~10 ms** |

~5.4 s → ~10 ms.

**Throughput cost is asymmetric** (documented honestly in the docstring/CHANGELOG):
- **search**: unaffected (~0%) — the snapshot + per-slice dispatch is tiny next to scanning the index.
- **add / add_with_ids**: a real multiplier — measured **~2–7× the unchunked wall time** at the default `chunk_size=1000` (the base add is fast, so fixed per-slice overhead dominates the *ratio*, which swings with dim/batch/machine). The **absolute** overhead is small (~1–10 µs/vector) and buys interruptibility. For a throughput-critical one-shot bulk load, pass **`chunk_size=0`** to run the add whole at full speed. (The first add into an empty index already runs whole regardless — see blind spots.)

### Review rounds
Two adversarial review passes (Q) were addressed on-branch: F1 `add_with_ids` now rejects a batch containing an id already in the index *before* chunking (atomic); F2 `add`/`add_with_ids` snapshot inputs once before validation (TOCTOU); F3 `_chunkable_2d` requires C-contiguity so a strided view isn't laundered by the snapshot; F4 the query snapshot also covers `mask`/`allowlist`. Regression tests for each.

## Equivalence & atomicity

- **search**: all slices read **one up-front snapshot** of the query batch, so a concurrent mid-search mutation still yields one coherent version — preserving the #108 data-integrity guarantee (`test_gil_release.py::test_mutating_query_array_mid_search_is_safe`, verified 15× non-flaky). Chunked results are bit-identical to a single call.
- **add**: chunked only once the index is **non-empty**. The first add into an empty index fits and locks the TQ+ calibration from its batch; later adds reuse it and slice bit-identically (asserted via `to_bytes()` equality). The whole batch is pre-validated (finite; ids unique/`uint64`/length-matched) so a would-be-rejected batch is delegated whole and fails **atomically** — no earlier slice committed. A genuine mid-batch **cancel commits the completed slices and raises**, leaving the index consistent and queryable at that count (the defined behavior; distinct from a torn within-encode write, which #89/#118 already guard).

## Blind spots (documented; both need the deferred core poll)

- A **single huge query** (`nq==1`) is one indivisible kernel call — stays deaf. Negligible in practice (a single query only nears multi-second latency around ~10^8 vectors).
- The **first (calibrating) add** into an empty index runs whole, since slicing it would change the whole index's quantization.

The follow-up for both is the core cancellation poll (`PyErr::CheckSignals` in the hot loops), now easier since #238 merged the `with_pool` wrapper — deliberately **not** implemented here.

## Tests

New `turbovec-python/tests/test_interruptible.py` (28 tests): chunked==unchunked for search/add/add_with_ids, real-SIGINT mid-batch delivery, cancel-commits-completed-slices (+ queryable), atomic bad-batch rejection (NaN / duplicate / pre-existing ids), input-snapshot decoupling, non-contiguous fall-through, mask/allowlist snapshot, the first-add and single-query blind spots, tunable knob.

```
tests/test_interruptible.py ... 28 passed
```
- Full `pytest`: **664 passed, 12 skipped** (incl. all four integration stores).
- `cargo test --workspace`: **green** (no core change).

Do not merge — for review.
