### PR TITLE
Harden the atomic-save temp-file protocol (Rust + Python)

### DIFF
--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -22,15 +22,25 @@ the same clean ``ValueError`` at load time.
 """
 from __future__ import annotations
 
+import itertools
 import json
 import os
+import secrets
 from typing import Any, Iterable
+
+# Mirrors the Rust writer's TMP_SEQ (turbovec/src/io.rs): a pid suffix
+# alone collides when two store objects in one process save to the same
+# directory — they interleave writes into one temp file and each
+# ``finally`` unlinks the other's in-flight temp (#316). ``count().
+# __next__`` is atomic under the GIL/free-threading lock.
+_TMP_SEQ = itertools.count()
 
 
 def _tmp_path(path: str) -> str:
-    """Pid-suffixed sibling temp-file name in the same directory as
-    ``path``."""
-    return f"{path}.tmp.{os.getpid()}"
+    """Sibling temp-file name ``<path>.tmp.{pid}.{seq}.{rand}`` in the
+    same directory as ``path`` — unique per save, even across concurrent
+    saves from one process."""
+    return f"{path}.tmp.{os.getpid()}.{next(_TMP_SEQ)}.{secrets.token_hex(4)}"
 
 
 def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
@@ -76,7 +86,9 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
         index.write(index_tmp)
         with open(index_tmp, "rb+") as f:
             os.fsync(f.fileno())
-        with open(sidecar_tmp, "w") as f:
+        # "x" (O_CREAT|O_EXCL) refuses a pre-existing file or planted
+        # symlink at the temp name instead of writing through it.
+        with open(sidecar_tmp, "x") as f:
             f.write(payload_str)
             f.flush()
             os.fsync(f.fileno())

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -29,3 +29,58 @@ def test_check_sidecar_keysets_mixed_type_ids_raise_value_error():
             mapping_name="node_id_to_u64",
             sidecar_name="nodes",
         )
+
+
+def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
+    # #316: two store objects saving to the same directory from one
+    # process used to derive identical `.tmp.{pid}` temp names — they
+    # interleaved writes into one temp file, os.replace'd each other's
+    # partial output, and each `finally` unlinked the other's in-flight
+    # temp (FileNotFoundError escaping the save, or a permanently
+    # mismatched index/side-car pair on disk).
+    import json
+    import threading
+
+    import numpy as np
+
+    from turbovec import IdMapIndex
+    from turbovec._persist import atomic_save
+
+    def make_index(n, seed):
+        rng = np.random.default_rng(seed)
+        v = rng.standard_normal((n, 32)).astype(np.float32)
+        v /= np.linalg.norm(v, axis=1, keepdims=True) + 1e-9
+        idx = IdMapIndex(dim=32, bit_width=4)
+        idx.add_with_ids(v, np.arange(n, dtype=np.uint64))
+        return idx
+
+    stores = [(make_index(5, 0), list(range(5))), (make_index(300, 1), list(range(300)))]
+    index_path = tmp_path / "index.tvim"
+    sidecar_path = tmp_path / "docstore.json"
+    errors = []
+    barrier = threading.Barrier(len(stores))
+
+    def save_loop(index, payload):
+        try:
+            barrier.wait()
+            for _ in range(25):
+                atomic_save(index, index_path, payload, sidecar_path)
+        except Exception as e:  # noqa: BLE001 — recorded for the assert
+            errors.append(e)
+
+    threads = [threading.Thread(target=save_loop, args=s) for s in stores]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"concurrent saves raised: {errors!r}"
+    # Each artifact must individually be a complete write from one of
+    # the two stores — never interleaved bytes.
+    loaded = IdMapIndex.load(str(index_path))
+    assert len(loaded) in (5, 300)
+    payload = json.loads(sidecar_path.read_text())
+    assert payload in (stores[0][1], stores[1][1])
+    # No temp strays.
+    strays = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
+    assert strays == []

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -704,6 +704,21 @@ fn claim_first_sweep(path: &Path) -> bool {
 /// Every error is ignored: sweeping is opportunistic and must never
 /// fail a save.
 fn sweep_stale_tmps(path: &Path) {
+    // A destination that is itself one of our temp names means someone
+    // is staging through us — `_persist.atomic_save` writes the index to
+    // a fresh `<dest>.tmp.…` name on every save, so all four Python
+    // integrations land here. Such a destination is unique per save: it
+    // can have no leaked siblings of its own, the memo below would never
+    // hit, and the scan would run on every save. Skip it; the outer
+    // destination gets swept when something writes to it directly.
+    if path
+        .file_name()
+        .and_then(std::ffi::OsStr::to_str)
+        .and_then(|n| n.rsplit_once(".tmp."))
+        .is_some_and(|(_, suffix)| is_our_tmp_suffix(suffix))
+    {
+        return;
+    }
     if !claim_first_sweep(path) {
         return;
     }
@@ -1593,6 +1608,27 @@ mod tmp_protocol_tests {
         let (f2, tmp2) = create_tmp(&dest).unwrap();
         drop(f2);
         assert_ne!(tmp, tmp2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sweep_skips_destinations_that_are_themselves_temps() {
+        // `_persist.atomic_save` writes the index to a fresh
+        // `<dest>.tmp.{pid}.{seq}.{hex}` name on every save, so the
+        // destination is unique per save and can have no leaked
+        // siblings: sweeping it would scan the directory every time and
+        // never dedup.
+        let dir = test_dir("sweep_nested");
+        let staged = dir.join(format!("index.tvim.tmp.{}.0.deadbeef", std::process::id()));
+        sweep_stale_tmps(&staged);
+        assert!(
+            claim_first_sweep(&staged),
+            "a staged temp destination must not be memoized — it was never swept"
+        );
+        // A real destination is still swept.
+        let real = dir.join("index.tvim");
+        sweep_stale_tmps(&real);
+        assert!(!claim_first_sweep(&real), "a real destination is swept and memoized");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -668,16 +668,45 @@ fn is_our_tmp_suffix(s: &str) -> bool {
     }
 }
 
+/// Destinations already swept by this process, so a repeated save to
+/// the same path pays the directory scan once rather than every time.
+/// The leak this reclaims is per-*process* (a writer killed before its
+/// rename), so a crash-looping writer still sweeps on each restart.
+static SWEPT: std::sync::Mutex<Option<std::collections::HashSet<PathBuf>>> =
+    std::sync::Mutex::new(None);
+
+/// True the first time this process is asked about `path`.
+fn claim_first_sweep(path: &Path) -> bool {
+    let Ok(mut guard) = SWEPT.lock() else {
+        return false;
+    };
+    let seen = guard.get_or_insert_with(std::collections::HashSet::new);
+    // A process writing an unbounded number of distinct destinations
+    // must not accumulate them forever; past the cap, fall back to
+    // sweeping every time (correct, just not deduplicated).
+    if seen.len() >= 4096 {
+        return true;
+    }
+    seen.insert(path.to_path_buf())
+}
+
 /// Best-effort reclaim of temp files leaked by a killed writer (#299):
 /// SIGKILL between temp creation and rename leaves a full-size
 /// `<dest>.tmp.*` sibling that nothing else ever deletes, so a
-/// crash-looping writer fills the volume. Swept at the next save to the
-/// same destination. Only names matching this module's exact pattern
-/// for this destination are candidates, and only when their mtime is
-/// over an hour old — a save takes seconds, so a live writer's
-/// in-flight temp is never touched. Every error is ignored: sweeping is
-/// opportunistic and must never fail a save.
+/// crash-looping writer fills the volume. Swept on this process's first
+/// save to a given destination — the scan is `O(entries in the parent
+/// directory)`, which measurably slows saves into a crowded directory
+/// if repeated (+38% at 20k siblings), and nothing new can leak at that
+/// destination while this process is the one writing it. Only names
+/// matching this module's exact pattern for this destination are
+/// candidates, and only when their mtime is over an hour old — a save
+/// takes seconds, so a live writer's in-flight temp is never touched.
+/// Every error is ignored: sweeping is opportunistic and must never
+/// fail a save.
 fn sweep_stale_tmps(path: &Path) {
+    if !claim_first_sweep(path) {
+        return;
+    }
     const STALE_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
     let Some(base) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
         return;
@@ -1564,6 +1593,18 @@ mod tmp_protocol_tests {
         let (f2, tmp2) = create_tmp(&dest).unwrap();
         drop(f2);
         assert_ne!(tmp, tmp2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sweep_runs_once_per_destination_per_process() {
+        // The scan is O(entries in the parent dir); repeated saves to
+        // one destination must not pay it more than once.
+        let dir = test_dir("sweep_once");
+        let dest = dir.join("index.tv");
+        assert!(claim_first_sweep(&dest), "first save sweeps");
+        assert!(!claim_first_sweep(&dest), "later saves skip the scan");
+        assert!(claim_first_sweep(&dir.join("other.tv")), "a new destination sweeps");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -9,6 +9,21 @@
 //! Both pairs produce and accept exactly the same bytes and apply
 //! exactly the same validation.
 //!
+//! ## Atomic-write protocol
+//!
+//! Path-based writes go to a sibling temp file named
+//! `<dest>.tmp.{pid}.{seq}.{rand}` — pid plus a process-wide counter
+//! plus a random component — opened with `O_CREAT|O_EXCL`, so a
+//! pre-existing file or planted symlink at the temp name is refused
+//! rather than followed, then atomically renamed over the destination.
+//! A write killed between temp creation and rename (SIGKILL, power
+//! loss) can leave the temp behind; the next save to the same
+//! destination sweeps siblings matching this exact pattern whose mtime
+//! is over an hour old. Note that if the destination itself is a
+//! symlink, the rename replaces the *link* with a regular file (the
+//! link's target is left untouched) — standard atomic-replace
+//! semantics.
+//!
 //! Two formats live here:
 //! * `.tv` — [`TurboQuantIndex`](crate::TurboQuantIndex) — 4-byte magic
 //!   "TVPI" + version + bit_width/dim/n_vectors header + packed codes +
@@ -182,13 +197,20 @@ pub fn write_with_durability(
         });
     }
     #[cfg(not(target_arch = "x86_64"))]
-    write_atomic(path.as_ref(), durability, |f| {
-        write_to(
-            f, bit_width, dim, n_vectors, codes_blocked_seq,
-            codebook_boundaries, codebook_centroids, scales,
-            tqplus_shift, tqplus_scale,
-        )
-    })
+    {
+        // On x86 the head closure carries these asserts and runs before
+        // the temp file exists; mirror that ordering here so a
+        // violation cannot leak a temp (a panic unwinds past the
+        // error-path cleanup) (#313).
+        assert_codebook_lengths(bit_width, codebook_boundaries, codebook_centroids);
+        write_atomic(path.as_ref(), durability, |f| {
+            write_to(
+                f, bit_width, dim, n_vectors, codes_blocked_seq,
+                codebook_boundaries, codebook_centroids, scales,
+                tqplus_shift, tqplus_scale,
+            )
+        })
+    }
 }
 
 /// `.tv` write to any [`Write`] sink — the in-memory counterpart of
@@ -364,13 +386,17 @@ pub fn write_id_map_with_durability(
         });
     }
     #[cfg(not(target_arch = "x86_64"))]
-    write_atomic(path.as_ref(), durability, |f| {
-        write_id_map_to(
-            f, bit_width, dim, n_vectors, codes_blocked_seq,
-            codebook_boundaries, codebook_centroids, scales,
-            tqplus_shift, tqplus_scale, slot_to_id,
-        )
-    })
+    {
+        // See `write_with_durability` — validate before the temp exists.
+        assert_codebook_lengths(bit_width, codebook_boundaries, codebook_centroids);
+        write_atomic(path.as_ref(), durability, |f| {
+            write_id_map_to(
+                f, bit_width, dim, n_vectors, codes_blocked_seq,
+                codebook_boundaries, codebook_centroids, scales,
+                tqplus_shift, tqplus_scale, slot_to_id,
+            )
+        })
+    }
 }
 
 /// `.tvim` write to any [`Write`] sink — the in-memory counterpart of
@@ -507,23 +533,187 @@ fn assert_tqplus_calibration(dim: usize, tqplus_shift: &[f32], tqplus_scale: &[f
     );
 }
 
+/// Codebook length invariant shared by [`write`] and [`write_id_map`].
+/// Like [`assert_tqplus_calibration`], must run before any file is
+/// created — a panic after temp creation would leak the temp (#313).
+fn assert_codebook_lengths(bit_width: usize, boundaries: &[f32], centroids: &[f32]) {
+    let n_levels = 1usize << bit_width;
+    assert_eq!(boundaries.len(), n_levels - 1, "codebook boundaries length");
+    assert_eq!(centroids.len(), n_levels, "codebook centroids length");
+}
+
 /// Process-wide counter distinguishing concurrent saves to the same
 /// path from one process: `.tmp.{pid}` alone would interleave two
 /// threads' writes into one temp file and rename the corruption into
 /// place, defeating the torn-index guarantee.
 static TMP_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-fn tmp_sibling(path: &Path) -> PathBuf {
-    let mut name = path
+/// Filename byte budget for the temp sibling: NAME_MAX is 255 bytes on
+/// every filesystem we target (ext4, APFS, NTFS component limit).
+const TMP_NAME_MAX: usize = 255;
+
+/// A fresh unpredictable value for the temp-name suffix. `RandomState`
+/// is seeded from OS entropy; folding in the current time varies the
+/// value per call. (Unpredictability is defense in depth — `O_EXCL` in
+/// [`create_tmp`] is what actually defeats a planted symlink; the
+/// randomness keeps collisions with a crash-leaked temp from a reused
+/// pid from turning into save failures.)
+fn tmp_rand() -> u32 {
+    use std::hash::{BuildHasher, Hasher};
+    let mut h = std::collections::hash_map::RandomState::new().build_hasher();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    h.write_u64(now);
+    h.finish() as u32
+}
+
+/// Sibling temp name `<dest>.tmp.{pid}.{seq}.{rand:08x}` in the same
+/// directory as `path`. If the destination's own filename would push
+/// the sibling past NAME_MAX, the base portion is truncated to fit —
+/// the temp name only has to be unique and recognizable, not complete
+/// (#299).
+fn tmp_sibling(path: &Path, rand: u32) -> PathBuf {
+    let suffix = format!(
+        ".tmp.{}.{}.{:08x}",
+        std::process::id(),
+        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        rand,
+    );
+    let base = path
         .file_name()
         .map(std::ffi::OsStr::to_os_string)
         .unwrap_or_default();
-    name.push(format!(
-        ".tmp.{}.{}",
-        std::process::id(),
-        TMP_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-    ));
-    path.with_file_name(name)
+    if base.len() + suffix.len() <= TMP_NAME_MAX {
+        let mut name = base;
+        name.push(suffix);
+        return path.with_file_name(name);
+    }
+    // Truncation goes through a lossy UTF-8 view so the cut lands on a
+    // char boundary; a mangled non-UTF-8 byte in a *temp* name is
+    // harmless (the destination name is untouched).
+    let s = base.to_string_lossy();
+    let mut cut = (TMP_NAME_MAX - suffix.len()).min(s.len());
+    while !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    path.with_file_name(format!("{}{}", &s[..cut], suffix))
+}
+
+/// Open a fresh sibling temp file with `create_new` (`O_CREAT|O_EXCL`):
+/// refuses any existing file *and never follows a symlink*, so a
+/// pre-planted `<dest>.tmp.*` symlink cannot redirect the write outside
+/// the destination directory (#293). A collision — possible only via a
+/// crash-leaked temp from a reused pid, since the name embeds pid, a
+/// process-wide counter, and a random component — retries with a fresh
+/// name a few times rather than failing the save.
+fn create_tmp(path: &Path) -> io::Result<(File, PathBuf)> {
+    let mut last_err = None;
+    for _ in 0..8 {
+        let tmp = tmp_sibling(path, tmp_rand());
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&tmp)
+        {
+            Ok(f) => return Ok((f, tmp)),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => last_err = Some(e),
+            Err(e) => return Err(e),
+        }
+    }
+    Err(last_err.expect("retry loop ran"))
+}
+
+/// Atomically rename `tmp` over `path`. On Windows, `MoveFileExW` fails
+/// with ERROR_SHARING_VIOLATION (os error 32) while any other handle to
+/// the destination lacks FILE_SHARE_DELETE — CPython's `open()` and
+/// antivirus/indexer scans both qualify — so retry briefly with backoff,
+/// the same posture cargo, rustup, and git take (#313).
+fn rename_atomic(tmp: &Path, path: &Path) -> io::Result<()> {
+    #[cfg(windows)]
+    {
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        let mut delay_ms = 1u64;
+        for _ in 0..10 {
+            match std::fs::rename(tmp, path) {
+                Err(e) if e.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
+                    std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+                    delay_ms = (delay_ms * 2).min(64);
+                }
+                r => return r,
+            }
+        }
+    }
+    std::fs::rename(tmp, path)
+}
+
+/// True when `s` is the part after `<dest>.tmp.` of a name this module
+/// generates: `{pid}.{seq}` (pre-0.10.1 writers) or `{pid}.{seq}.{hex8}`.
+fn is_our_tmp_suffix(s: &str) -> bool {
+    let mut parts = s.split('.');
+    let (Some(pid), Some(seq)) = (parts.next(), parts.next()) else {
+        return false;
+    };
+    if pid.is_empty() || seq.is_empty() {
+        return false;
+    }
+    if !pid.bytes().all(|b| b.is_ascii_digit()) || !seq.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+    match (parts.next(), parts.next()) {
+        (None, _) => true,
+        (Some(rand), None) => rand.len() == 8 && rand.bytes().all(|b| b.is_ascii_hexdigit()),
+        _ => false,
+    }
+}
+
+/// Best-effort reclaim of temp files leaked by a killed writer (#299):
+/// SIGKILL between temp creation and rename leaves a full-size
+/// `<dest>.tmp.*` sibling that nothing else ever deletes, so a
+/// crash-looping writer fills the volume. Swept at the next save to the
+/// same destination. Only names matching this module's exact pattern
+/// for this destination are candidates, and only when their mtime is
+/// over an hour old — a save takes seconds, so a live writer's
+/// in-flight temp is never touched. Every error is ignored: sweeping is
+/// opportunistic and must never fail a save.
+fn sweep_stale_tmps(path: &Path) {
+    const STALE_AGE: std::time::Duration = std::time::Duration::from_secs(60 * 60);
+    let Some(base) = path.file_name().and_then(std::ffi::OsStr::to_str) else {
+        return;
+    };
+    let parent = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p,
+        _ => Path::new("."),
+    };
+    let Ok(entries) = std::fs::read_dir(parent) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Some(suffix) = name
+            .strip_prefix(base)
+            .and_then(|s| s.strip_prefix(".tmp."))
+        else {
+            continue;
+        };
+        if !is_our_tmp_suffix(suffix) {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        if !meta.is_file() {
+            continue;
+        }
+        let stale = meta.modified().is_ok_and(|m| {
+            std::time::SystemTime::now()
+                .duration_since(m)
+                .is_ok_and(|age| age > STALE_AGE)
+        });
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
 }
 
 /// In `Durable` mode, fsync the parent directory after the rename so the
@@ -561,9 +751,7 @@ fn head_core(
     codebook_boundaries: &[f32],
     codebook_centroids: &[f32],
 ) -> io::Result<()> {
-    let n_levels = 1usize << bit_width;
-    assert_eq!(codebook_boundaries.len(), n_levels - 1, "codebook boundaries length");
-    assert_eq!(codebook_centroids.len(), n_levels, "codebook centroids length");
+    assert_codebook_lengths(bit_width, codebook_boundaries, codebook_centroids);
     head.push(bit_width as u8);
     head.extend_from_slice(&(dim as u32).to_le_bytes());
     head.extend_from_slice(&(n_vectors as u64).to_le_bytes());
@@ -615,9 +803,9 @@ fn write_atomic_parallel(
     let mut tail = Vec::new();
     tail_fn(&mut tail)?;
 
-    let tmp: PathBuf = tmp_sibling(path);
+    sweep_stale_tmps(path);
+    let (f, tmp) = create_tmp(path)?;
     let result = (|| {
-        let f = File::create(&tmp)?;
         const PAR_MIN: usize = 8 * 1024 * 1024;
         let n_threads = std::thread::available_parallelism().map(|n| n.get()).unwrap_or(1).min(4);
         if codes.len() < PAR_MIN || n_threads < 2 {
@@ -666,7 +854,8 @@ fn write_atomic_parallel(
         if durability == Durability::Durable {
             f.sync_all()?;
         }
-        std::fs::rename(&tmp, path)?;
+        drop(f);
+        rename_atomic(&tmp, path)?;
         if durability == Durability::Durable {
             sync_parent_dir(path)?;
         }
@@ -708,9 +897,9 @@ fn write_atomic(
     durability: Durability,
     write_payload: impl FnOnce(&mut BufWriter<&File>) -> io::Result<()>,
 ) -> io::Result<()> {
-    let tmp: PathBuf = tmp_sibling(path);
+    sweep_stale_tmps(path);
+    let (f, tmp) = create_tmp(path)?;
     let result = (|| {
-        let f = File::create(&tmp)?;
         let mut w = BufWriter::new(&f);
         write_payload(&mut w)?;
         w.flush()?;
@@ -718,7 +907,8 @@ fn write_atomic(
         if durability == Durability::Durable {
             f.sync_all()?;
         }
-        std::fs::rename(&tmp, path)?;
+        drop(f);
+        rename_atomic(&tmp, path)?;
         if durability == Durability::Durable {
             sync_parent_dir(path)?;
         }
@@ -748,9 +938,7 @@ fn write_core<W: Write>(
     tqplus_shift: &[f32],
     tqplus_scale: &[f32],
 ) -> io::Result<()> {
-    let n_levels = 1usize << bit_width;
-    assert_eq!(codebook_boundaries.len(), n_levels - 1, "codebook boundaries length");
-    assert_eq!(codebook_centroids.len(), n_levels, "codebook centroids length");
+    assert_codebook_lengths(bit_width, codebook_boundaries, codebook_centroids);
     w.write_all(&[bit_width as u8])?;
     w.write_all(&(dim as u32).to_le_bytes())?;
     w.write_all(&(n_vectors as u64).to_le_bytes())?;
@@ -1292,6 +1480,124 @@ fn read_exact_vec_capped<R: Read>(r: &mut R, n: usize, alloc_cap: u64) -> io::Re
         ));
     }
     Ok(buf)
+}
+
+#[cfg(test)]
+mod tmp_protocol_tests {
+    use super::*;
+
+    fn test_dir(name: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("turbovec_io_{}_{}", name, std::process::id()));
+        let _ = std::fs::remove_dir_all(&d);
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn tmp_sibling_names_are_unique_and_recognizable() {
+        let p = Path::new("/some/dir/index.tv");
+        let a = tmp_sibling(p, 0xdeadbeef);
+        let b = tmp_sibling(p, 0xdeadbeef);
+        assert_ne!(a, b, "process-wide counter must distinguish same-rand names");
+        let name = a.file_name().unwrap().to_str().unwrap();
+        assert!(name.starts_with("index.tv.tmp."));
+        assert!(is_our_tmp_suffix(name.strip_prefix("index.tv.tmp.").unwrap()));
+    }
+
+    #[test]
+    fn tmp_sibling_truncates_to_name_max() {
+        // 250-char base + ~30-char suffix would exceed NAME_MAX (255).
+        let long = "x".repeat(250);
+        let p = std::env::temp_dir().join(&long);
+        let tmp = tmp_sibling(&p, 1);
+        let name = tmp.file_name().unwrap().to_str().unwrap();
+        assert!(name.len() <= TMP_NAME_MAX, "temp name {} bytes", name.len());
+        assert!(name.starts_with("xxx"));
+        assert!(name.contains(".tmp."));
+        // Short names are passed through untruncated.
+        let short = tmp_sibling(Path::new("a.tv"), 1);
+        assert!(short.file_name().unwrap().to_str().unwrap().starts_with("a.tv.tmp."));
+    }
+
+    #[test]
+    fn is_our_tmp_suffix_matches_only_our_pattern() {
+        assert!(is_our_tmp_suffix("1234.0"));
+        assert!(is_our_tmp_suffix("1234.7.deadbeef"));
+        assert!(!is_our_tmp_suffix("1234"));
+        assert!(!is_our_tmp_suffix("1234.x"));
+        assert!(!is_our_tmp_suffix("1234.7.deadbee")); // 7 hex chars
+        assert!(!is_our_tmp_suffix("1234.7.deadbeef.9"));
+        assert!(!is_our_tmp_suffix("abc.0"));
+        assert!(!is_our_tmp_suffix(""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_new_refuses_planted_symlink() {
+        // The O_EXCL property #293 relies on: an open through
+        // `create_new` must refuse a symlink at the temp name instead
+        // of following it and overwriting the victim.
+        let dir = test_dir("symlink_excl");
+        let victim = dir.join("victim.txt");
+        std::fs::write(&victim, b"precious").unwrap();
+        let planted = dir.join("index.tv.tmp.999.0.00000000");
+        std::os::unix::fs::symlink(&victim, &planted).unwrap();
+        let err = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&planted)
+            .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(std::fs::read(&victim).unwrap(), b"precious");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn create_tmp_skips_colliding_names() {
+        // create_tmp must survive an existing file at a candidate name
+        // by retrying with a fresh one, not fail the save.
+        let dir = test_dir("create_tmp");
+        let dest = dir.join("index.tv");
+        let (f, tmp) = create_tmp(&dest).unwrap();
+        drop(f);
+        // A second call never reuses the live temp's name.
+        let (f2, tmp2) = create_tmp(&dest).unwrap();
+        drop(f2);
+        assert_ne!(tmp, tmp2);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sweep_removes_only_stale_matching_temps() {
+        let dir = test_dir("sweep");
+        let dest = dir.join("index.tv");
+        std::fs::write(&dest, b"dest").unwrap();
+        let stale = dir.join("index.tv.tmp.4242.0.deadbeef");
+        let stale_legacy = dir.join("index.tv.tmp.4242.1");
+        let fresh = dir.join("index.tv.tmp.4242.2.deadbeef");
+        let other = dir.join("other.tv.tmp.4242.0.deadbeef");
+        let non_pattern = dir.join("index.tv.tmp.notes");
+        for p in [&stale, &stale_legacy, &fresh, &other, &non_pattern] {
+            std::fs::write(p, b"x").unwrap();
+        }
+        // Age the stale candidates well past the one-hour threshold.
+        for p in [&stale, &stale_legacy, &other] {
+            let out = std::process::Command::new("touch")
+                .args(["-t", "202001010000", p.to_str().unwrap()])
+                .status()
+                .unwrap();
+            assert!(out.success());
+        }
+        sweep_stale_tmps(&dest);
+        assert!(!stale.exists(), "stale matching temp must be swept");
+        assert!(!stale_legacy.exists(), "stale legacy-pattern temp must be swept");
+        assert!(fresh.exists(), "fresh temp (possible live writer) must survive");
+        assert!(other.exists(), "another destination's temp must survive");
+        assert!(non_pattern.exists(), "non-matching name must survive");
+        assert!(dest.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }
 
 fn read_f32_array<R: Read>(r: &mut R, n: usize) -> io::Result<Vec<f32>> {

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -426,3 +426,65 @@ fn large_payload_write_matches_streamed_writer_in_both_durability_modes() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+// ---------------------------------------------------------------------------
+// #293 — symlink attack on the temp name
+// ---------------------------------------------------------------------------
+
+/// The issue's repro: an attacker with write access to the destination
+/// directory pre-plants symlinks at predictable `<dest>.tmp.{pid}.{seq}`
+/// names pointing at a victim file. The save must neither write through
+/// a planted link nor leave the destination as a symlink.
+#[cfg(unix)]
+#[test]
+fn planted_tmp_symlinks_cannot_redirect_the_write() {
+    let dir = temp_dir("symlink-attack");
+    let victim_dir = temp_dir("symlink-victim");
+    let victim = victim_dir.join("precious.txt");
+    std::fs::write(&victim, b"precious").unwrap();
+
+    let path = dir.join("index.tv");
+    // Cover the old fully-predictable pattern for a generous seq range,
+    // plus the destination itself.
+    let pid = std::process::id();
+    for seq in 0..512 {
+        std::os::unix::fs::symlink(&victim, dir.join(format!("index.tv.tmp.{pid}.{seq}"))).unwrap();
+    }
+    write_good_tv(&path);
+
+    assert_eq!(std::fs::read(&victim).unwrap(), b"precious", "victim must be untouched");
+    let meta = std::fs::symlink_metadata(&path).unwrap();
+    assert!(meta.file_type().is_file(), "destination must be a regular file, not a symlink");
+    load(&path).expect("saved index must load");
+    std::fs::remove_dir_all(&dir).ok();
+    std::fs::remove_dir_all(&victim_dir).ok();
+}
+
+// ---------------------------------------------------------------------------
+// #299 — NAME_MAX: long destination filenames must still save
+// ---------------------------------------------------------------------------
+
+/// A 250-byte destination filename is legal on ext4/APFS, but the temp
+/// suffix used to push the sibling past NAME_MAX and fail the save. The
+/// temp name's base is truncated to fit instead.
+#[test]
+fn long_destination_filename_saves_and_loads() {
+    let dir = temp_dir("name-max");
+    let name = format!("{}.tv", "v".repeat(247)); // 250-byte filename
+    let path = dir.join(&name);
+    let (packed, scales) = write_good_tv(&path);
+
+    let (bw, d, n, p, s, _, _) = load(&path).expect("long-named index must load");
+    assert_eq!((bw, d, n), (4, 32, 2));
+    assert_eq!(
+        p,
+        CodePayload::BlockedNative {
+            codes: expected_native(&packed),
+            boundaries: test_codebook(4).0,
+            centroids: test_codebook(4).1,
+        }
+    );
+    assert_eq!(s, scales);
+    assert_eq!(dir_entries(&dir), vec![name], "no temp strays");
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
One coherent redesign of the sibling-temp write protocol shared by `turbovec::io` and the Python integrations' `atomic_save`, fixing the persistence cluster.

## What / why

**#293 — symlink attack via predictable temp name.** `tmp_sibling` produced fully predictable `<dest>.tmp.{pid}.{seq}` names and opened them with `File::create` (follows symlinks). Temps are now `<dest>.tmp.{pid}.{seq}.{rand:08x}` and opened with `create_new(true)` (`O_CREAT|O_EXCL`) — an existing file or planted symlink is refused, never written through; EEXIST retries (8x) with a fresh random component so a crash-leaked temp from a reused pid can't hard-fail a save. Names stay recognizable as `<dest>.tmp.*`.

**#316 — Python temp collision.** `_persist._tmp_path` used `.tmp.{pid}` only, so two stores saving to one directory from one process interleaved into a single temp and unlinked each other's in-flight temp. It now mirrors the Rust `TMP_SEQ` approach — pid + process-wide `itertools.count()` + `secrets.token_hex(4)` — and the side-car temp opens with `"x"` (O_EXCL). Verified the new concurrent test's scenario reproduces the old failure (FileNotFoundError) against the pre-fix `_tmp_path` and passes with the fix.

**#299 — NAME_MAX + leaked temps.** (a) When base filename + temp suffix would exceed 255 bytes, the base portion of the *temp* name is truncated to fit (destination name untouched), so ~243+ char filenames now save. (b) Crash-leaked temps: each save now does a best-effort sweep of `<dest>.tmp.*` siblings that match our exact pattern (`{pid}.{seq}` legacy or `{pid}.{seq}.{hex8}`) **and** have an mtime over one hour old — saves take seconds, so a live writer's in-flight temp is never touched; all sweep errors are ignored. The protocol, the sweep, and the symlink-destination replace semantics (issue point 3) are documented in the module doc. Judgment call: the one-hour age gate is the safety mechanism against deleting a live writer's temp; temps of truncated long-named destinations are not swept (prefix no longer matches) — deliberate, conservative.

**#313 — Windows rename retry + non-x86 validation ordering.** The rename over the destination now goes through `rename_atomic`, which on Windows retries `ERROR_SHARING_VIOLATION` (os error 32) up to 10 times with 1→64 ms backoff (same posture as cargo/rustup/git); the temp handle is explicitly dropped before the rename. On non-x86, the codebook-length asserts now run in `write_with_durability`/`write_id_map_with_durability` *before* the temp file exists (shared `assert_codebook_lengths`, also used by `head_core`/`write_core`), matching x86 ordering so a validation panic can no longer leak a temp. Points 3–7 of the issue (pathlib `PathBuf` signatures, no-filename paths, `try_load_v6_fast` error contract, UEFI gate) are out of scope here; the title items (1 and 2) are fully fixed.

Closes #316, Closes #293, Closes #299, Closes #313

## Tests

- New unit tests (`io.rs::tmp_protocol_tests`): O_EXCL refuses a planted symlink (unix); unique/recognizable temp names; NAME_MAX truncation; suffix-pattern matcher; sweep removes only stale matching temps (fresh, other-destination, and non-pattern siblings survive).
- New integration tests (`tests/io_hardening.rs`): the #293 repro — 512 planted `<dest>.tmp.{pid}.{seq}` symlinks, victim untouched, destination a regular file; 250-byte destination filename saves and round-trips with no temp strays.
- New Python test (`tests/test_persist.py`): two stores (5 and 300 vectors) saving to the same directory from two threads, 25 iterations each — no exceptions, both artifacts individually complete, no temp strays.
- `cargo test --release`: all suites green (0 failures). `cargo clippy`: no new warnings.
- `pytest turbovec-python/tests/`: 187 passed, 124 skipped (integration extras not installed), after `maturin develop --release`.
- `cargo check --target x86_64-pc-windows-msvc`: clean (the retry path itself can't be exercised on macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)