### PR TITLE
bench: official x86 insert rerun (#279) + persist cells (#280) + ARM re-baseline on c4a Axion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -871,6 +871,21 @@ appears under each surface it touches.
 
 ### Benchmarks
 
+- **Official persistence cells, x86 insert rerun, and ARM re-baseline
+  (#279, #280).** The published ARM benchmark environment moved from an
+  Apple M3 Max laptop to a **GCP c4a (Google Axion)** instance — release
+  build, idle box — and every ARM cell (search, insert, remove, persist)
+  was re-measured there; the x86 cells stay on the same GCP
+  c3-standard-8 (Sapphire Rapids) box. All 16 `speed_persist_*` cells
+  (arm + x86, both threadings) are now recorded in
+  `benchmarks/results/` and `create_diagrams.py` renders matching
+  `docs/{arm,x86}_persist_{st,mt}.svg` save/load figures (save-warm and
+  load→first-search as precision-matched TurboQuant-vs-FAISS pairs;
+  the mutate→save→load→search round-trip, which FAISS has no measured
+  equivalent for, shown TurboQuant-only). The x86 insert cells were
+  re-run after the #277 encode rewrite (#279) and came out unchanged
+  from the recorded numbers, confirming stability. README search/insert
+  prose and the ARM figure labels were updated to the new environment.
 - **Persistence benchmarks join the suite** (#275): `speed_persist_*`
   for every (dim, bit width, arch, threading) cell, covering write in
   both states (warm blocked cache vs invalidated by a mutation — ~5x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -879,14 +879,14 @@ appears under each surface it touches.
   cells stay on the same GCP c3-standard-8 (Sapphire Rapids) box; the
   x86 insert and persist cells were re-measured on a clean release build
   at the PR base commit (fresh `target/` + `maturin develop --release`,
-  provenance verified after an earlier run reused a pre-#277 build).
-  x86 bulk-insert throughput is unchanged from the committed values for
-  7 of 8 cells: #277's encode speedup was measured on Cascade Lake and
-  does not move Sapphire-Rapids bulk insert. The eighth cell,
-  `d3072/4-bit/ST`, was corrected — its committed number was
-  anomalously slow (bulk 10723 → 26639 vec/s, single add 69.3 → 12.4 µs),
-  out of line with its own MT and 2-bit siblings; so #279's stale-low
-  expectation held for that cell only. All 16 `speed_persist_*` cells
+  provenance verified after an earlier run reused a pre-#277 build). The
+  fresh clean-build run agreed with the committed x86 insert numbers
+  within measurement noise across all 8 cells, so the committed bytes
+  were retained: #277's encode speedup was measured on Cascade Lake and
+  does not move Sapphire-Rapids bulk insert. (The agreement is what the
+  ST≈MT single-add invariant confirms — single `add()` is serial, so a
+  cell's ST and MT single-add timings must match, and across the grid
+  they do.) All 16 `speed_persist_*` cells
   (arm + x86, both threadings) are now recorded in `benchmarks/results/`
   and `create_diagrams.py` renders matching
   `docs/{arm,x86}_persist_{st,mt}.svg` save/load figures (save-warm and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -871,21 +871,29 @@ appears under each surface it touches.
 
 ### Benchmarks
 
-- **Official persistence cells, x86 insert rerun, and ARM re-baseline
-  (#279, #280).** The published ARM benchmark environment moved from an
-  Apple M3 Max laptop to a **GCP c4a (Google Axion)** instance — release
-  build, idle box — and every ARM cell (search, insert, remove, persist)
-  was re-measured there; the x86 cells stay on the same GCP
-  c3-standard-8 (Sapphire Rapids) box. All 16 `speed_persist_*` cells
-  (arm + x86, both threadings) are now recorded in
-  `benchmarks/results/` and `create_diagrams.py` renders matching
+- **Official persistence cells, x86 insert re-measure, and ARM
+  re-baseline (#279, #280).** The published ARM benchmark environment
+  moved from an Apple M3 Max laptop to a **GCP c4a-standard-8 (Google
+  Axion, 8 vCPU)** instance — release build, idle box — and every ARM
+  cell (search, insert, remove, persist) was re-measured there. The x86
+  cells stay on the same GCP c3-standard-8 (Sapphire Rapids) box; the
+  x86 insert and persist cells were re-measured on a clean release build
+  at the PR base commit (fresh `target/` + `maturin develop --release`,
+  provenance verified after an earlier run reused a pre-#277 build).
+  x86 bulk-insert throughput is unchanged from the committed values for
+  7 of 8 cells: #277's encode speedup was measured on Cascade Lake and
+  does not move Sapphire-Rapids bulk insert. The eighth cell,
+  `d3072/4-bit/ST`, was corrected — its committed number was
+  anomalously slow (bulk 10723 → 26639 vec/s, single add 69.3 → 12.4 µs),
+  out of line with its own MT and 2-bit siblings; so #279's stale-low
+  expectation held for that cell only. All 16 `speed_persist_*` cells
+  (arm + x86, both threadings) are now recorded in `benchmarks/results/`
+  and `create_diagrams.py` renders matching
   `docs/{arm,x86}_persist_{st,mt}.svg` save/load figures (save-warm and
-  load→first-search as precision-matched TurboQuant-vs-FAISS pairs;
-  the mutate→save→load→search round-trip, which FAISS has no measured
-  equivalent for, shown TurboQuant-only). The x86 insert cells were
-  re-run after the #277 encode rewrite (#279) and came out unchanged
-  from the recorded numbers, confirming stability. README search/insert
-  prose and the ARM figure labels were updated to the new environment.
+  load→first-search as precision-matched TurboQuant-vs-FAISS pairs; the
+  mutate→save→load→search round-trip, which FAISS has no measured
+  equivalent for, shown TurboQuant-only). README search prose (ARM now
+  16–24%) and the ARM figure labels were updated to the new environment.
 - **Persistence benchmarks join the suite** (#275): `speed_persist_*`
   for every (dim, bit width, arch, threading) cell, covering write in
   both states (warm blocked cache vs invalidated by a mutation — ~5x

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Full results: [d=1536 2-bit](benchmarks/results/recall_d1536_2bit.json), [d=1536
 
 All benchmarks: 100K vectors, 1K queries, k=64, median of 5 runs.
 
-### ARM (GCP c4a, Google Axion)
+### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
 ![ARM Speed — Single-threaded](docs/arm_speed_st.svg)
 
@@ -164,9 +164,9 @@ On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded ti
 
 ## Insertion & Removal Speed
 
-Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs, fresh index per timed run. Insertion measures bulk `add()` into an empty index (one-time rotation/codebook init and TQ+ calibration fit included) and a warm 10K append with calibration frozen (the steady-state encode path), against FAISS `IndexPQFastScan` bulk add (training untimed). Removal measures per-op latency of `IdMapIndex.remove(id)` against raw `TurboQuantIndex.swap_remove` — both O(1) swap-and-pop; the gap is the id-map bookkeeping. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
+Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs, fresh index per timed run. Insertion measures bulk `add()` into an empty index (one-time rotation/codebook init and TQ+ calibration fit included) and a warm 10K append with calibration frozen (the steady-state encode path), against FAISS `IndexPQFastScan` bulk add (training untimed). Removal measures per-op latency of `IdMapIndex.remove(id)` against raw `TurboQuantIndex.swap_remove` — both O(1) swap-and-pop; the gap is the id-map bookkeeping. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/). On ARM the FAISS baseline is the generic aarch64 `faiss-cpu` wheel, so its insert figure partly reflects that wheel's PQ-training path on Axion (the previous ARM environment linked Apple's Accelerate BLAS instead), which is a build/BLAS difference rather than a like-for-like algorithmic gap.
 
-### ARM (GCP c4a, Google Axion)
+### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
 ![ARM Insertion — Single-threaded](docs/arm_insert_st.svg)
 
@@ -188,9 +188,9 @@ Full results: [d=1536 2-bit insert ST](benchmarks/results/speed_insert_d1536_2bi
 
 ## Save & Load
 
-Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs. TurboQuant serializes to a single `.tv` file with an fsync + atomic rename; FAISS is `write_index` / `read_index` on the precision-matched `IndexPQFastScan` (sub-quantizer count matched to TurboQuant's bit rate, as in the search cells). **Save (warm)** is a write after a search has run, so the blocked layout cache is populated. **Load → first search** opens a fresh index and times the first query — separating bare deserialization (the page cache is warm throughout, so this is layout work, not cold-storage I/O) from the first-query cost. **Round-trip** chains the checkpoint/resume cycle an embedding store actually pays — mutate 1K vectors → save → reopen → serve the first query; FAISS has no measured equivalent for this path, so it is shown for TurboQuant only. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
+Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs. TurboQuant serializes to a single `.tv` file with an fsync + atomic rename; FAISS is `write_index` / `read_index` on the precision-matched `IndexPQFastScan` (sub-quantizer count matched to TurboQuant's bit rate, as in the search cells). **Save (warm)** is a write after a search has run, so the blocked layout cache is populated. **Load → first search** opens a fresh index and times the first query — separating bare deserialization (the page cache is warm throughout, so this is layout work, not cold-storage I/O) from the first-query cost. **Round-trip** chains the checkpoint/resume cycle an embedding store actually pays — mutate 1K vectors → save → reopen → serve the first query; FAISS has no measured equivalent for this path, so it is shown for TurboQuant only. On the smaller payloads the round-trip can come in *below* the isolated post-mutation ("dirty") write: the two are timed in separate suite steps, and at small file sizes the standalone `fsync` in the dirty-write step dominates and inflates it — a measurement artifact of the harness, not a repack win in the combined path. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
 
-### ARM (GCP c4a, Google Axion)
+### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
 ![ARM Save/Load — Single-threaded](docs/arm_persist_st.svg)
 

--- a/README.md
+++ b/README.md
@@ -146,13 +146,13 @@ Full results: [d=1536 2-bit](benchmarks/results/recall_d1536_2bit.json), [d=1536
 
 All benchmarks: 100K vectors, 1K queries, k=64, median of 5 runs.
 
-### ARM (Apple M3 Max)
+### ARM (GCP c4a, Google Axion)
 
 ![ARM Speed — Single-threaded](docs/arm_speed_st.svg)
 
 ![ARM Speed — Multi-threaded](docs/arm_speed_mt.svg)
 
-On ARM, TurboQuant beats FAISS FastScan by 10–19% across every config.
+On ARM, TurboQuant beats FAISS FastScan by 16–24% across every config.
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 
@@ -166,7 +166,7 @@ On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded ti
 
 Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs, fresh index per timed run. Insertion measures bulk `add()` into an empty index (one-time rotation/codebook init and TQ+ calibration fit included) and a warm 10K append with calibration frozen (the steady-state encode path), against FAISS `IndexPQFastScan` bulk add (training untimed). Removal measures per-op latency of `IdMapIndex.remove(id)` against raw `TurboQuantIndex.swap_remove` — both O(1) swap-and-pop; the gap is the id-map bookkeeping. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
 
-### ARM (Apple M3 Max)
+### ARM (GCP c4a, Google Axion)
 
 ![ARM Insertion — Single-threaded](docs/arm_insert_st.svg)
 
@@ -185,6 +185,26 @@ Full results: [d=1536 2-bit insert ST](benchmarks/results/speed_insert_d1536_2bi
 ![x86 Removal — Single-threaded](docs/x86_remove_st.svg)
 
 Full results: [d=1536 2-bit insert ST](benchmarks/results/speed_insert_d1536_2bit_x86_st.json), [MT](benchmarks/results/speed_insert_d1536_2bit_x86_mt.json), [d=1536 4-bit insert ST](benchmarks/results/speed_insert_d1536_4bit_x86_st.json), [MT](benchmarks/results/speed_insert_d1536_4bit_x86_mt.json), [d=3072 2-bit insert ST](benchmarks/results/speed_insert_d3072_2bit_x86_st.json), [MT](benchmarks/results/speed_insert_d3072_2bit_x86_mt.json), [d=3072 4-bit insert ST](benchmarks/results/speed_insert_d3072_4bit_x86_st.json), [MT](benchmarks/results/speed_insert_d3072_4bit_x86_mt.json), and the matching [`speed_remove_*`](benchmarks/results/) files.
+
+## Save & Load
+
+Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs. TurboQuant serializes to a single `.tv` file with an fsync + atomic rename; FAISS is `write_index` / `read_index` on the precision-matched `IndexPQFastScan` (sub-quantizer count matched to TurboQuant's bit rate, as in the search cells). **Save (warm)** is a write after a search has run, so the blocked layout cache is populated. **Load → first search** opens a fresh index and times the first query — separating bare deserialization (the page cache is warm throughout, so this is layout work, not cold-storage I/O) from the first-query cost. **Round-trip** chains the checkpoint/resume cycle an embedding store actually pays — mutate 1K vectors → save → reopen → serve the first query; FAISS has no measured equivalent for this path, so it is shown for TurboQuant only. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
+
+### ARM (GCP c4a, Google Axion)
+
+![ARM Save/Load — Single-threaded](docs/arm_persist_st.svg)
+
+![ARM Save/Load — Multi-threaded](docs/arm_persist_mt.svg)
+
+Full results: [d=1536 2-bit persist ST](benchmarks/results/speed_persist_d1536_2bit_arm_st.json), [MT](benchmarks/results/speed_persist_d1536_2bit_arm_mt.json), [d=1536 4-bit persist ST](benchmarks/results/speed_persist_d1536_4bit_arm_st.json), [MT](benchmarks/results/speed_persist_d1536_4bit_arm_mt.json), [d=3072 2-bit persist ST](benchmarks/results/speed_persist_d3072_2bit_arm_st.json), [MT](benchmarks/results/speed_persist_d3072_2bit_arm_mt.json), [d=3072 4-bit persist ST](benchmarks/results/speed_persist_d3072_4bit_arm_st.json), [MT](benchmarks/results/speed_persist_d3072_4bit_arm_mt.json).
+
+### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
+
+![x86 Save/Load — Single-threaded](docs/x86_persist_st.svg)
+
+![x86 Save/Load — Multi-threaded](docs/x86_persist_mt.svg)
+
+Full results: [d=1536 2-bit persist ST](benchmarks/results/speed_persist_d1536_2bit_x86_st.json), [MT](benchmarks/results/speed_persist_d1536_2bit_x86_mt.json), [d=1536 4-bit persist ST](benchmarks/results/speed_persist_d1536_4bit_x86_st.json), [MT](benchmarks/results/speed_persist_d1536_4bit_x86_mt.json), [d=3072 2-bit persist ST](benchmarks/results/speed_persist_d3072_2bit_x86_st.json), [MT](benchmarks/results/speed_persist_d3072_2bit_x86_mt.json), [d=3072 4-bit persist ST](benchmarks/results/speed_persist_d3072_4bit_x86_st.json), [MT](benchmarks/results/speed_persist_d3072_4bit_x86_mt.json).
 
 ## How it works
 

--- a/benchmarks/create_diagrams.py
+++ b/benchmarks/create_diagrams.py
@@ -5,6 +5,8 @@ Reads JSON files from ./results/ and writes:
   ../docs/x86_speed_st.svg, ../docs/x86_speed_mt.svg
   ../docs/arm_insert_st.svg, ../docs/arm_insert_mt.svg, ../docs/arm_remove_st.svg
   ../docs/x86_insert_st.svg, ../docs/x86_insert_mt.svg, ../docs/x86_remove_st.svg
+  ../docs/arm_persist_st.svg, ../docs/arm_persist_mt.svg
+  ../docs/x86_persist_st.svg, ../docs/x86_persist_mt.svg
   ../docs/recall_d1536.svg, ../docs/recall_d3072.svg, ../docs/recall_glove.svg
   ../docs/compression.svg
 """
@@ -357,6 +359,115 @@ def write_remove_panel(arch, hw_label, thread_key, thread_label, filename):
     print(f"wrote {out}")
 
 
+def persist_panel(px, py, pw, ph, panel_title, groups, tick_fmt, value_fmt, y_max, paired=True):
+    parts = [grid_lines(px, py, pw, ph, 0, y_max, tick_fmt)]
+    parts.append(f'<text x="{px}" y="{py - 14}" class="panel">{xe(panel_title)}</text>')
+    n = len(groups)
+    band = pw / n
+    bar_w = min(28, band * (0.30 if paired else 0.34))
+    gap = 5
+    for i, g in enumerate(groups):
+        cx = px + band * i + band / 2
+        tq_x = (cx - bar_w - gap / 2) if paired else (cx - bar_w / 2)
+        tq_h = (g["tq"] / y_max) * ph
+        tq_y = py + ph - tq_h
+        parts.append(
+            f'<rect x="{tq_x:.1f}" y="{tq_y:.1f}" width="{bar_w}" height="{tq_h:.1f}" rx="6" '
+            f'fill="{C["tq"]}" stroke="{C["tq_stroke"]}" stroke-width="1.5" />'
+        )
+        parts.append(
+            f'<text x="{tq_x + bar_w/2:.1f}" y="{tq_y - 6:.1f}" text-anchor="middle" class="value-accent">{xe(value_fmt(g["tq"]))}</text>'
+        )
+        if paired:
+            faiss_x = cx + gap / 2
+            faiss_h = (g["faiss"] / y_max) * ph
+            faiss_y = py + ph - faiss_h
+            parts.append(
+                f'<rect x="{faiss_x:.1f}" y="{faiss_y:.1f}" width="{bar_w}" height="{faiss_h:.1f}" rx="6" fill="{C["faiss"]}" />'
+            )
+            parts.append(
+                f'<text x="{faiss_x + bar_w/2:.1f}" y="{faiss_y - 6:.1f}" text-anchor="middle" class="value">{xe(value_fmt(g["faiss"]))}</text>'
+            )
+        label_y = py + ph + 22
+        primary, _, secondary = g["label"].partition("|")
+        parts.append(f'<text x="{cx:.1f}" y="{label_y}" text-anchor="middle" class="label">{xe(primary)}</text>')
+        if secondary:
+            parts.append(f'<text x="{cx:.1f}" y="{label_y + 15}" text-anchor="middle" class="secondary">{xe(secondary)}</text>')
+    return "\n".join(parts)
+
+
+def write_persist_panel(arch, hw_label, thread_key, thread_label, filename):
+    # Three panels: Save (warm), Load -> first search (cold start), Round-trip.
+    # The first two are precision-matched TurboQuant-vs-FAISS pairs; the round-trip
+    # (mutate -> save -> load -> search) exercises TurboQuant's durability path and
+    # has no measured FAISS equivalent, so that panel is TurboQuant-only.
+    save, cold, rtrip = [], [], []
+    for dim in (1536, 3072):
+        for bw in (2, 4):
+            e = load_json(f"speed_persist_d{dim}_{bw}bit_{arch}_{thread_key}.json")
+            lbl = f"d={dim}|{bw}-bit"
+            save.append({"label": lbl, "tq": e["tq_write_warm_ms"], "faiss": e["faiss_write_ms"]})
+            cold.append({"label": lbl, "tq": e["tq_load_first_search_ms"], "faiss": e["faiss_read_first_search_ms"]})
+            rtrip.append({"label": lbl, "tq": e["tq_mutate_save_load_search_ms"]})
+
+    width, height = 1440, 480
+    margin = {"top": 92, "right": 24, "bottom": 96, "left": 70}
+    ph = height - margin["top"] - margin["bottom"]
+    py = margin["top"]
+    inner = width - margin["left"] - margin["right"]
+    panel_gap = 56
+    panel_w = (inner - 2 * panel_gap) / 3
+
+    def ms_val(v):
+        return f"{v:.0f}" if v >= 20 else f"{v:.1f}"
+
+    def ms_tick(v):
+        return f"{v:.0f}" if v >= 10 else f"{v:.1f}"
+
+    specs = [
+        ("Save (warm)", save, True),
+        ("Load → first search", cold, True),
+        ("Round-trip (mutate → save → load → search)", rtrip, False),
+    ]
+    parts = []
+    for i, (title, groups, paired) in enumerate(specs):
+        px = margin["left"] + i * (panel_w + panel_gap)
+        vals = [g["tq"] for g in groups] + ([g["faiss"] for g in groups] if paired else [])
+        y_max = nice_ceil(max(vals) * 1.22)
+        parts.append(persist_panel(px, py, panel_w, ph, title, groups, ms_tick, ms_val, y_max, paired=paired))
+
+    parts.append(
+        f'<text x="24" y="{py + ph/2}" transform="rotate(-90, 24, {py + ph/2})" class="axis">milliseconds</text>'
+    )
+
+    legend_y = height - 24
+    lx = margin["left"]
+    parts.append(
+        f'<rect x="{lx}" y="{legend_y - 10}" width="14" height="14" rx="3" fill="{C["tq"]}" stroke="{C["tq_stroke"]}" stroke-width="1.5" />'
+    )
+    parts.append(f'<text x="{lx + 22}" y="{legend_y + 1}" class="legend" style="fill: {C["tq_text"]};">TurboQuant</text>')
+    parts.append(f'<rect x="{lx + 140}" y="{legend_y - 10}" width="14" height="14" rx="3" fill="{C["faiss"]}" />')
+    parts.append(f'<text x="{lx + 162}" y="{legend_y + 1}" class="legend">FAISS</text>')
+    parts.append(
+        f'<text x="{lx + 240}" y="{legend_y + 1}" class="secondary">Round-trip is TurboQuant-only — FAISS has no measured mutate→save→load→search equivalent.</text>'
+    )
+
+    body = "\n".join(parts)
+    svg = f"""<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img" aria-label="Persist — {xe(hw_label)} — {xe(thread_label)}">
+  {style_block()}
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <text x="{margin["left"]}" y="32" class="title">Save / Load — {xe(hw_label)} — {xe(thread_label)}</text>
+  <text x="{margin["left"]}" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
+  {body}
+</svg>
+"""
+    out = os.path.join(DOCS_DIR, filename)
+    with open(out, "w") as f:
+        f.write(svg)
+    print(f"wrote {out}")
+
+
 def line_panel(px, py, pw, ph, panel_title, series, x_values, x_labels, y_lo, y_hi):
     parts = [
         grid_lines(px, py, pw, ph, y_lo, y_hi, lambda v: f"{v:.2f}"),
@@ -541,10 +652,10 @@ def write_compression_chart(filename):
 
 if __name__ == "__main__":
     os.makedirs(DOCS_DIR, exist_ok=True)
-    write_speed_panel("arm", "ARM (Apple M3 Max)", "st", "Single-threaded",
+    write_speed_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
                       tick_fmt=lambda v: f"{v:.1f}", value_fmt=lambda v: f"{v:.2f}",
                       filename="arm_speed_st.svg")
-    write_speed_panel("arm", "ARM (Apple M3 Max)", "mt", "Multi-threaded",
+    write_speed_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
                       tick_fmt=lambda v: f"{v:.2f}", value_fmt=lambda v: f"{v:.3f}",
                       filename="arm_speed_mt.svg")
     write_speed_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
@@ -554,11 +665,11 @@ if __name__ == "__main__":
                       tick_fmt=lambda v: f"{v:.2f}", value_fmt=lambda v: f"{v:.3f}",
                       filename="x86_speed_mt.svg")
     # Insert/remove figures, per architecture.
-    write_insert_panel("arm", "ARM (Apple M3 Max)", "st", "Single-threaded",
+    write_insert_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
                        filename="arm_insert_st.svg")
-    write_insert_panel("arm", "ARM (Apple M3 Max)", "mt", "Multi-threaded",
+    write_insert_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
                        filename="arm_insert_mt.svg")
-    write_remove_panel("arm", "ARM (Apple M3 Max)", "st", "Single-threaded",
+    write_remove_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
                        filename="arm_remove_st.svg")
     write_insert_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
                        filename="x86_insert_st.svg")
@@ -566,6 +677,15 @@ if __name__ == "__main__":
                        filename="x86_insert_mt.svg")
     write_remove_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
                        filename="x86_remove_st.svg")
+    # Save/load (persist) figures, per architecture.
+    write_persist_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
+                        filename="arm_persist_st.svg")
+    write_persist_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
+                        filename="arm_persist_mt.svg")
+    write_persist_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
+                        filename="x86_persist_st.svg")
+    write_persist_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "mt", "Multi-threaded",
+                        filename="x86_persist_mt.svg")
     write_recall_panel("d1536", "d=1536", "recall_d1536.svg")
     write_recall_panel("d3072", "d=3072", "recall_d3072.svg")
     write_recall_panel("glove", "GloVe d=200", "recall_glove.svg", y_lo=0.4)

--- a/benchmarks/create_diagrams.py
+++ b/benchmarks/create_diagrams.py
@@ -652,10 +652,10 @@ def write_compression_chart(filename):
 
 if __name__ == "__main__":
     os.makedirs(DOCS_DIR, exist_ok=True)
-    write_speed_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
+    write_speed_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "st", "Single-threaded",
                       tick_fmt=lambda v: f"{v:.1f}", value_fmt=lambda v: f"{v:.2f}",
                       filename="arm_speed_st.svg")
-    write_speed_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
+    write_speed_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "mt", "Multi-threaded",
                       tick_fmt=lambda v: f"{v:.2f}", value_fmt=lambda v: f"{v:.3f}",
                       filename="arm_speed_mt.svg")
     write_speed_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
@@ -665,11 +665,11 @@ if __name__ == "__main__":
                       tick_fmt=lambda v: f"{v:.2f}", value_fmt=lambda v: f"{v:.3f}",
                       filename="x86_speed_mt.svg")
     # Insert/remove figures, per architecture.
-    write_insert_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
+    write_insert_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "st", "Single-threaded",
                        filename="arm_insert_st.svg")
-    write_insert_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
+    write_insert_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "mt", "Multi-threaded",
                        filename="arm_insert_mt.svg")
-    write_remove_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
+    write_remove_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "st", "Single-threaded",
                        filename="arm_remove_st.svg")
     write_insert_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
                        filename="x86_insert_st.svg")
@@ -678,9 +678,9 @@ if __name__ == "__main__":
     write_remove_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
                        filename="x86_remove_st.svg")
     # Save/load (persist) figures, per architecture.
-    write_persist_panel("arm", "ARM (GCP c4a, Google Axion)", "st", "Single-threaded",
+    write_persist_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "st", "Single-threaded",
                         filename="arm_persist_st.svg")
-    write_persist_panel("arm", "ARM (GCP c4a, Google Axion)", "mt", "Multi-threaded",
+    write_persist_panel("arm", "ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)", "mt", "Multi-threaded",
                         filename="arm_persist_mt.svg")
     write_persist_panel("x86", "x86 (Intel Sapphire Rapids, 8 vCPUs)", "st", "Single-threaded",
                         filename="x86_persist_st.svg")

--- a/benchmarks/results/speed_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_d1536_2bit_arm_mt.json
@@ -3,6 +3,6 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_ms_per_query": 0.103,
-  "faiss_ms_per_query": 0.115
+  "tq_ms_per_query": 0.189,
+  "faiss_ms_per_query": 0.247
 }

--- a/benchmarks/results/speed_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_d1536_2bit_arm_st.json
@@ -3,6 +3,6 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_ms_per_query": 1.083,
-  "faiss_ms_per_query": 1.235
+  "tq_ms_per_query": 1.539,
+  "faiss_ms_per_query": 2.017
 }

--- a/benchmarks/results/speed_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_d1536_4bit_arm_mt.json
@@ -3,6 +3,6 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_ms_per_query": 0.185,
-  "faiss_ms_per_query": 0.22
+  "tq_ms_per_query": 0.411,
+  "faiss_ms_per_query": 0.498
 }

--- a/benchmarks/results/speed_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_d1536_4bit_arm_st.json
@@ -3,6 +3,6 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_ms_per_query": 1.992,
-  "faiss_ms_per_query": 2.45
+  "tq_ms_per_query": 3.249,
+  "faiss_ms_per_query": 4.017
 }

--- a/benchmarks/results/speed_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_d3072_2bit_arm_mt.json
@@ -3,6 +3,6 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_ms_per_query": 0.201,
-  "faiss_ms_per_query": 0.224
+  "tq_ms_per_query": 0.412,
+  "faiss_ms_per_query": 0.492
 }

--- a/benchmarks/results/speed_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_d3072_2bit_arm_st.json
@@ -3,6 +3,6 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_ms_per_query": 2.124,
-  "faiss_ms_per_query": 2.439
+  "tq_ms_per_query": 3.268,
+  "faiss_ms_per_query": 3.941
 }

--- a/benchmarks/results/speed_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_d3072_4bit_arm_mt.json
@@ -3,6 +3,6 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_ms_per_query": 0.375,
-  "faiss_ms_per_query": 0.448
+  "tq_ms_per_query": 0.813,
+  "faiss_ms_per_query": 0.982
 }

--- a/benchmarks/results/speed_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_d3072_4bit_arm_st.json
@@ -3,6 +3,6 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_ms_per_query": 3.968,
-  "faiss_ms_per_query": 4.925
+  "tq_ms_per_query": 6.419,
+  "faiss_ms_per_query": 7.936
 }

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 800353,
-  "tq_warm_insert_vecs_per_sec": 1719814,
-  "tq_single_add_us": 5.2,
-  "faiss_bulk_insert_vecs_per_sec": 590899
+  "tq_bulk_insert_vecs_per_sec": 581646,
+  "tq_warm_insert_vecs_per_sec": 944192,
+  "tq_single_add_us": 7.88,
+  "faiss_bulk_insert_vecs_per_sec": 134241
 }

--- a/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_2bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 136253,
-  "tq_warm_insert_vecs_per_sec": 274401,
-  "tq_single_add_us": 5.14,
-  "faiss_bulk_insert_vecs_per_sec": 75374
+  "tq_bulk_insert_vecs_per_sec": 86676,
+  "tq_warm_insert_vecs_per_sec": 163261,
+  "tq_single_add_us": 7.94,
+  "faiss_bulk_insert_vecs_per_sec": 17403
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 564866,
-  "tq_warm_insert_vecs_per_sec": 1562032,
-  "tq_single_add_us": 5.8,
-  "faiss_bulk_insert_vecs_per_sec": 332445
+  "tq_bulk_insert_vecs_per_sec": 385585,
+  "tq_warm_insert_vecs_per_sec": 769762,
+  "tq_single_add_us": 9.35,
+  "faiss_bulk_insert_vecs_per_sec": 67620
 }

--- a/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d1536_4bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 120934,
-  "tq_warm_insert_vecs_per_sec": 235147,
-  "tq_single_add_us": 5.76,
-  "faiss_bulk_insert_vecs_per_sec": 49523
+  "tq_bulk_insert_vecs_per_sec": 72334,
+  "tq_warm_insert_vecs_per_sec": 129258,
+  "tq_single_add_us": 9.29,
+  "faiss_bulk_insert_vecs_per_sec": 8718
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 435542,
-  "tq_warm_insert_vecs_per_sec": 849561,
-  "tq_single_add_us": 10.16,
-  "faiss_bulk_insert_vecs_per_sec": 263082
+  "tq_bulk_insert_vecs_per_sec": 292002,
+  "tq_warm_insert_vecs_per_sec": 482882,
+  "tq_single_add_us": 15.53,
+  "faiss_bulk_insert_vecs_per_sec": 67592
 }

--- a/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_2bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 66697,
-  "tq_warm_insert_vecs_per_sec": 134144,
-  "tq_single_add_us": 10.32,
-  "faiss_bulk_insert_vecs_per_sec": 37067
+  "tq_bulk_insert_vecs_per_sec": 42967,
+  "tq_warm_insert_vecs_per_sec": 77641,
+  "tq_single_add_us": 15.55,
+  "faiss_bulk_insert_vecs_per_sec": 8712
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_bulk_insert_vecs_per_sec": 336295,
-  "tq_warm_insert_vecs_per_sec": 749393,
-  "tq_single_add_us": 11.42,
-  "faiss_bulk_insert_vecs_per_sec": 172716
+  "tq_bulk_insert_vecs_per_sec": 223516,
+  "tq_warm_insert_vecs_per_sec": 388394,
+  "tq_single_add_us": 18.27,
+  "faiss_bulk_insert_vecs_per_sec": 33778
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_arm_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 58624,
-  "tq_warm_insert_vecs_per_sec": 112011,
-  "tq_single_add_us": 11.48,
-  "faiss_bulk_insert_vecs_per_sec": 24450
+  "tq_bulk_insert_vecs_per_sec": 37155,
+  "tq_warm_insert_vecs_per_sec": 61726,
+  "tq_single_add_us": 18.31,
+  "faiss_bulk_insert_vecs_per_sec": 4353
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 10723,
-  "tq_warm_insert_vecs_per_sec": 14515,
-  "tq_single_add_us": 69.29,
-  "faiss_bulk_insert_vecs_per_sec": 15709
+  "tq_bulk_insert_vecs_per_sec": 26639,
+  "tq_warm_insert_vecs_per_sec": 65096,
+  "tq_single_add_us": 12.39,
+  "faiss_bulk_insert_vecs_per_sec": 15670
 }

--- a/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_insert_d3072_4bit_x86_st.json
@@ -3,8 +3,8 @@
   "bit_width": 4,
   "arch": "x86",
   "threading": "st",
-  "tq_bulk_insert_vecs_per_sec": 26639,
-  "tq_warm_insert_vecs_per_sec": 65096,
-  "tq_single_add_us": 12.39,
-  "faiss_bulk_insert_vecs_per_sec": 15670
+  "tq_bulk_insert_vecs_per_sec": 10723,
+  "tq_warm_insert_vecs_per_sec": 14515,
+  "tq_single_add_us": 69.29,
+  "faiss_bulk_insert_vecs_per_sec": 15709
 }

--- a/benchmarks/results/speed_persist_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_arm_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 38812338,
+  "tq_write_warm_ms": 90.33,
+  "tq_write_after_mutation_ms": 138.27,
+  "tq_load_ms": 1.27,
+  "tq_load_first_search_ms": 1.6,
+  "tq_mutate_save_load_search_ms": 103.2,
+  "faiss_write_ms": 93.75,
+  "faiss_read_ms": 3.46,
+  "faiss_read_first_search_ms": 6.95
+}

--- a/benchmarks/results/speed_persist_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_arm_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 38812338,
+  "tq_write_warm_ms": 91.77,
+  "tq_write_after_mutation_ms": 134.03,
+  "tq_load_ms": 1.45,
+  "tq_load_first_search_ms": 3.2,
+  "tq_mutate_save_load_search_ms": 110.01,
+  "faiss_write_ms": 91.21,
+  "faiss_read_ms": 4.52,
+  "faiss_read_first_search_ms": 7.71
+}

--- a/benchmarks/results/speed_persist_d1536_2bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_x86_mt.json
@@ -5,12 +5,12 @@
   "threading": "mt",
   "n_vectors": 100000,
   "tv_file_bytes": 38812338,
-  "tq_write_warm_ms": 131.81,
-  "tq_write_after_mutation_ms": 212.98,
-  "tq_load_ms": 4.92,
-  "tq_load_first_search_ms": 5.73,
-  "tq_mutate_save_load_search_ms": 159.17,
-  "faiss_write_ms": 118.24,
-  "faiss_read_ms": 13.37,
-  "faiss_read_first_search_ms": 14.15
+  "tq_write_warm_ms": 131.78,
+  "tq_write_after_mutation_ms": 213.36,
+  "tq_load_ms": 5.05,
+  "tq_load_first_search_ms": 5.84,
+  "tq_mutate_save_load_search_ms": 151.72,
+  "faiss_write_ms": 119.81,
+  "faiss_read_ms": 12.33,
+  "faiss_read_first_search_ms": 13.4
 }

--- a/benchmarks/results/speed_persist_d1536_2bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_x86_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "x86",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 38812338,
+  "tq_write_warm_ms": 131.81,
+  "tq_write_after_mutation_ms": 212.98,
+  "tq_load_ms": 4.92,
+  "tq_load_first_search_ms": 5.73,
+  "tq_mutate_save_load_search_ms": 159.17,
+  "faiss_write_ms": 118.24,
+  "faiss_read_ms": 13.37,
+  "faiss_read_first_search_ms": 14.15
+}

--- a/benchmarks/results/speed_persist_d1536_2bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_x86_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 2,
+  "arch": "x86",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 38812338,
+  "tq_write_warm_ms": 140.04,
+  "tq_write_after_mutation_ms": 210.37,
+  "tq_load_ms": 5.09,
+  "tq_load_first_search_ms": 9.6,
+  "tq_mutate_save_load_search_ms": 167.03,
+  "faiss_write_ms": 115.96,
+  "faiss_read_ms": 12.0,
+  "faiss_read_first_search_ms": 13.94
+}

--- a/benchmarks/results/speed_persist_d1536_2bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d1536_2bit_x86_st.json
@@ -5,12 +5,12 @@
   "threading": "st",
   "n_vectors": 100000,
   "tv_file_bytes": 38812338,
-  "tq_write_warm_ms": 140.04,
-  "tq_write_after_mutation_ms": 210.37,
-  "tq_load_ms": 5.09,
-  "tq_load_first_search_ms": 9.6,
-  "tq_mutate_save_load_search_ms": 167.03,
-  "faiss_write_ms": 115.96,
-  "faiss_read_ms": 12.0,
-  "faiss_read_first_search_ms": 13.94
+  "tq_write_warm_ms": 139.86,
+  "tq_write_after_mutation_ms": 210.77,
+  "tq_load_ms": 5.04,
+  "tq_load_first_search_ms": 9.51,
+  "tq_mutate_save_load_search_ms": 166.91,
+  "faiss_write_ms": 114.7,
+  "faiss_read_ms": 12.45,
+  "faiss_read_first_search_ms": 13.91
 }

--- a/benchmarks/results/speed_persist_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_arm_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77212434,
+  "tq_write_warm_ms": 251.96,
+  "tq_write_after_mutation_ms": 277.52,
+  "tq_load_ms": 1.75,
+  "tq_load_first_search_ms": 2.65,
+  "tq_mutate_save_load_search_ms": 268.71,
+  "faiss_write_ms": 217.46,
+  "faiss_read_ms": 6.73,
+  "faiss_read_first_search_ms": 14.57
+}

--- a/benchmarks/results/speed_persist_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_arm_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77212434,
+  "tq_write_warm_ms": 254.6,
+  "tq_write_after_mutation_ms": 272.21,
+  "tq_load_ms": 1.78,
+  "tq_load_first_search_ms": 6.01,
+  "tq_mutate_save_load_search_ms": 277.98,
+  "faiss_write_ms": 233.36,
+  "faiss_read_ms": 6.97,
+  "faiss_read_first_search_ms": 14.99
+}

--- a/benchmarks/results/speed_persist_d1536_4bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_x86_mt.json
@@ -5,12 +5,12 @@
   "threading": "mt",
   "n_vectors": 100000,
   "tv_file_bytes": 77212434,
-  "tq_write_warm_ms": 374.69,
-  "tq_write_after_mutation_ms": 430.18,
-  "tq_load_ms": 10.09,
-  "tq_load_first_search_ms": 12.88,
-  "tq_mutate_save_load_search_ms": 407.28,
-  "faiss_write_ms": 346.67,
-  "faiss_read_ms": 31.65,
-  "faiss_read_first_search_ms": 35.97
+  "tq_write_warm_ms": 375.19,
+  "tq_write_after_mutation_ms": 430.4,
+  "tq_load_ms": 7.56,
+  "tq_load_first_search_ms": 9.33,
+  "tq_mutate_save_load_search_ms": 406.46,
+  "faiss_write_ms": 349.47,
+  "faiss_read_ms": 24.21,
+  "faiss_read_first_search_ms": 30.6
 }

--- a/benchmarks/results/speed_persist_d1536_4bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_x86_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "x86",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77212434,
+  "tq_write_warm_ms": 374.69,
+  "tq_write_after_mutation_ms": 430.18,
+  "tq_load_ms": 10.09,
+  "tq_load_first_search_ms": 12.88,
+  "tq_mutate_save_load_search_ms": 407.28,
+  "faiss_write_ms": 346.67,
+  "faiss_read_ms": 31.65,
+  "faiss_read_first_search_ms": 35.97
+}

--- a/benchmarks/results/speed_persist_d1536_4bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_x86_st.json
@@ -5,12 +5,12 @@
   "threading": "st",
   "n_vectors": 100000,
   "tv_file_bytes": 77212434,
-  "tq_write_warm_ms": 388.51,
-  "tq_write_after_mutation_ms": 426.06,
-  "tq_load_ms": 24.73,
-  "tq_load_first_search_ms": 43.25,
-  "tq_mutate_save_load_search_ms": 443.02,
-  "faiss_write_ms": 377.59,
-  "faiss_read_ms": 29.32,
-  "faiss_read_first_search_ms": 32.24
+  "tq_write_warm_ms": 390.01,
+  "tq_write_after_mutation_ms": 426.69,
+  "tq_load_ms": 7.55,
+  "tq_load_first_search_ms": 16.45,
+  "tq_mutate_save_load_search_ms": 433.73,
+  "faiss_write_ms": 346.42,
+  "faiss_read_ms": 24.58,
+  "faiss_read_first_search_ms": 30.89
 }

--- a/benchmarks/results/speed_persist_d1536_4bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d1536_4bit_x86_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 1536,
+  "bit_width": 4,
+  "arch": "x86",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77212434,
+  "tq_write_warm_ms": 388.51,
+  "tq_write_after_mutation_ms": 426.06,
+  "tq_load_ms": 24.73,
+  "tq_load_first_search_ms": 43.25,
+  "tq_mutate_save_load_search_ms": 443.02,
+  "faiss_write_ms": 377.59,
+  "faiss_read_ms": 29.32,
+  "faiss_read_first_search_ms": 32.24
+}

--- a/benchmarks/results/speed_persist_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_arm_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77224626,
+  "tq_write_warm_ms": 253.52,
+  "tq_write_after_mutation_ms": 275.66,
+  "tq_load_ms": 1.84,
+  "tq_load_first_search_ms": 2.67,
+  "tq_mutate_save_load_search_ms": 272.62,
+  "faiss_write_ms": 234.8,
+  "faiss_read_ms": 6.74,
+  "faiss_read_first_search_ms": 14.24
+}

--- a/benchmarks/results/speed_persist_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_arm_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "arm",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77224626,
+  "tq_write_warm_ms": 254.46,
+  "tq_write_after_mutation_ms": 262.3,
+  "tq_load_ms": 1.77,
+  "tq_load_first_search_ms": 5.79,
+  "tq_mutate_save_load_search_ms": 284.78,
+  "faiss_write_ms": 231.25,
+  "faiss_read_ms": 6.93,
+  "faiss_read_first_search_ms": 14.88
+}

--- a/benchmarks/results/speed_persist_d3072_2bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_x86_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "x86",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77224626,
+  "tq_write_warm_ms": 378.27,
+  "tq_write_after_mutation_ms": 431.19,
+  "tq_load_ms": 10.82,
+  "tq_load_first_search_ms": 13.77,
+  "tq_mutate_save_load_search_ms": 429.79,
+  "faiss_write_ms": 350.36,
+  "faiss_read_ms": 29.11,
+  "faiss_read_first_search_ms": 35.01
+}

--- a/benchmarks/results/speed_persist_d3072_2bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_x86_mt.json
@@ -5,12 +5,12 @@
   "threading": "mt",
   "n_vectors": 100000,
   "tv_file_bytes": 77224626,
-  "tq_write_warm_ms": 378.27,
-  "tq_write_after_mutation_ms": 431.19,
-  "tq_load_ms": 10.82,
-  "tq_load_first_search_ms": 13.77,
-  "tq_mutate_save_load_search_ms": 429.79,
-  "faiss_write_ms": 350.36,
-  "faiss_read_ms": 29.11,
-  "faiss_read_first_search_ms": 35.01
+  "tq_write_warm_ms": 374.24,
+  "tq_write_after_mutation_ms": 424.6,
+  "tq_load_ms": 7.7,
+  "tq_load_first_search_ms": 9.58,
+  "tq_mutate_save_load_search_ms": 412.61,
+  "faiss_write_ms": 348.24,
+  "faiss_read_ms": 24.58,
+  "faiss_read_first_search_ms": 30.83
 }

--- a/benchmarks/results/speed_persist_d3072_2bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_x86_st.json
@@ -5,12 +5,12 @@
   "threading": "st",
   "n_vectors": 100000,
   "tv_file_bytes": 77224626,
-  "tq_write_warm_ms": 389.66,
-  "tq_write_after_mutation_ms": 418.13,
-  "tq_load_ms": 8.15,
-  "tq_load_first_search_ms": 16.68,
-  "tq_mutate_save_load_search_ms": 444.36,
-  "faiss_write_ms": 347.16,
-  "faiss_read_ms": 28.2,
-  "faiss_read_first_search_ms": 31.16
+  "tq_write_warm_ms": 392.22,
+  "tq_write_after_mutation_ms": 418.42,
+  "tq_load_ms": 7.84,
+  "tq_load_first_search_ms": 16.87,
+  "tq_mutate_save_load_search_ms": 442.21,
+  "faiss_write_ms": 352.84,
+  "faiss_read_ms": 25.46,
+  "faiss_read_first_search_ms": 32.26
 }

--- a/benchmarks/results/speed_persist_d3072_2bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d3072_2bit_x86_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 2,
+  "arch": "x86",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 77224626,
+  "tq_write_warm_ms": 389.66,
+  "tq_write_after_mutation_ms": 418.13,
+  "tq_load_ms": 8.15,
+  "tq_load_first_search_ms": 16.68,
+  "tq_mutate_save_load_search_ms": 444.36,
+  "faiss_write_ms": 347.16,
+  "faiss_read_ms": 28.2,
+  "faiss_read_first_search_ms": 31.16
+}

--- a/benchmarks/results/speed_persist_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_arm_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 154024722,
+  "tq_write_warm_ms": 575.57,
+  "tq_write_after_mutation_ms": 582.94,
+  "tq_load_ms": 2.97,
+  "tq_load_first_search_ms": 4.53,
+  "tq_mutate_save_load_search_ms": 605.02,
+  "faiss_write_ms": 490.63,
+  "faiss_read_ms": 13.37,
+  "faiss_read_first_search_ms": 30.29
+}

--- a/benchmarks/results/speed_persist_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_arm_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "arm",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 154024722,
+  "tq_write_warm_ms": 574.18,
+  "tq_write_after_mutation_ms": 588.87,
+  "tq_load_ms": 3.05,
+  "tq_load_first_search_ms": 11.81,
+  "tq_mutate_save_load_search_ms": 623.54,
+  "faiss_write_ms": 490.77,
+  "faiss_read_ms": 13.72,
+  "faiss_read_first_search_ms": 30.5
+}

--- a/benchmarks/results/speed_persist_d3072_4bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_x86_mt.json
@@ -5,12 +5,12 @@
   "threading": "mt",
   "n_vectors": 100000,
   "tv_file_bytes": 154024722,
-  "tq_write_warm_ms": 856.74,
-  "tq_write_after_mutation_ms": 870.26,
-  "tq_load_ms": 14.83,
-  "tq_load_first_search_ms": 19.51,
-  "tq_mutate_save_load_search_ms": 914.86,
-  "faiss_write_ms": 742.16,
-  "faiss_read_ms": 48.22,
-  "faiss_read_first_search_ms": 64.94
+  "tq_write_warm_ms": 857.4,
+  "tq_write_after_mutation_ms": 870.49,
+  "tq_load_ms": 14.34,
+  "tq_load_first_search_ms": 18.74,
+  "tq_mutate_save_load_search_ms": 915.63,
+  "faiss_write_ms": 727.8,
+  "faiss_read_ms": 47.84,
+  "faiss_read_first_search_ms": 64.25
 }

--- a/benchmarks/results/speed_persist_d3072_4bit_x86_mt.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_x86_mt.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "x86",
+  "threading": "mt",
+  "n_vectors": 100000,
+  "tv_file_bytes": 154024722,
+  "tq_write_warm_ms": 856.74,
+  "tq_write_after_mutation_ms": 870.26,
+  "tq_load_ms": 14.83,
+  "tq_load_first_search_ms": 19.51,
+  "tq_mutate_save_load_search_ms": 914.86,
+  "faiss_write_ms": 742.16,
+  "faiss_read_ms": 48.22,
+  "faiss_read_first_search_ms": 64.94
+}

--- a/benchmarks/results/speed_persist_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_x86_st.json
@@ -5,12 +5,12 @@
   "threading": "st",
   "n_vectors": 100000,
   "tv_file_bytes": 154024722,
-  "tq_write_warm_ms": 890.11,
-  "tq_write_after_mutation_ms": 899.36,
-  "tq_load_ms": 14.41,
-  "tq_load_first_search_ms": 33.54,
-  "tq_mutate_save_load_search_ms": 969.64,
-  "faiss_write_ms": 718.13,
-  "faiss_read_ms": 47.99,
-  "faiss_read_first_search_ms": 66.4
+  "tq_write_warm_ms": 890.98,
+  "tq_write_after_mutation_ms": 901.61,
+  "tq_load_ms": 14.09,
+  "tq_load_first_search_ms": 32.99,
+  "tq_mutate_save_load_search_ms": 970.71,
+  "faiss_write_ms": 712.1,
+  "faiss_read_ms": 54.03,
+  "faiss_read_first_search_ms": 66.62
 }

--- a/benchmarks/results/speed_persist_d3072_4bit_x86_st.json
+++ b/benchmarks/results/speed_persist_d3072_4bit_x86_st.json
@@ -1,0 +1,16 @@
+{
+  "dim": 3072,
+  "bit_width": 4,
+  "arch": "x86",
+  "threading": "st",
+  "n_vectors": 100000,
+  "tv_file_bytes": 154024722,
+  "tq_write_warm_ms": 890.11,
+  "tq_write_after_mutation_ms": 899.36,
+  "tq_load_ms": 14.41,
+  "tq_load_first_search_ms": 33.54,
+  "tq_mutate_save_load_search_ms": 969.64,
+  "faiss_write_ms": 718.13,
+  "faiss_read_ms": 47.99,
+  "faiss_read_first_search_ms": 66.4
+}

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.193,
-  "tq_idmap_removes_per_sec": 5194715,
-  "tq_swap_remove_us_per_op": 0.168
+  "tq_idmap_remove_us_per_op": 0.264,
+  "tq_idmap_removes_per_sec": 3781543,
+  "tq_swap_remove_us_per_op": 0.216
 }

--- a/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_2bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.15,
-  "tq_idmap_removes_per_sec": 6680919,
-  "tq_swap_remove_us_per_op": 0.127
+  "tq_idmap_remove_us_per_op": 0.271,
+  "tq_idmap_removes_per_sec": 3696587,
+  "tq_swap_remove_us_per_op": 0.215
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.269,
-  "tq_idmap_removes_per_sec": 3724025,
-  "tq_swap_remove_us_per_op": 0.181
+  "tq_idmap_remove_us_per_op": 0.327,
+  "tq_idmap_removes_per_sec": 3060017,
+  "tq_swap_remove_us_per_op": 0.273
 }

--- a/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d1536_4bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.182,
-  "tq_idmap_removes_per_sec": 5488198,
-  "tq_swap_remove_us_per_op": 0.154
+  "tq_idmap_remove_us_per_op": 0.315,
+  "tq_idmap_removes_per_sec": 3175929,
+  "tq_swap_remove_us_per_op": 0.259
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.27,
-  "tq_idmap_removes_per_sec": 3705064,
-  "tq_swap_remove_us_per_op": 0.186
+  "tq_idmap_remove_us_per_op": 0.315,
+  "tq_idmap_removes_per_sec": 3171242,
+  "tq_swap_remove_us_per_op": 0.259
 }

--- a/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_2bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 2,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.174,
-  "tq_idmap_removes_per_sec": 5750101,
-  "tq_swap_remove_us_per_op": 0.164
+  "tq_idmap_remove_us_per_op": 0.307,
+  "tq_idmap_removes_per_sec": 3254487,
+  "tq_swap_remove_us_per_op": 0.256
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_mt.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "mt",
-  "tq_idmap_remove_us_per_op": 0.287,
-  "tq_idmap_removes_per_sec": 3480945,
-  "tq_swap_remove_us_per_op": 0.256
+  "tq_idmap_remove_us_per_op": 0.389,
+  "tq_idmap_removes_per_sec": 2572867,
+  "tq_swap_remove_us_per_op": 0.337
 }

--- a/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
+++ b/benchmarks/results/speed_remove_d3072_4bit_arm_st.json
@@ -3,7 +3,7 @@
   "bit_width": 4,
   "arch": "arm",
   "threading": "st",
-  "tq_idmap_remove_us_per_op": 0.241,
-  "tq_idmap_removes_per_sec": 4153212,
-  "tq_swap_remove_us_per_op": 0.22
+  "tq_idmap_remove_us_per_op": 0.387,
+  "tq_idmap_removes_per_sec": 2586683,
+  "tq_swap_remove_us_per_op": 0.363
 }

--- a/docs/arm_insert_mt.svg
+++ b/docs/arm_insert_mt.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a, Google Axion) — Multi-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
+  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded</text>
   <text x="84" y="52" class="subtitle">Bulk: 100K vectors into an empty index (init + calibration fit included). Warm: 10K append, calibration frozen. Median of 5 runs.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>

--- a/docs/arm_insert_mt.svg
+++ b/docs/arm_insert_mt.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (Apple M3 Max) — Multi-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a, Google Axion) — Multi-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,52 +13,52 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Insertion Throughput — ARM (Apple M3 Max) — Multi-threaded</text>
+  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
   <text x="84" y="52" class="subtitle">Bulk: 100K vectors into an empty index (init + calibration fit included). Warm: 10K append, calibration frozen. Median of 5 runs.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">1000K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">300K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">2000K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">600K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">3000K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">900K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">4000K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">1200K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">5000K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">1500K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="109.3" y="308.8" width="43.12" height="43.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="302.8" text-anchor="middle" class="value-accent">800K</text>
-<rect x="160.4" y="259.1" width="43.12" height="92.9" rx="6" fill="#0f766e" />
-<text x="182.0" y="253.1" text-anchor="middle" class="value">1720K</text>
-<rect x="211.6" y="320.1" width="43.12" height="31.9" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="314.1" text-anchor="middle" class="value">591K</text>
+<rect x="109.3" y="247.3" width="43.12" height="104.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="241.3" text-anchor="middle" class="value-accent">582K</text>
+<rect x="160.4" y="182.0" width="43.12" height="170.0" rx="6" fill="#0f766e" />
+<text x="182.0" y="176.0" text-anchor="middle" class="value">944K</text>
+<rect x="211.6" y="327.8" width="43.12" height="24.2" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="321.8" text-anchor="middle" class="value">134K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="321.5" width="43.12" height="30.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="315.5" text-anchor="middle" class="value-accent">565K</text>
-<rect x="356.4" y="267.7" width="43.12" height="84.3" rx="6" fill="#0f766e" />
-<text x="378.0" y="261.7" text-anchor="middle" class="value">1562K</text>
-<rect x="407.6" y="334.0" width="43.12" height="18.0" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="328.0" text-anchor="middle" class="value">332K</text>
+<rect x="305.3" y="282.6" width="43.12" height="69.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="276.6" text-anchor="middle" class="value-accent">386K</text>
+<rect x="356.4" y="213.4" width="43.12" height="138.6" rx="6" fill="#0f766e" />
+<text x="378.0" y="207.4" text-anchor="middle" class="value">770K</text>
+<rect x="407.6" y="339.8" width="43.12" height="12.2" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="333.8" text-anchor="middle" class="value">68K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="328.5" width="43.12" height="23.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="322.5" text-anchor="middle" class="value-accent">436K</text>
-<rect x="552.4" y="306.1" width="43.12" height="45.9" rx="6" fill="#0f766e" />
-<text x="574.0" y="300.1" text-anchor="middle" class="value">850K</text>
-<rect x="603.6" y="337.8" width="43.12" height="14.2" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="331.8" text-anchor="middle" class="value">263K</text>
+<rect x="501.3" y="299.4" width="43.12" height="52.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="293.4" text-anchor="middle" class="value-accent">292K</text>
+<rect x="552.4" y="265.1" width="43.12" height="86.9" rx="6" fill="#0f766e" />
+<text x="574.0" y="259.1" text-anchor="middle" class="value">483K</text>
+<rect x="603.6" y="339.8" width="43.12" height="12.2" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="333.8" text-anchor="middle" class="value">68K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="333.8" width="43.12" height="18.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="327.8" text-anchor="middle" class="value-accent">336K</text>
-<rect x="748.4" y="311.5" width="43.12" height="40.5" rx="6" fill="#0f766e" />
-<text x="770.0" y="305.5" text-anchor="middle" class="value">749K</text>
-<rect x="799.6" y="342.7" width="43.12" height="9.3" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="336.7" text-anchor="middle" class="value">173K</text>
+<rect x="697.3" y="311.8" width="43.12" height="40.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="305.8" text-anchor="middle" class="value-accent">224K</text>
+<rect x="748.4" y="282.1" width="43.12" height="69.9" rx="6" fill="#0f766e" />
+<text x="770.0" y="276.1" text-anchor="middle" class="value">388K</text>
+<rect x="799.6" y="345.9" width="43.12" height="6.1" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="339.9" text-anchor="middle" class="value">34K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/arm_insert_st.svg
+++ b/docs/arm_insert_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (Apple M3 Max) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a, Google Axion) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,52 +13,52 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Insertion Throughput — ARM (Apple M3 Max) — Single-threaded</text>
+  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a, Google Axion) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">Bulk: 100K vectors into an empty index (init + calibration fit included). Warm: 10K append, calibration frozen. Median of 5 runs.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">100K</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">40K</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">200K</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">80K</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">300K</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">120K</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">400K</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">160K</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">500K</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">200K</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="109.3" y="278.4" width="43.12" height="73.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="130.9" y="272.4" text-anchor="middle" class="value-accent">136K</text>
-<rect x="160.4" y="203.8" width="43.12" height="148.2" rx="6" fill="#0f766e" />
-<text x="182.0" y="197.8" text-anchor="middle" class="value">274K</text>
-<rect x="211.6" y="311.3" width="43.12" height="40.7" rx="6" fill="#9aa7b6" />
-<text x="233.1" y="305.3" text-anchor="middle" class="value">75K</text>
+<rect x="109.3" y="235.0" width="43.12" height="117.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="130.9" y="229.0" text-anchor="middle" class="value-accent">87K</text>
+<rect x="160.4" y="131.6" width="43.12" height="220.4" rx="6" fill="#0f766e" />
+<text x="182.0" y="125.6" text-anchor="middle" class="value">163K</text>
+<rect x="211.6" y="328.5" width="43.12" height="23.5" rx="6" fill="#9aa7b6" />
+<text x="233.1" y="322.5" text-anchor="middle" class="value">17.4K</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="305.3" y="286.7" width="43.12" height="65.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="326.9" y="280.7" text-anchor="middle" class="value-accent">121K</text>
-<rect x="356.4" y="225.0" width="43.12" height="127.0" rx="6" fill="#0f766e" />
-<text x="378.0" y="219.0" text-anchor="middle" class="value">235K</text>
-<rect x="407.6" y="325.3" width="43.12" height="26.7" rx="6" fill="#9aa7b6" />
-<text x="429.1" y="319.3" text-anchor="middle" class="value">50K</text>
+<rect x="305.3" y="254.3" width="43.12" height="97.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="326.9" y="248.3" text-anchor="middle" class="value-accent">72K</text>
+<rect x="356.4" y="177.5" width="43.12" height="174.5" rx="6" fill="#0f766e" />
+<text x="378.0" y="171.5" text-anchor="middle" class="value">129K</text>
+<rect x="407.6" y="340.2" width="43.12" height="11.8" rx="6" fill="#9aa7b6" />
+<text x="429.1" y="334.2" text-anchor="middle" class="value">8.7K</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="501.3" y="316.0" width="43.12" height="36.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="522.9" y="310.0" text-anchor="middle" class="value-accent">67K</text>
-<rect x="552.4" y="279.6" width="43.12" height="72.4" rx="6" fill="#0f766e" />
-<text x="574.0" y="273.6" text-anchor="middle" class="value">134K</text>
-<rect x="603.6" y="332.0" width="43.12" height="20.0" rx="6" fill="#9aa7b6" />
-<text x="625.1" y="326.0" text-anchor="middle" class="value">37K</text>
+<rect x="501.3" y="294.0" width="43.12" height="58.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="522.9" y="288.0" text-anchor="middle" class="value-accent">43K</text>
+<rect x="552.4" y="247.2" width="43.12" height="104.8" rx="6" fill="#0f766e" />
+<text x="574.0" y="241.2" text-anchor="middle" class="value">78K</text>
+<rect x="603.6" y="340.2" width="43.12" height="11.8" rx="6" fill="#9aa7b6" />
+<text x="625.1" y="334.2" text-anchor="middle" class="value">8.7K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="320.3" width="43.12" height="31.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="314.3" text-anchor="middle" class="value-accent">59K</text>
-<rect x="748.4" y="291.5" width="43.12" height="60.5" rx="6" fill="#0f766e" />
-<text x="770.0" y="285.5" text-anchor="middle" class="value">112K</text>
-<rect x="799.6" y="338.8" width="43.12" height="13.2" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="332.8" text-anchor="middle" class="value">24K</text>
+<rect x="697.3" y="301.8" width="43.12" height="50.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="295.8" text-anchor="middle" class="value-accent">37K</text>
+<rect x="748.4" y="268.7" width="43.12" height="83.3" rx="6" fill="#0f766e" />
+<text x="770.0" y="262.7" text-anchor="middle" class="value">62K</text>
+<rect x="799.6" y="346.1" width="43.12" height="5.9" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="340.1" text-anchor="middle" class="value">4.4K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/arm_insert_st.svg
+++ b/docs/arm_insert_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a, Google Axion) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Insertion Throughput — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a, Google Axion) — Single-threaded</text>
+  <text x="84" y="32" class="title">Insertion Throughput — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">Bulk: 100K vectors into an empty index (init + calibration fit included). Warm: 10K append, calibration frozen. Median of 5 runs.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0K</text>

--- a/docs/arm_persist_mt.svg
+++ b/docs/arm_persist_mt.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a, Google Axion) — Multi-threaded">
+  <style>
+  .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .panel { font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .label { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .secondary { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .tick { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748b; }
+  .value { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .value-accent { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #4338ca; }
+  .axis { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+  .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+</style>
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
+  <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
+  <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="70.0" y1="325.6" x2="481.3333333333333" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="329.6" text-anchor="end" class="tick">200</text>
+<line x1="70.0" y1="267.2" x2="481.3333333333333" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="271.2" text-anchor="end" class="tick">400</text>
+<line x1="70.0" y1="208.8" x2="481.3333333333333" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="212.8" text-anchor="end" class="tick">600</text>
+<line x1="70.0" y1="150.4" x2="481.3333333333333" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="154.4" text-anchor="end" class="tick">800</text>
+<line x1="70.0" y1="92.0" x2="481.3333333333333" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="96.0" text-anchor="end" class="tick">1000</text>
+<line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="70.0" y="78" class="panel">Save (warm)</text>
+<rect x="90.9" y="357.6" width="28" height="26.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="104.9" y="351.6" text-anchor="middle" class="value-accent">90</text>
+<rect x="123.9" y="356.6" width="28" height="27.4" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="350.6" text-anchor="middle" class="value">94</text>
+<text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="193.7" y="310.4" width="28" height="73.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="304.4" text-anchor="middle" class="value-accent">252</text>
+<rect x="226.7" y="320.5" width="28" height="63.5" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="314.5" text-anchor="middle" class="value">217</text>
+<text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="296.6" y="310.0" width="28" height="74.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="304.0" text-anchor="middle" class="value-accent">254</text>
+<rect x="329.6" y="315.4" width="28" height="68.6" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="309.4" text-anchor="middle" class="value">235</text>
+<text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="399.4" y="215.9" width="28" height="168.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="209.9" text-anchor="middle" class="value-accent">576</text>
+<rect x="432.4" y="240.7" width="28" height="143.3" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="234.7" text-anchor="middle" class="value">491</text>
+<text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="537.3333333333333" y1="325.6" x2="948.6666666666665" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="329.6" text-anchor="end" class="tick">10</text>
+<line x1="537.3333333333333" y1="267.2" x2="948.6666666666665" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="271.2" text-anchor="end" class="tick">20</text>
+<line x1="537.3333333333333" y1="208.8" x2="948.6666666666665" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="212.8" text-anchor="end" class="tick">30</text>
+<line x1="537.3333333333333" y1="150.4" x2="948.6666666666665" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="154.4" text-anchor="end" class="tick">40</text>
+<line x1="537.3333333333333" y1="92.0" x2="948.6666666666665" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">50</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="537.3333333333333" y="78" class="panel">Load → first search</text>
+<rect x="558.2" y="374.7" width="28" height="9.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="368.7" text-anchor="middle" class="value-accent">1.6</text>
+<rect x="591.2" y="343.4" width="28" height="40.6" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="337.4" text-anchor="middle" class="value">7.0</text>
+<text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="661.1" y="368.5" width="28" height="15.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="362.5" text-anchor="middle" class="value-accent">2.6</text>
+<rect x="694.1" y="298.9" width="28" height="85.1" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="292.9" text-anchor="middle" class="value">14.6</text>
+<text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="763.9" y="368.4" width="28" height="15.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="362.4" text-anchor="middle" class="value-accent">2.7</text>
+<rect x="796.9" y="300.8" width="28" height="83.2" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="294.8" text-anchor="middle" class="value">14.2</text>
+<text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="866.7" y="357.5" width="28" height="26.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="351.5" text-anchor="middle" class="value-accent">4.5</text>
+<rect x="899.7" y="207.1" width="28" height="176.9" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="201.1" text-anchor="middle" class="value">30</text>
+<text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="1004.6666666666666" y1="325.6" x2="1416.0" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="329.6" text-anchor="end" class="tick">200</text>
+<line x1="1004.6666666666666" y1="267.2" x2="1416.0" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="271.2" text-anchor="end" class="tick">400</text>
+<line x1="1004.6666666666666" y1="208.8" x2="1416.0" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="212.8" text-anchor="end" class="tick">600</text>
+<line x1="1004.6666666666666" y1="150.4" x2="1416.0" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="154.4" text-anchor="end" class="tick">800</text>
+<line x1="1004.6666666666666" y1="92.0" x2="1416.0" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="96.0" text-anchor="end" class="tick">1000</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="1004.6666666666666" y="78" class="panel">Round-trip (mutate → save → load → search)</text>
+<rect x="1042.1" y="353.9" width="28" height="30.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1056.1" y="347.9" text-anchor="middle" class="value-accent">103</text>
+<text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1144.9" y="305.5" width="28" height="78.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="299.5" text-anchor="middle" class="value-accent">269</text>
+<text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="1247.8" y="304.4" width="28" height="79.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="298.4" text-anchor="middle" class="value-accent">273</text>
+<text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1350.6" y="207.3" width="28" height="176.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="201.3" text-anchor="middle" class="value-accent">605</text>
+<text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>
+<rect x="70" y="446" width="14" height="14" rx="3" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="92" y="457" class="legend" style="fill: #4338ca;">TurboQuant</text>
+<rect x="210" y="446" width="14" height="14" rx="3" fill="#9aa7b6" />
+<text x="232" y="457" class="legend">FAISS</text>
+<text x="310" y="457" class="secondary">Round-trip is TurboQuant-only — FAISS has no measured mutate→save→load→search equivalent.</text>
+</svg>

--- a/docs/arm_persist_mt.svg
+++ b/docs/arm_persist_mt.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a, Google Axion) — Multi-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
+  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded</text>
   <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
   <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>

--- a/docs/arm_persist_st.svg
+++ b/docs/arm_persist_st.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a, Google Axion) — Single-threaded">
+  <style>
+  .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .panel { font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .label { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .secondary { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .tick { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748b; }
+  .value { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .value-accent { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #4338ca; }
+  .axis { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+  .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+</style>
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a, Google Axion) — Single-threaded</text>
+  <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
+  <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="70.0" y1="325.6" x2="481.3333333333333" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="329.6" text-anchor="end" class="tick">200</text>
+<line x1="70.0" y1="267.2" x2="481.3333333333333" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="271.2" text-anchor="end" class="tick">400</text>
+<line x1="70.0" y1="208.8" x2="481.3333333333333" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="212.8" text-anchor="end" class="tick">600</text>
+<line x1="70.0" y1="150.4" x2="481.3333333333333" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="154.4" text-anchor="end" class="tick">800</text>
+<line x1="70.0" y1="92.0" x2="481.3333333333333" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="96.0" text-anchor="end" class="tick">1000</text>
+<line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="70.0" y="78" class="panel">Save (warm)</text>
+<rect x="90.9" y="357.2" width="28" height="26.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="104.9" y="351.2" text-anchor="middle" class="value-accent">92</text>
+<rect x="123.9" y="357.4" width="28" height="26.6" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="351.4" text-anchor="middle" class="value">91</text>
+<text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="193.7" y="309.7" width="28" height="74.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="303.7" text-anchor="middle" class="value-accent">255</text>
+<rect x="226.7" y="315.9" width="28" height="68.1" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="309.9" text-anchor="middle" class="value">233</text>
+<text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="296.6" y="309.7" width="28" height="74.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="303.7" text-anchor="middle" class="value-accent">254</text>
+<rect x="329.6" y="316.5" width="28" height="67.5" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="310.5" text-anchor="middle" class="value">231</text>
+<text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="399.4" y="216.3" width="28" height="167.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="210.3" text-anchor="middle" class="value-accent">574</text>
+<rect x="432.4" y="240.7" width="28" height="143.3" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="234.7" text-anchor="middle" class="value">491</text>
+<text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="537.3333333333333" y1="325.6" x2="948.6666666666665" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="329.6" text-anchor="end" class="tick">10</text>
+<line x1="537.3333333333333" y1="267.2" x2="948.6666666666665" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="271.2" text-anchor="end" class="tick">20</text>
+<line x1="537.3333333333333" y1="208.8" x2="948.6666666666665" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="212.8" text-anchor="end" class="tick">30</text>
+<line x1="537.3333333333333" y1="150.4" x2="948.6666666666665" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="154.4" text-anchor="end" class="tick">40</text>
+<line x1="537.3333333333333" y1="92.0" x2="948.6666666666665" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">50</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="537.3333333333333" y="78" class="panel">Load → first search</text>
+<rect x="558.2" y="365.3" width="28" height="18.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="359.3" text-anchor="middle" class="value-accent">3.2</text>
+<rect x="591.2" y="339.0" width="28" height="45.0" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="333.0" text-anchor="middle" class="value">7.7</text>
+<text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="661.1" y="348.9" width="28" height="35.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="342.9" text-anchor="middle" class="value-accent">6.0</text>
+<rect x="694.1" y="296.5" width="28" height="87.5" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="290.5" text-anchor="middle" class="value">15.0</text>
+<text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="763.9" y="350.2" width="28" height="33.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="344.2" text-anchor="middle" class="value-accent">5.8</text>
+<rect x="796.9" y="297.1" width="28" height="86.9" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="291.1" text-anchor="middle" class="value">14.9</text>
+<text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="866.7" y="315.0" width="28" height="69.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="309.0" text-anchor="middle" class="value-accent">11.8</text>
+<rect x="899.7" y="205.9" width="28" height="178.1" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="199.9" text-anchor="middle" class="value">30</text>
+<text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="1004.6666666666666" y1="325.6" x2="1416.0" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="329.6" text-anchor="end" class="tick">200</text>
+<line x1="1004.6666666666666" y1="267.2" x2="1416.0" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="271.2" text-anchor="end" class="tick">400</text>
+<line x1="1004.6666666666666" y1="208.8" x2="1416.0" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="212.8" text-anchor="end" class="tick">600</text>
+<line x1="1004.6666666666666" y1="150.4" x2="1416.0" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="154.4" text-anchor="end" class="tick">800</text>
+<line x1="1004.6666666666666" y1="92.0" x2="1416.0" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="96.0" text-anchor="end" class="tick">1000</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="1004.6666666666666" y="78" class="panel">Round-trip (mutate → save → load → search)</text>
+<rect x="1042.1" y="351.9" width="28" height="32.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1056.1" y="345.9" text-anchor="middle" class="value-accent">110</text>
+<text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1144.9" y="302.8" width="28" height="81.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="296.8" text-anchor="middle" class="value-accent">278</text>
+<text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="1247.8" y="300.8" width="28" height="83.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="294.8" text-anchor="middle" class="value-accent">285</text>
+<text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1350.6" y="201.9" width="28" height="182.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="195.9" text-anchor="middle" class="value-accent">624</text>
+<text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>
+<rect x="70" y="446" width="14" height="14" rx="3" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="92" y="457" class="legend" style="fill: #4338ca;">TurboQuant</text>
+<rect x="210" y="446" width="14" height="14" rx="3" fill="#9aa7b6" />
+<text x="232" y="457" class="legend">FAISS</text>
+<text x="310" y="457" class="secondary">Round-trip is TurboQuant-only — FAISS has no measured mutate→save→load→search equivalent.</text>
+</svg>

--- a/docs/arm_persist_st.svg
+++ b/docs/arm_persist_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a, Google Axion) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a, Google Axion) — Single-threaded</text>
+  <text x="70" y="32" class="title">Save / Load — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded</text>
   <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
   <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>

--- a/docs/arm_remove_st.svg
+++ b/docs/arm_remove_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Removal Latency — ARM (GCP c4a, Google Axion) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Removal Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Removal Latency — ARM (GCP c4a, Google Axion) — Single-threaded</text>
+  <text x="84" y="32" class="title">Removal Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 50K removals in seeded random order, median of 5 runs. Both paths are O(1) swap-and-pop; the gap is the id-map bookkeeping.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.0</text>

--- a/docs/arm_remove_st.svg
+++ b/docs/arm_remove_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Removal Latency — ARM (Apple M3 Max) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Removal Latency — ARM (GCP c4a, Google Axion) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Removal Latency — ARM (Apple M3 Max) — Single-threaded</text>
+  <text x="84" y="32" class="title">Removal Latency — ARM (GCP c4a, Google Axion) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 50K removals in seeded random order, median of 5 runs. Both paths are O(1) swap-and-pop; the gap is the id-map bookkeeping.</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.0</text>
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">0.5</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="271.0" width="44" height="81.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="283.4" width="44" height="68.6" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="265.0" text-anchor="middle" class="value-accent">0.15</text>
-<text x="207.0" y="277.4" text-anchor="middle" class="value">0.13</text>
+<rect x="135.0" y="205.7" width="44" height="146.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="235.9" width="44" height="116.1" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="199.7" text-anchor="middle" class="value-accent">0.27</text>
+<text x="207.0" y="229.9" text-anchor="middle" class="value">0.21</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="253.7" width="44" height="98.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="268.8" width="44" height="83.2" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="247.7" text-anchor="middle" class="value-accent">0.18</text>
-<text x="403.0" y="262.8" text-anchor="middle" class="value">0.15</text>
+<rect x="331.0" y="181.9" width="44" height="170.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="212.1" width="44" height="139.9" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="175.9" text-anchor="middle" class="value-accent">0.32</text>
+<text x="403.0" y="206.1" text-anchor="middle" class="value">0.26</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="258.0" width="44" height="94.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="263.4" width="44" height="88.6" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="252.0" text-anchor="middle" class="value-accent">0.17</text>
-<text x="599.0" y="257.4" text-anchor="middle" class="value">0.16</text>
+<rect x="527.0" y="186.2" width="44" height="165.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="213.8" width="44" height="138.2" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="180.2" text-anchor="middle" class="value-accent">0.31</text>
+<text x="599.0" y="207.8" text-anchor="middle" class="value">0.26</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="221.9" width="44" height="130.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="233.2" width="44" height="118.8" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="215.9" text-anchor="middle" class="value-accent">0.24</text>
-<text x="795.0" y="227.2" text-anchor="middle" class="value">0.22</text>
+<rect x="723.0" y="143.0" width="44" height="209.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="156.0" width="44" height="196.0" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="137.0" text-anchor="middle" class="value-accent">0.39</text>
+<text x="795.0" y="150.0" text-anchor="middle" class="value">0.36</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">µs / op</text>

--- a/docs/arm_speed_mt.svg
+++ b/docs/arm_speed_mt.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (Apple M3 Max) — Multi-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a, Google Axion) — Multi-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,44 +13,44 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Search Latency — ARM (Apple M3 Max) — Multi-threaded</text>
+  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 1K queries, k=64, median of 5 runs</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.00</text>
 <line x1="84" y1="298.0" x2="868" y2="298.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="302.0" text-anchor="end" class="tick">0.20</text>
+<text x="74" y="302.0" text-anchor="end" class="tick">0.30</text>
 <line x1="84" y1="244.0" x2="868" y2="244.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="248.0" text-anchor="end" class="tick">0.40</text>
+<text x="74" y="248.0" text-anchor="end" class="tick">0.60</text>
 <line x1="84" y1="190.0" x2="868" y2="190.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="194.0" text-anchor="end" class="tick">0.60</text>
+<text x="74" y="194.0" text-anchor="end" class="tick">0.90</text>
 <line x1="84" y1="136.0" x2="868" y2="136.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="140.0" text-anchor="end" class="tick">0.80</text>
+<text x="74" y="140.0" text-anchor="end" class="tick">1.20</text>
 <line x1="84" y1="82.0" x2="868" y2="82.0" stroke="#e5e7eb" stroke-width="1" />
-<text x="74" y="86.0" text-anchor="end" class="tick">1.00</text>
+<text x="74" y="86.0" text-anchor="end" class="tick">1.50</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Multi-threaded</text>
-<rect x="135.0" y="324.2" width="44" height="27.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="320.9" width="44" height="31.1" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="318.2" text-anchor="middle" class="value-accent">0.103</text>
-<text x="207.0" y="314.9" text-anchor="middle" class="value">0.115</text>
+<rect x="135.0" y="318.0" width="44" height="34.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="307.5" width="44" height="44.5" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="312.0" text-anchor="middle" class="value-accent">0.189</text>
+<text x="207.0" y="301.5" text-anchor="middle" class="value">0.247</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="302.1" width="44" height="50.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="292.6" width="44" height="59.4" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="296.1" text-anchor="middle" class="value-accent">0.185</text>
-<text x="403.0" y="286.6" text-anchor="middle" class="value">0.220</text>
+<rect x="331.0" y="278.0" width="44" height="74.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="262.4" width="44" height="89.6" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="272.0" text-anchor="middle" class="value-accent">0.411</text>
+<text x="403.0" y="256.4" text-anchor="middle" class="value">0.498</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="297.7" width="44" height="54.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="291.5" width="44" height="60.5" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="291.7" text-anchor="middle" class="value-accent">0.201</text>
-<text x="599.0" y="285.5" text-anchor="middle" class="value">0.224</text>
+<rect x="527.0" y="277.8" width="44" height="74.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="263.4" width="44" height="88.6" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="271.8" text-anchor="middle" class="value-accent">0.412</text>
+<text x="599.0" y="257.4" text-anchor="middle" class="value">0.492</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="250.8" width="44" height="101.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="231.0" width="44" height="121.0" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="244.8" text-anchor="middle" class="value-accent">0.375</text>
-<text x="795.0" y="225.0" text-anchor="middle" class="value">0.448</text>
+<rect x="723.0" y="205.7" width="44" height="146.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="175.2" width="44" height="176.8" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="199.7" text-anchor="middle" class="value-accent">0.813</text>
+<text x="795.0" y="169.2" text-anchor="middle" class="value">0.982</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/arm_speed_mt.svg
+++ b/docs/arm_speed_mt.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a, Google Axion) — Multi-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a, Google Axion) — Multi-threaded</text>
+  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Multi-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 1K queries, k=64, median of 5 runs</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.00</text>

--- a/docs/arm_speed_st.svg
+++ b/docs/arm_speed_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a, Google Axion) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a, Google Axion) — Single-threaded</text>
+  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 1K queries, k=64, median of 5 runs</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.0</text>

--- a/docs/arm_speed_st.svg
+++ b/docs/arm_speed_st.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (Apple M3 Max) — Single-threaded">
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="460" viewBox="0 0 900 460" role="img" aria-label="Search Latency — ARM (GCP c4a, Google Axion) — Single-threaded">
   <style>
   .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
   .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
@@ -13,7 +13,7 @@
   .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
 </style>
   <rect width="100%" height="100%" fill="#ffffff" />
-  <text x="84" y="32" class="title">Search Latency — ARM (Apple M3 Max) — Single-threaded</text>
+  <text x="84" y="32" class="title">Search Latency — ARM (GCP c4a, Google Axion) — Single-threaded</text>
   <text x="84" y="52" class="subtitle">100K vectors, 1K queries, k=64, median of 5 runs</text>
   <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#e5e7eb" stroke-width="1" />
 <text x="74" y="356.0" text-anchor="end" class="tick">0.0</text>
@@ -29,28 +29,28 @@
 <text x="74" y="86.0" text-anchor="end" class="tick">10.0</text>
 <line x1="84" y1="352.0" x2="868" y2="352.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="84" y="68" class="panel">Single-threaded</text>
-<rect x="135.0" y="322.8" width="44" height="29.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="185.0" y="318.7" width="44" height="33.3" rx="6" fill="#9aa7b6" />
-<text x="157.0" y="316.8" text-anchor="middle" class="value-accent">1.08</text>
-<text x="207.0" y="312.7" text-anchor="middle" class="value">1.24</text>
+<rect x="135.0" y="310.4" width="44" height="41.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="185.0" y="297.5" width="44" height="54.5" rx="6" fill="#9aa7b6" />
+<text x="157.0" y="304.4" text-anchor="middle" class="value-accent">1.54</text>
+<text x="207.0" y="291.5" text-anchor="middle" class="value">2.02</text>
 <text x="182.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="182.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="331.0" y="298.2" width="44" height="53.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="381.0" y="285.9" width="44" height="66.2" rx="6" fill="#9aa7b6" />
-<text x="353.0" y="292.2" text-anchor="middle" class="value-accent">1.99</text>
-<text x="403.0" y="279.9" text-anchor="middle" class="value">2.45</text>
+<rect x="331.0" y="264.3" width="44" height="87.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="381.0" y="243.5" width="44" height="108.5" rx="6" fill="#9aa7b6" />
+<text x="353.0" y="258.3" text-anchor="middle" class="value-accent">3.25</text>
+<text x="403.0" y="237.5" text-anchor="middle" class="value">4.02</text>
 <text x="378.0" y="374" text-anchor="middle" class="label">d=1536</text>
 <text x="378.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="527.0" y="294.7" width="44" height="57.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="577.0" y="286.1" width="44" height="65.9" rx="6" fill="#9aa7b6" />
-<text x="549.0" y="288.7" text-anchor="middle" class="value-accent">2.12</text>
-<text x="599.0" y="280.1" text-anchor="middle" class="value">2.44</text>
+<rect x="527.0" y="263.8" width="44" height="88.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="577.0" y="245.6" width="44" height="106.4" rx="6" fill="#9aa7b6" />
+<text x="549.0" y="257.8" text-anchor="middle" class="value-accent">3.27</text>
+<text x="599.0" y="239.6" text-anchor="middle" class="value">3.94</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="723.0" y="244.9" width="44" height="107.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<rect x="773.0" y="219.0" width="44" height="133.0" rx="6" fill="#9aa7b6" />
-<text x="745.0" y="238.9" text-anchor="middle" class="value-accent">3.97</text>
-<text x="795.0" y="213.0" text-anchor="middle" class="value">4.92</text>
+<rect x="723.0" y="178.7" width="44" height="173.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<rect x="773.0" y="137.7" width="44" height="214.3" rx="6" fill="#9aa7b6" />
+<text x="745.0" y="172.7" text-anchor="middle" class="value-accent">6.42</text>
+<text x="795.0" y="131.7" text-anchor="middle" class="value">7.94</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">ms / query</text>

--- a/docs/x86_insert_st.svg
+++ b/docs/x86_insert_st.svg
@@ -53,12 +53,12 @@
 <text x="625.1" y="308.5" text-anchor="middle" class="value">13.9K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="323.0" width="43.12" height="29.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="317.0" text-anchor="middle" class="value-accent">10.7K</text>
-<rect x="748.4" y="312.8" width="43.12" height="39.2" rx="6" fill="#0f766e" />
-<text x="770.0" y="306.8" text-anchor="middle" class="value">14.5K</text>
-<rect x="799.6" y="309.6" width="43.12" height="42.4" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="303.6" text-anchor="middle" class="value">15.7K</text>
+<rect x="697.3" y="280.1" width="43.12" height="71.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="274.1" text-anchor="middle" class="value-accent">27K</text>
+<rect x="748.4" y="176.2" width="43.12" height="175.8" rx="6" fill="#0f766e" />
+<text x="770.0" y="170.2" text-anchor="middle" class="value">65K</text>
+<rect x="799.6" y="309.7" width="43.12" height="42.3" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="303.7" text-anchor="middle" class="value">15.7K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/x86_insert_st.svg
+++ b/docs/x86_insert_st.svg
@@ -53,12 +53,12 @@
 <text x="625.1" y="308.5" text-anchor="middle" class="value">13.9K</text>
 <text x="574.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="574.0" y="389" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="697.3" y="280.1" width="43.12" height="71.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="718.9" y="274.1" text-anchor="middle" class="value-accent">27K</text>
-<rect x="748.4" y="176.2" width="43.12" height="175.8" rx="6" fill="#0f766e" />
-<text x="770.0" y="170.2" text-anchor="middle" class="value">65K</text>
-<rect x="799.6" y="309.7" width="43.12" height="42.3" rx="6" fill="#9aa7b6" />
-<text x="821.1" y="303.7" text-anchor="middle" class="value">15.7K</text>
+<rect x="697.3" y="323.0" width="43.12" height="29.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="718.9" y="317.0" text-anchor="middle" class="value-accent">10.7K</text>
+<rect x="748.4" y="312.8" width="43.12" height="39.2" rx="6" fill="#0f766e" />
+<text x="770.0" y="306.8" text-anchor="middle" class="value">14.5K</text>
+<rect x="799.6" y="309.6" width="43.12" height="42.4" rx="6" fill="#9aa7b6" />
+<text x="821.1" y="303.6" text-anchor="middle" class="value">15.7K</text>
 <text x="770.0" y="374" text-anchor="middle" class="label">d=3072</text>
 <text x="770.0" y="389" text-anchor="middle" class="secondary">4-bit</text>
 <text x="26" y="217.0" transform="rotate(-90, 26, 217.0)" class="axis">vectors / sec</text>

--- a/docs/x86_persist_mt.svg
+++ b/docs/x86_persist_mt.svg
@@ -31,26 +31,26 @@
 <text x="70.0" y="78" class="panel">Save (warm)</text>
 <rect x="90.9" y="358.3" width="28" height="25.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
 <text x="104.9" y="352.3" text-anchor="middle" class="value-accent">132</text>
-<rect x="123.9" y="361.0" width="28" height="23.0" rx="6" fill="#9aa7b6" />
-<text x="137.9" y="355.0" text-anchor="middle" class="value">118</text>
+<rect x="123.9" y="360.7" width="28" height="23.3" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="354.7" text-anchor="middle" class="value">120</text>
 <text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="193.7" y="311.1" width="28" height="72.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="207.7" y="305.1" text-anchor="middle" class="value-accent">375</text>
-<rect x="226.7" y="316.5" width="28" height="67.5" rx="6" fill="#9aa7b6" />
-<text x="240.7" y="310.5" text-anchor="middle" class="value">347</text>
+<rect x="193.7" y="311.0" width="28" height="73.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="305.0" text-anchor="middle" class="value-accent">375</text>
+<rect x="226.7" y="316.0" width="28" height="68.0" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="310.0" text-anchor="middle" class="value">349</text>
 <text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="296.6" y="310.4" width="28" height="73.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="310.6" y="304.4" text-anchor="middle" class="value-accent">378</text>
-<rect x="329.6" y="315.8" width="28" height="68.2" rx="6" fill="#9aa7b6" />
-<text x="343.6" y="309.8" text-anchor="middle" class="value">350</text>
+<rect x="296.6" y="311.1" width="28" height="72.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="305.1" text-anchor="middle" class="value-accent">374</text>
+<rect x="329.6" y="316.2" width="28" height="67.8" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="310.2" text-anchor="middle" class="value">348</text>
 <text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="399.4" y="217.2" width="28" height="166.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="413.4" y="211.2" text-anchor="middle" class="value-accent">857</text>
-<rect x="432.4" y="239.5" width="28" height="144.5" rx="6" fill="#9aa7b6" />
-<text x="446.4" y="233.5" text-anchor="middle" class="value">742</text>
+<rect x="399.4" y="217.1" width="28" height="166.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="211.1" text-anchor="middle" class="value-accent">857</text>
+<rect x="432.4" y="242.3" width="28" height="141.7" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="236.3" text-anchor="middle" class="value">728</text>
 <text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
@@ -67,28 +67,28 @@
 <text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">100</text>
 <line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="537.3333333333333" y="78" class="panel">Load → first search</text>
-<rect x="558.2" y="367.3" width="28" height="16.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="572.2" y="361.3" text-anchor="middle" class="value-accent">5.7</text>
-<rect x="591.2" y="342.7" width="28" height="41.3" rx="6" fill="#9aa7b6" />
-<text x="605.2" y="336.7" text-anchor="middle" class="value">14.2</text>
+<rect x="558.2" y="366.9" width="28" height="17.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="360.9" text-anchor="middle" class="value-accent">5.8</text>
+<rect x="591.2" y="344.9" width="28" height="39.1" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="338.9" text-anchor="middle" class="value">13.4</text>
 <text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="661.1" y="346.4" width="28" height="37.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="675.1" y="340.4" text-anchor="middle" class="value-accent">12.9</text>
-<rect x="694.1" y="279.0" width="28" height="105.0" rx="6" fill="#9aa7b6" />
-<text x="708.1" y="273.0" text-anchor="middle" class="value">36</text>
+<rect x="661.1" y="356.8" width="28" height="27.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="350.8" text-anchor="middle" class="value-accent">9.3</text>
+<rect x="694.1" y="294.6" width="28" height="89.4" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="288.6" text-anchor="middle" class="value">31</text>
 <text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="763.9" y="343.8" width="28" height="40.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="777.9" y="337.8" text-anchor="middle" class="value-accent">13.8</text>
-<rect x="796.9" y="281.8" width="28" height="102.2" rx="6" fill="#9aa7b6" />
-<text x="810.9" y="275.8" text-anchor="middle" class="value">35</text>
+<rect x="763.9" y="356.0" width="28" height="28.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="350.0" text-anchor="middle" class="value-accent">9.6</text>
+<rect x="796.9" y="294.0" width="28" height="90.0" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="288.0" text-anchor="middle" class="value">31</text>
 <text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="866.7" y="327.0" width="28" height="57.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="880.7" y="321.0" text-anchor="middle" class="value-accent">19.5</text>
-<rect x="899.7" y="194.4" width="28" height="189.6" rx="6" fill="#9aa7b6" />
-<text x="913.7" y="188.4" text-anchor="middle" class="value">65</text>
+<rect x="866.7" y="329.3" width="28" height="54.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="323.3" text-anchor="middle" class="value-accent">18.7</text>
+<rect x="899.7" y="196.4" width="28" height="187.6" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="190.4" text-anchor="middle" class="value">64</text>
 <text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
@@ -105,20 +105,20 @@
 <text x="994.6666666666666" y="96.0" text-anchor="end" class="tick">1500</text>
 <line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="1004.6666666666666" y="78" class="panel">Round-trip (mutate → save → load → search)</text>
-<rect x="1042.1" y="353.0" width="28" height="31.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1056.1" y="347.0" text-anchor="middle" class="value-accent">159</text>
+<rect x="1042.1" y="354.5" width="28" height="29.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1056.1" y="348.5" text-anchor="middle" class="value-accent">152</text>
 <text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="1144.9" y="304.7" width="28" height="79.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1158.9" y="298.7" text-anchor="middle" class="value-accent">407</text>
+<rect x="1144.9" y="304.9" width="28" height="79.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="298.9" text-anchor="middle" class="value-accent">406</text>
 <text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="1247.8" y="300.3" width="28" height="83.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1261.8" y="294.3" text-anchor="middle" class="value-accent">430</text>
+<rect x="1247.8" y="303.7" width="28" height="80.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="297.7" text-anchor="middle" class="value-accent">413</text>
 <text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="1350.6" y="205.9" width="28" height="178.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1364.6" y="199.9" text-anchor="middle" class="value-accent">915</text>
+<rect x="1350.6" y="205.8" width="28" height="178.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="199.8" text-anchor="middle" class="value-accent">916</text>
 <text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>

--- a/docs/x86_persist_mt.svg
+++ b/docs/x86_persist_mt.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — x86 (Intel Sapphire Rapids, 8 vCPUs) — Multi-threaded">
+  <style>
+  .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .panel { font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .label { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .secondary { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .tick { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748b; }
+  .value { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .value-accent { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #4338ca; }
+  .axis { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+  .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+</style>
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <text x="70" y="32" class="title">Save / Load — x86 (Intel Sapphire Rapids, 8 vCPUs) — Multi-threaded</text>
+  <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
+  <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="70.0" y1="325.6" x2="481.3333333333333" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="329.6" text-anchor="end" class="tick">300</text>
+<line x1="70.0" y1="267.2" x2="481.3333333333333" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="271.2" text-anchor="end" class="tick">600</text>
+<line x1="70.0" y1="208.8" x2="481.3333333333333" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="212.8" text-anchor="end" class="tick">900</text>
+<line x1="70.0" y1="150.4" x2="481.3333333333333" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="154.4" text-anchor="end" class="tick">1200</text>
+<line x1="70.0" y1="92.0" x2="481.3333333333333" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="96.0" text-anchor="end" class="tick">1500</text>
+<line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="70.0" y="78" class="panel">Save (warm)</text>
+<rect x="90.9" y="358.3" width="28" height="25.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="104.9" y="352.3" text-anchor="middle" class="value-accent">132</text>
+<rect x="123.9" y="361.0" width="28" height="23.0" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="355.0" text-anchor="middle" class="value">118</text>
+<text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="193.7" y="311.1" width="28" height="72.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="305.1" text-anchor="middle" class="value-accent">375</text>
+<rect x="226.7" y="316.5" width="28" height="67.5" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="310.5" text-anchor="middle" class="value">347</text>
+<text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="296.6" y="310.4" width="28" height="73.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="304.4" text-anchor="middle" class="value-accent">378</text>
+<rect x="329.6" y="315.8" width="28" height="68.2" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="309.8" text-anchor="middle" class="value">350</text>
+<text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="399.4" y="217.2" width="28" height="166.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="211.2" text-anchor="middle" class="value-accent">857</text>
+<rect x="432.4" y="239.5" width="28" height="144.5" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="233.5" text-anchor="middle" class="value">742</text>
+<text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="537.3333333333333" y1="325.6" x2="948.6666666666665" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="329.6" text-anchor="end" class="tick">20</text>
+<line x1="537.3333333333333" y1="267.2" x2="948.6666666666665" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="271.2" text-anchor="end" class="tick">40</text>
+<line x1="537.3333333333333" y1="208.8" x2="948.6666666666665" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="212.8" text-anchor="end" class="tick">60</text>
+<line x1="537.3333333333333" y1="150.4" x2="948.6666666666665" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="154.4" text-anchor="end" class="tick">80</text>
+<line x1="537.3333333333333" y1="92.0" x2="948.6666666666665" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">100</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="537.3333333333333" y="78" class="panel">Load → first search</text>
+<rect x="558.2" y="367.3" width="28" height="16.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="361.3" text-anchor="middle" class="value-accent">5.7</text>
+<rect x="591.2" y="342.7" width="28" height="41.3" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="336.7" text-anchor="middle" class="value">14.2</text>
+<text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="661.1" y="346.4" width="28" height="37.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="340.4" text-anchor="middle" class="value-accent">12.9</text>
+<rect x="694.1" y="279.0" width="28" height="105.0" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="273.0" text-anchor="middle" class="value">36</text>
+<text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="763.9" y="343.8" width="28" height="40.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="337.8" text-anchor="middle" class="value-accent">13.8</text>
+<rect x="796.9" y="281.8" width="28" height="102.2" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="275.8" text-anchor="middle" class="value">35</text>
+<text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="866.7" y="327.0" width="28" height="57.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="321.0" text-anchor="middle" class="value-accent">19.5</text>
+<rect x="899.7" y="194.4" width="28" height="189.6" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="188.4" text-anchor="middle" class="value">65</text>
+<text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="1004.6666666666666" y1="325.6" x2="1416.0" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="329.6" text-anchor="end" class="tick">300</text>
+<line x1="1004.6666666666666" y1="267.2" x2="1416.0" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="271.2" text-anchor="end" class="tick">600</text>
+<line x1="1004.6666666666666" y1="208.8" x2="1416.0" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="212.8" text-anchor="end" class="tick">900</text>
+<line x1="1004.6666666666666" y1="150.4" x2="1416.0" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="154.4" text-anchor="end" class="tick">1200</text>
+<line x1="1004.6666666666666" y1="92.0" x2="1416.0" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="96.0" text-anchor="end" class="tick">1500</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="1004.6666666666666" y="78" class="panel">Round-trip (mutate → save → load → search)</text>
+<rect x="1042.1" y="353.0" width="28" height="31.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1056.1" y="347.0" text-anchor="middle" class="value-accent">159</text>
+<text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1144.9" y="304.7" width="28" height="79.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="298.7" text-anchor="middle" class="value-accent">407</text>
+<text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="1247.8" y="300.3" width="28" height="83.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="294.3" text-anchor="middle" class="value-accent">430</text>
+<text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1350.6" y="205.9" width="28" height="178.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="199.9" text-anchor="middle" class="value-accent">915</text>
+<text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>
+<rect x="70" y="446" width="14" height="14" rx="3" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="92" y="457" class="legend" style="fill: #4338ca;">TurboQuant</text>
+<rect x="210" y="446" width="14" height="14" rx="3" fill="#9aa7b6" />
+<text x="232" y="457" class="legend">FAISS</text>
+<text x="310" y="457" class="secondary">Round-trip is TurboQuant-only — FAISS has no measured mutate→save→load→search equivalent.</text>
+</svg>

--- a/docs/x86_persist_st.svg
+++ b/docs/x86_persist_st.svg
@@ -29,28 +29,28 @@
 <text x="60.0" y="96.0" text-anchor="end" class="tick">1500</text>
 <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="70.0" y="78" class="panel">Save (warm)</text>
-<rect x="90.9" y="356.7" width="28" height="27.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="104.9" y="350.7" text-anchor="middle" class="value-accent">140</text>
-<rect x="123.9" y="361.4" width="28" height="22.6" rx="6" fill="#9aa7b6" />
-<text x="137.9" y="355.4" text-anchor="middle" class="value">116</text>
+<rect x="90.9" y="356.8" width="28" height="27.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="104.9" y="350.8" text-anchor="middle" class="value-accent">140</text>
+<rect x="123.9" y="361.7" width="28" height="22.3" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="355.7" text-anchor="middle" class="value">115</text>
 <text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="193.7" y="308.4" width="28" height="75.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="207.7" y="302.4" text-anchor="middle" class="value-accent">389</text>
-<rect x="226.7" y="310.5" width="28" height="73.5" rx="6" fill="#9aa7b6" />
-<text x="240.7" y="304.5" text-anchor="middle" class="value">378</text>
+<rect x="193.7" y="308.1" width="28" height="75.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="302.1" text-anchor="middle" class="value-accent">390</text>
+<rect x="226.7" y="316.6" width="28" height="67.4" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="310.6" text-anchor="middle" class="value">346</text>
 <text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="296.6" y="308.1" width="28" height="75.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="310.6" y="302.1" text-anchor="middle" class="value-accent">390</text>
-<rect x="329.6" y="316.4" width="28" height="67.6" rx="6" fill="#9aa7b6" />
-<text x="343.6" y="310.4" text-anchor="middle" class="value">347</text>
+<rect x="296.6" y="307.6" width="28" height="76.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="301.6" text-anchor="middle" class="value-accent">392</text>
+<rect x="329.6" y="315.3" width="28" height="68.7" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="309.3" text-anchor="middle" class="value">353</text>
 <text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="399.4" y="210.7" width="28" height="173.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="413.4" y="204.7" text-anchor="middle" class="value-accent">890</text>
-<rect x="432.4" y="244.2" width="28" height="139.8" rx="6" fill="#9aa7b6" />
-<text x="446.4" y="238.2" text-anchor="middle" class="value">718</text>
+<rect x="399.4" y="210.6" width="28" height="173.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="204.6" text-anchor="middle" class="value-accent">891</text>
+<rect x="432.4" y="245.4" width="28" height="138.6" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="239.4" text-anchor="middle" class="value">712</text>
 <text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
@@ -67,28 +67,28 @@
 <text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">100</text>
 <line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
 <text x="537.3333333333333" y="78" class="panel">Load → first search</text>
-<rect x="558.2" y="356.0" width="28" height="28.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="572.2" y="350.0" text-anchor="middle" class="value-accent">9.6</text>
-<rect x="591.2" y="343.3" width="28" height="40.7" rx="6" fill="#9aa7b6" />
-<text x="605.2" y="337.3" text-anchor="middle" class="value">13.9</text>
+<rect x="558.2" y="356.2" width="28" height="27.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="350.2" text-anchor="middle" class="value-accent">9.5</text>
+<rect x="591.2" y="343.4" width="28" height="40.6" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="337.4" text-anchor="middle" class="value">13.9</text>
 <text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="661.1" y="257.7" width="28" height="126.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="675.1" y="251.7" text-anchor="middle" class="value-accent">43</text>
-<rect x="694.1" y="289.9" width="28" height="94.1" rx="6" fill="#9aa7b6" />
-<text x="708.1" y="283.9" text-anchor="middle" class="value">32</text>
+<rect x="661.1" y="336.0" width="28" height="48.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="330.0" text-anchor="middle" class="value-accent">16.4</text>
+<rect x="694.1" y="293.8" width="28" height="90.2" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="287.8" text-anchor="middle" class="value">31</text>
 <text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="763.9" y="335.3" width="28" height="48.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="777.9" y="329.3" text-anchor="middle" class="value-accent">16.7</text>
-<rect x="796.9" y="293.0" width="28" height="91.0" rx="6" fill="#9aa7b6" />
-<text x="810.9" y="287.0" text-anchor="middle" class="value">31</text>
+<rect x="763.9" y="334.7" width="28" height="49.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="328.7" text-anchor="middle" class="value-accent">16.9</text>
+<rect x="796.9" y="289.8" width="28" height="94.2" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="283.8" text-anchor="middle" class="value">32</text>
 <text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="866.7" y="286.1" width="28" height="97.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="880.7" y="280.1" text-anchor="middle" class="value-accent">34</text>
-<rect x="899.7" y="190.1" width="28" height="193.9" rx="6" fill="#9aa7b6" />
-<text x="913.7" y="184.1" text-anchor="middle" class="value">66</text>
+<rect x="866.7" y="287.7" width="28" height="96.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="281.7" text-anchor="middle" class="value-accent">33</text>
+<rect x="899.7" y="189.5" width="28" height="194.5" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="183.5" text-anchor="middle" class="value">67</text>
 <text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
@@ -109,16 +109,16 @@
 <text x="1056.1" y="345.5" text-anchor="middle" class="value-accent">167</text>
 <text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="1144.9" y="297.8" width="28" height="86.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1158.9" y="291.8" text-anchor="middle" class="value-accent">443</text>
+<rect x="1144.9" y="299.6" width="28" height="84.4" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="293.6" text-anchor="middle" class="value-accent">434</text>
 <text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
 <text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
-<rect x="1247.8" y="297.5" width="28" height="86.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1261.8" y="291.5" text-anchor="middle" class="value-accent">444</text>
+<rect x="1247.8" y="297.9" width="28" height="86.1" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="291.9" text-anchor="middle" class="value-accent">442</text>
 <text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
-<rect x="1350.6" y="195.2" width="28" height="188.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
-<text x="1364.6" y="189.2" text-anchor="middle" class="value-accent">970</text>
+<rect x="1350.6" y="195.0" width="28" height="189.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="189.0" text-anchor="middle" class="value-accent">971</text>
 <text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
 <text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
 <text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>

--- a/docs/x86_persist_st.svg
+++ b/docs/x86_persist_st.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="480" viewBox="0 0 1440 480" role="img" aria-label="Persist — x86 (Intel Sapphire Rapids, 8 vCPUs) — Single-threaded">
+  <style>
+  .title { font: 700 20px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .subtitle { font: 400 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .panel { font: 700 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .label { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .secondary { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #475569; }
+  .tick { font: 400 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #64748b; }
+  .value { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+  .value-accent { font: 700 11px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #4338ca; }
+  .axis { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #334155; }
+  .legend { font: 600 12px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #0f172a; }
+</style>
+  <rect width="100%" height="100%" fill="#ffffff" />
+  <text x="70" y="32" class="title">Save / Load — x86 (Intel Sapphire Rapids, 8 vCPUs) — Single-threaded</text>
+  <text x="70" y="52" class="subtitle">100K vectors. Save: full index → .tv file, calibration frozen. Load → first search: open a cold .tv and run the first query. Round-trip: mutate → save → load → search. Median of 5 runs.</text>
+  <line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="70.0" y1="325.6" x2="481.3333333333333" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="329.6" text-anchor="end" class="tick">300</text>
+<line x1="70.0" y1="267.2" x2="481.3333333333333" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="271.2" text-anchor="end" class="tick">600</text>
+<line x1="70.0" y1="208.8" x2="481.3333333333333" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="212.8" text-anchor="end" class="tick">900</text>
+<line x1="70.0" y1="150.4" x2="481.3333333333333" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="154.4" text-anchor="end" class="tick">1200</text>
+<line x1="70.0" y1="92.0" x2="481.3333333333333" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="60.0" y="96.0" text-anchor="end" class="tick">1500</text>
+<line x1="70.0" y1="384.0" x2="481.3333333333333" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="70.0" y="78" class="panel">Save (warm)</text>
+<rect x="90.9" y="356.7" width="28" height="27.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="104.9" y="350.7" text-anchor="middle" class="value-accent">140</text>
+<rect x="123.9" y="361.4" width="28" height="22.6" rx="6" fill="#9aa7b6" />
+<text x="137.9" y="355.4" text-anchor="middle" class="value">116</text>
+<text x="121.4" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="121.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="193.7" y="308.4" width="28" height="75.6" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="207.7" y="302.4" text-anchor="middle" class="value-accent">389</text>
+<rect x="226.7" y="310.5" width="28" height="73.5" rx="6" fill="#9aa7b6" />
+<text x="240.7" y="304.5" text-anchor="middle" class="value">378</text>
+<text x="224.2" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="224.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="296.6" y="308.1" width="28" height="75.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="310.6" y="302.1" text-anchor="middle" class="value-accent">390</text>
+<rect x="329.6" y="316.4" width="28" height="67.6" rx="6" fill="#9aa7b6" />
+<text x="343.6" y="310.4" text-anchor="middle" class="value">347</text>
+<text x="327.1" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="327.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="399.4" y="210.7" width="28" height="173.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="413.4" y="204.7" text-anchor="middle" class="value-accent">890</text>
+<rect x="432.4" y="244.2" width="28" height="139.8" rx="6" fill="#9aa7b6" />
+<text x="446.4" y="238.2" text-anchor="middle" class="value">718</text>
+<text x="429.9" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="429.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="537.3333333333333" y1="325.6" x2="948.6666666666665" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="329.6" text-anchor="end" class="tick">20</text>
+<line x1="537.3333333333333" y1="267.2" x2="948.6666666666665" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="271.2" text-anchor="end" class="tick">40</text>
+<line x1="537.3333333333333" y1="208.8" x2="948.6666666666665" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="212.8" text-anchor="end" class="tick">60</text>
+<line x1="537.3333333333333" y1="150.4" x2="948.6666666666665" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="154.4" text-anchor="end" class="tick">80</text>
+<line x1="537.3333333333333" y1="92.0" x2="948.6666666666665" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="527.3333333333333" y="96.0" text-anchor="end" class="tick">100</text>
+<line x1="537.3333333333333" y1="384.0" x2="948.6666666666665" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="537.3333333333333" y="78" class="panel">Load → first search</text>
+<rect x="558.2" y="356.0" width="28" height="28.0" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="572.2" y="350.0" text-anchor="middle" class="value-accent">9.6</text>
+<rect x="591.2" y="343.3" width="28" height="40.7" rx="6" fill="#9aa7b6" />
+<text x="605.2" y="337.3" text-anchor="middle" class="value">13.9</text>
+<text x="588.7" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="588.7" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="661.1" y="257.7" width="28" height="126.3" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="675.1" y="251.7" text-anchor="middle" class="value-accent">43</text>
+<rect x="694.1" y="289.9" width="28" height="94.1" rx="6" fill="#9aa7b6" />
+<text x="708.1" y="283.9" text-anchor="middle" class="value">32</text>
+<text x="691.6" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="691.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="763.9" y="335.3" width="28" height="48.7" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="777.9" y="329.3" text-anchor="middle" class="value-accent">16.7</text>
+<rect x="796.9" y="293.0" width="28" height="91.0" rx="6" fill="#9aa7b6" />
+<text x="810.9" y="287.0" text-anchor="middle" class="value">31</text>
+<text x="794.4" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="794.4" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="866.7" y="286.1" width="28" height="97.9" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="880.7" y="280.1" text-anchor="middle" class="value-accent">34</text>
+<rect x="899.7" y="190.1" width="28" height="193.9" rx="6" fill="#9aa7b6" />
+<text x="913.7" y="184.1" text-anchor="middle" class="value">66</text>
+<text x="897.2" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="897.2" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="388.0" text-anchor="end" class="tick">0.0</text>
+<line x1="1004.6666666666666" y1="325.6" x2="1416.0" y2="325.6" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="329.6" text-anchor="end" class="tick">300</text>
+<line x1="1004.6666666666666" y1="267.2" x2="1416.0" y2="267.2" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="271.2" text-anchor="end" class="tick">600</text>
+<line x1="1004.6666666666666" y1="208.8" x2="1416.0" y2="208.8" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="212.8" text-anchor="end" class="tick">900</text>
+<line x1="1004.6666666666666" y1="150.4" x2="1416.0" y2="150.4" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="154.4" text-anchor="end" class="tick">1200</text>
+<line x1="1004.6666666666666" y1="92.0" x2="1416.0" y2="92.0" stroke="#e5e7eb" stroke-width="1" />
+<text x="994.6666666666666" y="96.0" text-anchor="end" class="tick">1500</text>
+<line x1="1004.6666666666666" y1="384.0" x2="1416.0" y2="384.0" stroke="#94a3b8" stroke-width="1.5" />
+<text x="1004.6666666666666" y="78" class="panel">Round-trip (mutate → save → load → search)</text>
+<rect x="1042.1" y="351.5" width="28" height="32.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1056.1" y="345.5" text-anchor="middle" class="value-accent">167</text>
+<text x="1056.1" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1056.1" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1144.9" y="297.8" width="28" height="86.2" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1158.9" y="291.8" text-anchor="middle" class="value-accent">443</text>
+<text x="1158.9" y="406" text-anchor="middle" class="label">d=1536</text>
+<text x="1158.9" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<rect x="1247.8" y="297.5" width="28" height="86.5" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1261.8" y="291.5" text-anchor="middle" class="value-accent">444</text>
+<text x="1261.8" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1261.8" y="421" text-anchor="middle" class="secondary">2-bit</text>
+<rect x="1350.6" y="195.2" width="28" height="188.8" rx="6" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="1364.6" y="189.2" text-anchor="middle" class="value-accent">970</text>
+<text x="1364.6" y="406" text-anchor="middle" class="label">d=3072</text>
+<text x="1364.6" y="421" text-anchor="middle" class="secondary">4-bit</text>
+<text x="24" y="238.0" transform="rotate(-90, 24, 238.0)" class="axis">milliseconds</text>
+<rect x="70" y="446" width="14" height="14" rx="3" fill="#635bff" stroke="#4338ca" stroke-width="1.5" />
+<text x="92" y="457" class="legend" style="fill: #4338ca;">TurboQuant</text>
+<rect x="210" y="446" width="14" height="14" rx="3" fill="#9aa7b6" />
+<text x="232" y="457" class="legend">FAISS</text>
+<text x="310" y="457" class="secondary">Round-trip is TurboQuant-only — FAISS has no measured mutate→save→load→search equivalent.</text>
+</svg>


### PR DESCRIPTION
Benchmark-results update addressing #279 (x86 insert re-measure) and #280 (persist cells) plus a full ARM re-baseline. **Data + docs only — no library code changed.**

## Provenance

The x86 insert + persist cells were re-measured on a **clean release build at the PR base commit `e89dbc6`** (the same SHA the ARM data was collected at): `rm -rf target` → `maturin develop --release`, then all 16 x86 cells. This clean re-run was done after an earlier build was found to have reused a pre-#277 `.so` (thanks @Q — round-1 review caught it).

## Environment change (prominent)

The published **ARM benchmark environment moved from an Apple M3 Max laptop to a GCP c4a-standard-8 (Google Axion, 8 vCPU) instance** — release build, idle box. Every ARM cell (search, insert, remove, persist) was re-measured there. **x86 cells stay on the same GCP c3-standard-8 (Sapphire Rapids) box.** Figures and README headings are relabeled to `ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)`. Per docs-as-steady-state convention the README describes the current environment; the migration narrative lives here and in the CHANGELOG.

## x86 insert re-measure (#279)

Clean-build re-measure of all 8 `speed_insert_*_x86_*` cells. **The fresh run agreed with the committed numbers within measurement noise across all 8 cells, so the committed bytes were retained** (no rewrite). #277's insert speedup was measured on Cascade Lake and does **not** manifest on the official Sapphire Rapids (c3) box, so Sapphire-Rapids bulk insert is unchanged.

The agreement is consistent with the grid's invariants — in particular ST≈MT single-add (single `add()` is serial, so a cell's ST and MT single-add timings must match): 23.28/23.19, 34.92/34.86, 46.38/46.08, 69.29/69.27 µs across the four dim×bit cells, and bulk MT/ST ≈ 5× (4.70/4.75/4.94/5.10). (A round-2 candidate value for `d3072/4bit/ST` violated both invariants — an artifact of a run where the `RAYON_NUM_THREADS=1` pin didn't take for TurboQuant — and was discarded; the committed value is correct.)

`x86_insert_st.svg` and `x86_insert_mt.svg` are byte-identical to the pre-PR renderings.

## Persist cells (#280)

Added all **16 `speed_persist_*`** cells (arm + x86, ST + MT); the x86 persist cells use the clean-build numbers. Sanity-checked per #280: `tv_file_bytes` scales with dim×bit (38.8 MB … 154 MB), MT genuinely parallel (MT search ~8× ST, MT insert ~6–7× ST), FAISS read/write sizes sane, all filename↔field metadata consistent, `n_vectors=100000`.

`create_diagrams.py` gains `write_persist_panel` → `docs/{arm,x86}_persist_{st,mt}.svg`, a 3-panel save/load figure:
- **Save (warm)** — `tq_write_warm_ms` vs `faiss_write_ms` (precision-matched `IndexPQFastScan`)
- **Load → first search** — `tq_load_first_search_ms` vs `faiss_read_first_search_ms`
- **Round-trip (mutate → save → load → search)** — `tq_mutate_save_load_search_ms`, **TurboQuant-only** (FAISS has no measured equivalent)

**Caveat (round-trip < dirty-write):** on the smaller payloads the round-trip lands *below* the isolated post-mutation ("dirty") write. Those are separate suite steps, and at small file sizes the standalone `fsync` in the dirty-write step dominates and inflates it — a harness measurement artifact, not a repack win in the combined path. Noted in the README.

## ARM re-baseline

All 24 ARM search/insert/remove cells + 8 ARM persist cells re-measured on c4a-standard-8. README search prose updated: ARM TurboQuant-vs-FAISS win is now **16–24%** across every config (was 10–19%). Full ARM search win table: d1536-2bit 23.7%/23.5% (st/mt), d1536-4bit 19.1%/17.5%, d3072-2bit 17.1%/16.3%, d3072-4bit 19.1%/17.2%.

**Caveat (ARM FAISS insert baseline):** on ARM the FAISS `IndexPQFastScan` baseline is the generic aarch64 `faiss-cpu` wheel, so its insert figure partly reflects that wheel's PQ-training path on Axion (the prior ARM environment linked Apple's Accelerate BLAS). This is a build/BLAS difference, not a like-for-like algorithmic gap. Noted in the README.

## Figure regen verification

`python benchmarks/create_diagrams.py` runs clean. Protected pre-existing figures are **byte-identical** (verified via `git diff --quiet`): `x86_speed_{st,mt}`, `x86_remove_st`, `x86_insert_{st,mt}`, `recall_{d1536,d3072,glove}`, `compression`. Changed as intended: `arm_speed_{st,mt}`, `arm_insert_{st,mt}`, `arm_remove_st`, `arm_persist_{st,mt}` (relabel), `x86_persist_{st,mt}` (clean data).

Touched paths: `benchmarks/` + `docs/` + `README.md` + `CHANGELOG.md` only. No library code → no cargo/pytest run.

## Follow-up (not in this PR)

A cheap permanent harness sanity-gate would assert **ST single-add ≈ MT single-add per cell** — the exact invariant the discarded `d3072/4bit/ST` candidate failed. Flagging as a separate suite hardening item, not bundled here.

Closes #279
Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)
