### PR TITLE
Retain blocked cache after cold writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,7 @@ appears under each surface it touches.
   win; ARM keeps the streamed writer, where the same technique regresses).
   Temp files now carry a per-process sequence number so concurrent saves to
   one path cannot interleave.
+- **Faster saves.** New indexes retain blocked cache (#323), thanks @faysou
 - **File format v6 for `.tv` / `.tvim`: the file *is* the search-ready
   index — loads skip the first-search rebuild entirely (#68).** The code
   payload is now stored in the arch-neutral *sequential blocked* layout

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1646,10 +1646,10 @@ impl TurboQuantIndex {
     }
 
     /// The v6 file payload: codes in the arch-neutral sequential blocked
-    /// layout. Cheap when the SIMD-blocked cache is warm (a per-block
-    /// nibble de-interleave on x86, a copy elsewhere); otherwise the full
-    /// O(n·dim) bit-plane repack — the same cost the pre-v6 format paid
-    /// on every load instead of once per write.
+    /// layout. The first cold write retains the native blocked cache so
+    /// later mutations can repair only their affected blocks. Producing
+    /// sequential bytes is a per-block nibble de-interleave on x86 and a
+    /// copy elsewhere.
     pub fn codes_blocked_seq(&self) -> Vec<u8> {
         let Some(dim) = self.dim else {
             return Vec::new();
@@ -1657,10 +1657,11 @@ impl TurboQuantIndex {
         if self.n_vectors == 0 {
             return Vec::new();
         }
-        if let Some(cache) = self.blocked.get() {
-            return pack::native_to_seq(&cache.data);
-        }
-        pack::repack_seq(self.packed(), self.n_vectors, self.bit_width, dim)
+        let cache = self.blocked.get_or_init(|| {
+            let (data, n_blocks) = pack::repack(self.packed(), self.n_vectors, self.bit_width, dim);
+            BlockedCache { data, n_blocks }
+        });
+        pack::native_to_seq(&cache.data)
     }
 
     /// The codebook arrays the v6 file embeds — `(boundaries,
@@ -2595,6 +2596,39 @@ mod scratch_retention_tests {
             0,
             "a buffer no recent add needed was not released",
         );
+    }
+}
+
+#[cfg(test)]
+mod blocked_cache_tests {
+    use super::{pack, TurboQuantIndex};
+
+    fn vectors(n: usize, dim: usize) -> Vec<f32> {
+        let mut state = 1u64;
+        (0..n * dim)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                ((state >> 32) as u32 as f64 / 2_147_483_648.0 - 1.0) as f32
+            })
+            .collect()
+    }
+
+    #[test]
+    fn cold_write_seeds_blocked_cache() {
+        let mut idx = TurboQuantIndex::new(64, 4).unwrap();
+        idx.add(&vectors(65, 64));
+        assert!(idx.blocked.get().is_none());
+
+        let first = idx.to_bytes();
+        let cache = idx.blocked.get().expect("write must retain blocked cache");
+        let dim = idx.dim.expect("constructor sets dim");
+        let (expected, n_blocks) =
+            pack::repack(idx.packed(), idx.n_vectors, idx.bit_width, dim);
+        assert_eq!(cache.data, expected);
+        assert_eq!(cache.n_blocks, n_blocks);
+        assert_eq!(idx.to_bytes(), first);
     }
 }
 

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -294,7 +294,6 @@ fn extract_codes_flat(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: u
 /// arch-neutral form the v6 file format persists: vectors in order inside
 /// each 32-vector block, one code byte per lane. On non-x86 this is also
 /// the layout the search kernel consumes.
-#[cfg(test)]
 fn pack_blocked_sequential(
     n: usize,
     n_blocks: usize,

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -294,6 +294,7 @@ fn extract_codes_flat(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: u
 /// arch-neutral form the v6 file format persists: vectors in order inside
 /// each 32-vector block, one code byte per lane. On non-x86 this is also
 /// the layout the search kernel consumes.
+#[cfg_attr(target_arch = "x86_64", allow(dead_code))]
 fn pack_blocked_sequential(
     n: usize,
     n_blocks: usize,

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -294,6 +294,7 @@ fn extract_codes_flat(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: u
 /// arch-neutral form the v6 file format persists: vectors in order inside
 /// each 32-vector block, one code byte per lane. On non-x86 this is also
 /// the layout the search kernel consumes.
+#[cfg(test)]
 fn pack_blocked_sequential(
     n: usize,
     n_blocks: usize,
@@ -320,6 +321,7 @@ fn pack_blocked_sequential(
 /// Packed bit-plane rows → sequential blocked layout (the v6 file
 /// payload). Arch-independent and deterministic: identical bytes on every
 /// platform for the same packed codes.
+#[cfg(test)]
 pub(crate) fn repack_seq(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: usize) -> Vec<u8> {
     let (n_blocks, n_byte_groups, blocked_size) = blocked_geometry(n_vectors, bits, dim);
     let codes_flat = extract_codes_flat(packed_codes, n_vectors, bits, dim);


### PR DESCRIPTION
### Scope

- Base reviewed: `RyanCodrai/turbovec:main` at `cdb5c165a9513986c3f57ba079cdc08954b12e20`.
- Branch head: `84a66d1516195d6dbf35788bab5526e5f6e68438`.
- Retains only the cold‑write cache behavior that remains unique on current upstream.
- Preserves upstream's LUT‑based packed‑to‑blocked conversion, fused warm writes,
  incremental appends, and lane‑level removals.
- Keeps the v6 `.tv` and `.tvim` layouts unchanged.
- Keeps `.tvim` as the only authoritative ID‑mapped index artifact.
- Preserves complete sibling‑temporary‑file replacement, flush, `fsync`, and atomic rename.
- Does not reduce the number of bytes written by a successful path write.

### Summary

`TurboQuantIndex::codes_blocked_seq` now builds the native blocked cache through
`OnceLock::get_or_init` on its first cold call, then converts that retained cache to the
sequential v6 payload. Before this change, a cold call built only the sequential payload
and discarded the conversion result.

Retaining the native cache lets later writes use upstream's fused writer. It also lets
later appends and removals update the existing cache through upstream's incremental
mutation paths.

No sidecar, persistent cache, journal, manifest, or write‑ahead log is added. The v6
file remains portable and architecture‑neutral.

### Rebase decision

Current upstream already supplies the LUT repacker, fused warm‑cache writes,
incremental append, and lane‑level removal paths. Replaying the original broader
converter would replace those newer paths with obsolete code. The rebased branch
therefore keeps only behavior that remains unique:

- Seed `BlockedCache` during the first cold `codes_blocked_seq` call.
- Reuse that cache for later writes and incremental mutations.
- Keep the sequential reference repacker test‑only.
- Keep `pack_blocked_sequential` available for ARM production and x86 mutation tests.
- Assert that the retained cache matches a fresh rebuild and does not change bytes.

The final branch is three commits above current `main`: the rebased feature commit, an
ARM compatibility correction, and the CI validation correction.

### Cache and write flow

```mermaid
flowchart TD
    Cold["Cold packed index"] --> Payload["codes_blocked_seq"]
    Payload --> Build["Upstream pack::repack builds native cache"]
    Build --> Retain["Retain BlockedCache in OnceLock"]
    Retain --> Sequential["Convert native cache to sequential v6 bytes"]
    Sequential --> Temp["Existing writer writes and fsyncs sibling temporary file"]
    Temp --> Replace["Atomically replace authoritative file"]
    Retain --> Later{"Later operation"}
    Later --> Write["Path write borrows cache for upstream fused write"]
    Later --> Add["Append updates cache through upstream lane writes"]
    Later --> Remove["Removal updates cache through upstream lane moves"]
```

### Compatibility and durability

- Writers still emit v6 bytes, and v5 inputs still rewrite as v6.
- Cold and warm writes produce byte‑identical v6 payloads.
- Search, ID mapping, append, removal, and reload behavior remain unchanged.
- ARM production builds retain `pack_blocked_sequential`; only the unused sequential
  reference repacker is restricted to tests.
- Path writers still write the complete payload to a sibling temporary file, flush it,
  call `sync_all`, and rename it over the destination.
- A failed atomic write preserves the previous destination and removes the temporary
  file on a best‑effort basis.
- In‑memory writers remain sidecar‑free and byte‑identical to path writers.

This PR does not modify `io.rs` or the existing durability protocol.

### Performance

The focused benchmark used an Apple M5 Pro with `RAYON_NUM_THREADS=4`, dimension 1536,
4‑bit codes, 20,000 initial vectors, four 500‑vector append/write rounds, and three
repetitions. The table reports medians.

| Measurement                    | Upstream `main` | Feature branch | Change       |
| ------------------------------ | --------------- | -------------- | ------------ |
| First cold write               | 31.54 ms        | 33.79 ms       | 7.1% slower  |
| Later incremental write        | 31.23 ms        | 14.03 ms       | 55.1% faster |
| Five writes combined           | 157.10 ms       | 90.74 ms       | 42.2% faster |

The first write does not improve because it must build and retain the native cache.
The benefit begins when the same new in‑memory index is mutated and written again.

The tradeoff is retained memory approximately equal to the quantized blocked payload.
For 184,000 vectors at dimension 1536 and 4 bits, that is about 134.8 MiB before
allocator overhead. Existing loaded indexes already populate the blocked cache, so the
feature primarily helps repeated writes of newly created indexes.

### Relevant files

- [`turbovec/src/lib.rs`](https://github.com/faysou/turbovec/blob/v6-incremental-persistence/turbovec/src/lib.rs):
  cold cache seeding and byte‑stable serialization.
- [`turbovec/src/pack.rs`](https://github.com/faysou/turbovec/blob/v6-incremental-persistence/turbovec/src/pack.rs):
  test‑only reference repacking and the ARM production packing path.
- [`CHANGELOG.md`](https://github.com/faysou/turbovec/blob/v6-incremental-persistence/CHANGELOG.md):
  user‑visible repeated‑save performance entry.

### Verification

- `CARGO_BUILD_JOBS=4 cargo test -p turbovec
  blocked_cache_tests::cold_write_seeds_blocked_cache`: passed.
- `CARGO_BUILD_JOBS=4 cargo test -p turbovec --lib pack::tests::`: passed.
- `CARGO_BUILD_JOBS=4 cargo test -p turbovec --test io_v6`: passed.
- Rust 1.97.0 Clippy with the CI allow‑list for the native workspace: passed.
- Rust 1.97.0 Clippy for `x86_64-unknown-linux-gnu`: passed.
- Rust 1.97.0 Clippy for `aarch64-unknown-linux-gnu`: passed.
- `.github/scripts/changelog_gate.py --base main --head HEAD`: passed.
- Focused repeated‑write benchmark: completed for upstream and feature builds.
- `git merge-base --is-ancestor cdb5c16 HEAD`: passed.
- `git rev-list --left-right --count main...HEAD`: `0 3`.
- `git diff --check main...HEAD`: passed.
- Conflict‑marker scan: passed.
- `markdownlint-cli2`: passed.
- `mermaid-lint --strict`: passed.

No full test suite or pre‑commit run was requested.
