### PR TITLE
docs: correct drifted benchmark prose, format version, and API signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 turbovec is a Rust vector index with Python bindings, built on Google Research's [**TurboQuant**](https://arxiv.org/abs/2504.19874) algorithm — a data-oblivious quantizer with near-optimal distortion and no separate training phase.
 
 - **Online ingest.** Add vectors, they're indexed — no train step, no parameter tuning, no rebuilds as the corpus grows.
-- **Fast SIMD search.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 10–19% on ARM; on x86 they win the 4-bit configs and trail by a few percent on 2-bit.
+- **Fast SIMD search.** Hand-written NEON (ARM) and AVX-512BW (x86) kernels beat FAISS IndexPQFastScan by 19–31% on ARM; on x86 they win the 4-bit configs and trail by a few percent on 2-bit.
 - **Filter at search time.** Pass an id allowlist (or a slot bitmask) to `search()` and the kernel honours it directly. You always get up to `k` results from the allowed set — no over-fetching, no recall hit on selective filters.
 - **Pure local.** No managed service, no data leaving your machine or VPC. Pair with any open-source embedding model for a fully air-gapped RAG stack.
 
@@ -80,7 +80,7 @@ scores, ids = idx.search(query, k=10, allowlist=allowed)
 
 Filtering happens inside the SIMD kernel at 32-vector block granularity: blocks with no allowed slots are short-circuited before any LUT lookup or scoring work, and individual non-allowed slots inside scored blocks are dropped at heap-insert. Selective allowlists (small fraction of the index allowed) therefore avoid most of the SIMD cost rather than paying it and discarding the result afterwards.
 
-The output length is `min(k, len(allowed))` — when the allowlist is smaller than `k` you get exactly `len(allowed)` results rather than padded fallbacks.
+The output length is `min(k, n_allowed)`, where `n_allowed` counts *distinct* allowed vectors — when fewer vectors are allowed than `k` you get exactly that many results rather than padded fallbacks.
 
 See [`docs/api.md`](docs/api.md) for the full reference.
 
@@ -152,7 +152,7 @@ All benchmarks: 100K vectors, 1K queries, k=64, median of 5 runs.
 
 ![ARM Speed — Multi-threaded](docs/arm_speed_mt.svg)
 
-On ARM, TurboQuant beats FAISS FastScan by 16–24% across every config.
+On ARM, TurboQuant beats FAISS FastScan by 19–31% across every config.
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,7 +45,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 | `search(queries, k, *, mask=None)` | Returns `(scores, indices)`, both shape `(nq, effective_k)`. Indices are `int64` slot positions. `mask` is an optional `bool` array of length `len(idx)`; when given, only slots with `mask[i] == True` contribute. `effective_k = min(k, mask.sum())`. Raises `ValueError` on a non-finite or `\|value\| ≥ 1e16` query coordinate. |
 | `swap_remove(idx)` | O(1). Moves the last vector into `idx`; returns the previous position of that moved vector (so external refs can be updated if needed). |
 | `prepare()` | Optional. Eagerly builds the rotation matrix, Lloyd-Max centroids and SIMD-blocked layout so the first `search` call doesn't pay the one-time cost. No-op on a lazy index that hasn't seen its first add. |
-| `write(path)` / `load(path)` | `.tv` format. |
+| `write(path, *, durable=True)` / `load(path)` | `.tv` format. `durable=False` skips the fsync before the atomic rename — faster, but a power loss can lose the file. |
 | `to_bytes()` / `from_bytes(data)` | In-memory `.tv` serialization — see [In-memory serialization](#in-memory-serialization). |
 | `len(idx)` / `idx.dim` / `idx.bit_width` | Introspection. `idx.dim` returns `int` once committed, or `None` on a lazy index that hasn't seen its first add. |
 
@@ -111,7 +111,7 @@ idx.add_with_ids(vectors, ids)           # locks dim to vectors.shape[1]
 | `remove(id) -> bool` | `True` if the id was present and removed, `False` otherwise. O(1). |
 | `search(queries, k, *, allowlist=None)` | Returns `(scores, ids)` — `ids` are `uint64` external ids. `allowlist` is an optional `uint64` array of ids; when given, results are restricted to those ids and `effective_k = min(k, number of unique ids in allowlist)` (the allowlist is deduplicated; repeated ids don't widen the result). Raises `ValueError` on an empty allowlist or a non-finite / `\|value\| ≥ 1e16` query coordinate, and `KeyError` on unknown ids. |
 | `contains(id)` / `id in idx` | Membership. |
-| `write(path)` / `load(path)` | `.tvim` format. |
+| `write(path, *, durable=True)` / `load(path)` | `.tvim` format. `durable=False` skips the fsync before the atomic rename — faster, but a power loss can lose the file. |
 | `to_bytes()` / `from_bytes(data)` | In-memory `.tvim` serialization — see [In-memory serialization](#in-memory-serialization). |
 | `len(idx)` / `idx.dim` / `idx.bit_width` / `prepare()` | Same as `TurboQuantIndex`. |
 
@@ -157,7 +157,7 @@ Common use cases:
 ```
 ┌──────────────────────────────────────┐
 │ magic    "TVPI"  (4 bytes)            │
-│ version  u8    = 4                     │
+│ version  u8    = 6                     │
 ├──────────────────────────────────────┤
 │ core header                           │
 │   bit_width    (u8)                   │
@@ -185,7 +185,7 @@ Common use cases:
 ```
 ┌──────────────────────────────────────┐
 │ magic    "TVIM"  (4 bytes)            │
-│ version  u8    = 4                     │
+│ version  u8    = 6                     │
 ├──────────────────────────────────────┤
 │ core payload (same as .tv:            │
 │   header + codes + scales + TQ+)      │

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,43 +155,52 @@ Common use cases:
 ### `.tv` — `TurboQuantIndex`
 
 ```
-┌──────────────────────────────────────┐
-│ magic    "TVPI"  (4 bytes)            │
-│ version  u8    = 6                     │
-├──────────────────────────────────────┤
-│ core header                           │
-│   bit_width    (u8)                   │
-│   dim          (u32 LE)               │
-│   n_vectors    (u64 LE)               │
-│   rotation fingerprint                │
-│     hash    (u64 LE, FNV-1a)          │
-│     probes  (64 × f32 LE)             │
-├──────────────────────────────────────┤
-│ packed codes                          │
-│   (dim / 8) * bit_width * n_vectors   │
-├──────────────────────────────────────┤
-│ scales  (n_vectors × f32 LE)          │
-│   per-vector length-renormalization   │
-├──────────────────────────────────────┤
-│ TQ+ trailer                           │
-│   n_calib  (u32 LE)  — 0 or dim       │
-│   shift    (n_calib × f32 LE)         │
-│   scale    (n_calib × f32 LE)         │
-└──────────────────────────────────────┘
+┌───────────────────────────────────────────┐
+│ magic    "TVPI"  (4 bytes)                │
+│ version  u8    = 6                        │
+├───────────────────────────────────────────┤
+│ core header                               │
+│   bit_width    (u8)                       │
+│   dim          (u32 LE)                   │
+│   n_vectors    (u64 LE)                   │
+├───────────────────────────────────────────┤
+│ Lloyd-Max codebook                        │
+│   boundaries  ((2^bit_width − 1) × f32 LE)│
+│   centroids   (2^bit_width × f32 LE)      │
+├───────────────────────────────────────────┤
+│ codes — sequential blocked layout         │
+│   n_byte_groups = dim / (8 / bit_width)   │
+│   ceil(n_vectors / 32)                    │
+│     × n_byte_groups × 32 bytes            │
+├───────────────────────────────────────────┤
+│ scales  (n_vectors × f32 LE)              │
+│   per-vector length-renormalization       │
+├───────────────────────────────────────────┤
+│ TQ+ trailer                               │
+│   n_calib  (u32 LE)  — 0 or dim           │
+│   shift    (n_calib × f32 LE)             │
+│   scale    (n_calib × f32 LE)             │
+└───────────────────────────────────────────┘
 ```
+
+The code payload is grouped into 32-vector blocks and padded up to a
+whole block, so it is `ceil(n_vectors / 32) * 32` vectors wide on disk.
+At `bit_width = 3` a byte holds only two codes rather than 8/3, making
+the payload ~33% larger than `dim * bit_width / 8` per vector would
+suggest.
 
 ### `.tvim` — `IdMapIndex`
 
 ```
-┌──────────────────────────────────────┐
-│ magic    "TVIM"  (4 bytes)            │
-│ version  u8    = 6                     │
-├──────────────────────────────────────┤
-│ core payload (same as .tv:            │
-│   header + codes + scales + TQ+)      │
-├──────────────────────────────────────┤
-│ slot_to_id  (n_vectors × u64 LE)      │
-└──────────────────────────────────────┘
+┌───────────────────────────────────────────┐
+│ magic    "TVIM"  (4 bytes)                │
+│ version  u8    = 6                        │
+├───────────────────────────────────────────┤
+│ core payload (same as .tv: header +       │
+│   codebook + codes + scales + TQ+)        │
+├───────────────────────────────────────────┤
+│ slot_to_id  (n_vectors × u64 LE)          │
+└───────────────────────────────────────────┘
 ```
 
 On load, the reverse `id → slot` map is rebuilt in memory. Duplicate ids in the `slot_to_id` table are rejected as corrupt.

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -110,7 +110,7 @@ vector_db.delete_by_name("paper.pdf")             # by Document.name
 vector_db.delete_by_metadata({"source": "web"})   # AND-of-equality on meta_data
 vector_db.delete_by_content_id("cid-42")          # by Document.content_id
 vector_db.drop()                                  # clear all
-vector_db.delete()                                # alias for drop(), returns True
+vector_db.delete()                                # returns False, deletes nothing — use drop()
 ```
 
 Each `delete_by_*` returns `True` iff at least one document was removed. `delete_by_name` / `delete_by_content_id` / `delete_by_metadata` remove only the documents matching that exact predicate, even when other stored documents share the same derived `doc_id`. `delete_by_id` removes every document under that internal id.
@@ -148,7 +148,7 @@ The store also supports `pickle` (e.g. for `multiprocessing` workers, provided t
 
 ## Async
 
-The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. When the embedder exposes `async_get_embedding` / `async_get_embeddings_batch_and_usage`, the async paths use it for genuine async embedding generation.
+The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. The async paths call the embedder's `async_get_embedding` / `async_get_embeddings_batch_and_usage` for genuine async embedding generation. Agno's `Embedder` base class always defines both, so an embedder that inherits them without implementing them raises `NotImplementedError` on the async paths — use the sync methods with such an embedder.
 
 ## Thread safety
 

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -879,8 +879,8 @@ impl IdMapIndex {
         })
     }
 
-    /// Serialize the index and id-map side-tables to a `.tvim` file.
-    /// Persist the index. ``durable=True`` (the default) fsyncs before
+    /// Serialize the index and id-map side-tables to a ``.tvim`` file.
+    /// ``durable=True`` (the default) fsyncs before
     /// the atomic rename, surviving power loss; ``durable=False`` keeps
     /// the temp-file + atomic-rename protocol (the destination can never
     /// hold a torn index and the previous file survives a process crash)
@@ -902,8 +902,8 @@ impl IdMapIndex {
         .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
-    /// Load an `IdMapIndex` from a `.tvim` file previously written by
-    /// [`IdMapIndex.write`].
+    /// Load an ``IdMapIndex`` from a ``.tvim`` file previously written
+    /// by ``IdMapIndex.write``.
     #[classmethod]
     fn load(cls: &Bound<PyType>, path: &str) -> PyResult<Self> {
         // The v6 load parallelizes the layout transform — run it in the


### PR DESCRIPTION
Fixes every confirmed docs drift in #296, #297 and #298. Each claim below was re-verified against the source or the benchmark JSONs in this tree rather than taken from the issue text — which matters, because **the ARM numbers in #298 are themselves already stale**: the c4a Axion re-baseline (#290, merged in `44571a3`) moved them again after the issue was filed.

## ARM speed prose (#298)

Recomputed from `benchmarks/results/speed_d*_arm_*.json` as `faiss/tq − 1`:

| cell | mt | st |
|---|---|---|
| d1536 2-bit | +30.7% | +31.1% |
| d1536 4-bit | +21.2% | +23.6% |
| d3072 2-bit | +19.4% | +20.6% |
| d3072 4-bit | +20.8% | +23.6% |

True span is **19–31%**. `README.md:19` said "10–19%" and `README.md:155` said "16–24%" — two different wrong ranges, both now 19–31%.

Checked and left alone because they are exactly right against the current JSONs: the x86 speed prose (`README.md:163` — 4-bit +5.0/+2.5/+2.4/+0.0%, 2-bit −7.8/−2.8/−3.0/−5.8%, d3072 4-bit mt ties) and all recall prose (`README.md:135` — d1536/d3072 R@1 gaps span 0.2–1.9pp; GloVe 4-bit +0.88pp; GloVe 2-bit −0.06pp, "within 0.1 points").

Note this PR does **not** address the other half of #312: the recall JSONs themselves predate the v5 rotation change, so the prose is now consistent with files that need regenerating on the official benchmark hosts. That rerun is left for @RyanCodrai.

## Format version and API signatures (#297)

- `docs/api.md:160,188` — both format diagrams showed `version u8 = 4`; `io.rs:64,66` define `TV_VERSION`/`TVIM_VERSION` as **6**. A reader parsing `.tv` from the diagram would reject valid files. Now 6.
- `docs/api.md:48,114` — method tables listed `write(path)`; the real signature is `write(path, *, durable=True)` on both classes (`turbovec-python/src/lib.rs:459,888`). `grep -rn durable docs/ README.md` previously returned zero hits for a shipped public parameter. Both rows now carry the signature and a one-line description of what `durable=False` trades away.
- `README.md:83` — said allowlist output length is `min(k, len(allowed))`; `id_map.rs:259-265` deduplicates the allowlist, so it is `min(k, n_allowed)` over *distinct* ids. `docs/api.md:143` already said this correctly; the README now matches.
- Cosmetic docstrings visible in `help()`: `IdMapIndex.write` had two concatenated intro sentences from a merge, and `IdMapIndex.load` leaked rustdoc link syntax (``[`IdMapIndex.write`]``). Both cleaned.

## agno integration docs (#296)

- `docs/integrations/agno.md:113` claimed `delete()` is an "alias for drop(), returns True". `agno.py:272-276` returns `False` and deletes nothing (deliberate — it matches LanceDb; destruction goes through `drop()`). The doc page was the wrong one, so it now says so.
- `agno.md:151` implied the async paths fall back for a sync-only embedder. They do not: the `hasattr` guard at `agno.py:846` never fires because `agno.knowledge.embedder.base.Embedder` always defines `async_get_embedding` (its body raises `NotImplementedError`). Reworded to describe the real behaviour.

## Verification

Docs-only plus two Rust docstrings; `cargo check -p turbovec-python` clean. Percentages recomputed directly from the committed JSONs; every source claim quoted above was read in this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)