### PR TITLE
fix: core-crate batch — masked-search atomic, uninit slices, pool guard, x86 dispatch gates, codebook validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "statrs",
+ "turbovec",
 ]
 
 [[package]]

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1220,10 +1220,19 @@ fn in_forked_child() -> bool {
 /// (which blocks on rayon's latch and never steals) and move only a plain
 /// `&T` / `&mut T` into `f`.
 fn with_pool<R: Send>(f: impl FnOnce() -> R + Send) -> PyResult<R> {
+    // Drop guard so an unwinding `f` (or rayon worker) still decrements
+    // the counter — a leaked increment would make `pool_idle()` false
+    // forever and silently route every add through the serial copy
+    // path (#300).
+    struct InFlight;
+    impl Drop for InFlight {
+        fn drop(&mut self) {
+            POOL_IN_FLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
     POOL_IN_FLIGHT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let result = current_pool().map(|c| c.pool.install(f));
-    POOL_IN_FLIGHT.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
-    result
+    let _in_flight = InFlight;
+    current_pool().map(|c| c.pool.install(f))
 }
 
 /// Number of `with_pool` jobs currently running or queued. Used by

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -24,3 +24,14 @@ rand = "0.8"
 # so the version is frozen and a golden-bytes test guards it.
 rand_chacha = "=0.3.1"
 statrs = "0.17"
+
+[features]
+# Debug/test telemetry: count 32-vector blocks short-circuited by the
+# slot-mask early exit. Off by default — the per-skip atomic RMW on a
+# shared cache line serializes the masked search hot loop (#294).
+mask-skip-counter = []
+
+[dev-dependencies]
+# Self dev-dependency so `cargo test` still exercises the block-skip
+# activation test without the counter existing in release builds.
+turbovec = { path = ".", features = ["mask-skip-counter"] }

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -270,29 +270,44 @@ pub(crate) fn encode(
     let rotated_buf: &mut Vec<f32> = rotated_scratch;
     rotated_buf.clear();
     rotated_buf.reserve(n * dim);
-    #[allow(clippy::uninit_vec)]
-    // SAFETY: f32 has no invalid bit patterns, and every element is
-    // written by apply_scaled_into (each output row is fully written)
-    // before `rotated_buf` is read. Reusing the caller's scratch keeps
-    // the allocation warm across adds instead of paying a fresh
-    // multi-MB mmap + page-fault walk per call.
-    unsafe {
-        rotated_buf.set_len(n * dim);
-    }
+    // Each row is rotated into a per-worker staging row and then copied
+    // into the Vec's spare capacity through `MaybeUninit`; the length is
+    // set only after every row has been written (#292). The Vec
+    // therefore never claims uninitialized elements, so a panic
+    // mid-rotation leaves an empty — not uninit-length — scratch for
+    // `add_2d`'s unwind guard to store back. The staging copy costs
+    // ~1% of encode; writing the rotation's final `permute_gather`
+    // output straight into the spare capacity would remove it but means
+    // a `MaybeUninit` variant of every NEON/AVX/scalar gather kernel.
+    // Reusing the caller's scratch keeps the allocation warm across adds
+    // instead of paying a fresh multi-MB mmap + page-fault walk.
+    //
     // The norm is computed in the same per-row task as the rotation —
     // the row is already in cache, so the separate full-batch norms
     // pass disappears. Same per-row operations, identical bytes.
-    rotated_buf
+    rotated_buf.spare_capacity_mut()[..n * dim]
         .par_chunks_mut(dim)
         .zip(norms.par_iter_mut())
         .enumerate()
-        .for_each_init(|| vec![0.0f32; dim], |scratch, (i, (dst_row, norm))| {
-            let src = &vectors[i * dim..(i + 1) * dim];
-            let n_val = simd_norm(src);
-            *norm = n_val;
-            let inv = if n_val > 1e-10 { 1.0 / n_val } else { 0.0 };
-            rotation.apply_scaled_into(src, inv, dst_row, scratch)
-        });
+        .for_each_init(
+            || (vec![0.0f32; dim], vec![0.0f32; dim]),
+            |(scratch, row), (i, (dst_row, norm))| {
+                let src = &vectors[i * dim..(i + 1) * dim];
+                let n_val = simd_norm(src);
+                *norm = n_val;
+                // Norms at or below MIN_INPUT_NORM have no representable
+                // direction; scale 0 is the documented outcome (#286).
+                let inv = if n_val > crate::MIN_INPUT_NORM { 1.0 / n_val } else { 0.0 };
+                rotation.apply_scaled_into(src, inv, row, scratch);
+                for (d, &s) in dst_row.iter_mut().zip(row.iter()) {
+                    d.write(s);
+                }
+            },
+        );
+    // SAFETY: every one of the n*dim spare slots was written above.
+    unsafe {
+        rotated_buf.set_len(n * dim);
+    }
     let rotated: &[f32] = rotated_buf;
 
     // TQ+ per-coord (shift, scale) — fitted to empirical quantiles of the
@@ -364,22 +379,15 @@ pub(crate) fn encode(
     // extend_from_slice copy afterwards.
     let packed_old = packed_out.len();
     let scales_old = scales_out.len();
-    {
-        // Every quantize kernel — NEON, AVX2, and the scalar fallback —
-        // stores whole bytes (one store per plane per 8-coord chunk)
-        // rather than OR-ing bits into a pre-zeroed row, so the
-        // bytes_per_row * n zero-fill is dead work.
-        // SAFETY: u8 has no invalid bit patterns, and fused_quantize_
-        // scale_pack overwrites all bytes_per_row bytes of every row
-        // before the region is read.
-        packed_out.reserve(n * bytes_per_row);
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            packed_out.set_len(packed_old + n * bytes_per_row);
-        }
-    }
+    // Every quantize kernel — NEON, AVX2, and the scalar fallback —
+    // stores whole bytes (one store per plane per 8-coord chunk)
+    // rather than OR-ing bits into a pre-zeroed row, so the
+    // bytes_per_row * n zero-fill is dead work. The rows land in the
+    // Vec's spare capacity via `MaybeUninit` and the length is only set
+    // after `quantize_batch` returns having written every row (#292).
+    packed_out.reserve(n * bytes_per_row);
     scales_out.resize(scales_old + n, 0.0f32);
-    let packed = &mut packed_out[packed_old..];
+    let packed = &mut packed_out.spare_capacity_mut()[..n * bytes_per_row];
     let scales = &mut scales_out[scales_old..];
 
     // Monomorphized per bit-width so the per-plane pack loop and the
@@ -403,6 +411,10 @@ pub(crate) fn encode(
         ),
         other => unreachable!("unsupported bit_width {other}"),
     }
+    // SAFETY: quantize_batch wrote all n*bytes_per_row spare bytes.
+    unsafe {
+        packed_out.set_len(packed_old + n * bytes_per_row);
+    }
 
     fitted
 }
@@ -410,7 +422,7 @@ pub(crate) fn encode(
 /// Quantize + pack the whole batch with a compile-time bit width.
 #[allow(clippy::too_many_arguments)]
 fn quantize_batch<const BITS: usize>(
-    packed: &mut [u8],
+    packed: &mut [std::mem::MaybeUninit<u8>],
     scales: &mut [f32],
     rotated: &[f32],
     shift: &[f32],
@@ -427,14 +439,23 @@ fn quantize_batch<const BITS: usize>(
     packed.par_chunks_mut(bytes_per_row)
         .zip(scales.par_iter_mut())
         .enumerate()
-        .for_each(|(i, (packed_row, scale))| {
-            let rot_orig = &rotated[i * dim..(i + 1) * dim];
-            *scale = fused_quantize_scale_pack::<BITS>(
-                rot_orig, shift, scale_tq, inv_scale_tq,
-                centroid_orig, boundaries, centroids, norms[i],
-                packed_row, dim, bytes_per_plane,
-            );
-        });
+        .for_each_init(
+            || vec![0u8; bytes_per_row],
+            |row_buf, (i, (packed_row, scale))| {
+                let rot_orig = &rotated[i * dim..(i + 1) * dim];
+                *scale = fused_quantize_scale_pack::<BITS>(
+                    rot_orig, shift, scale_tq, inv_scale_tq,
+                    centroid_orig, boundaries, centroids, norms[i],
+                    row_buf, dim, bytes_per_plane,
+                );
+                // The kernels overwrite every byte of the row, so the
+                // per-thread staging row publishes fully-written bytes
+                // into the spare capacity (#292).
+                for (d, &s) in packed_row.iter_mut().zip(row_buf.iter()) {
+                    d.write(s);
+                }
+            },
+        );
 }
 
 /// Per-coordinate TQ+ calibration. For each of the `dim` rotated coordinates,
@@ -506,13 +527,10 @@ fn compute_tqplus_calibration(
             // 128-coordinate tile ceiling and n 100k this is a ~51 MB
             // memset (and its page-fault walk) per tile, paid purely to
             // be overwritten.
-            // SAFETY: u32 has no invalid bit patterns, and every one of
-            // the `tile * n` slots is assigned in the scatter loop.
+            // The scatter writes into the spare capacity via
+            // `MaybeUninit`; length is set only after every one of the
+            // `tile * n` slots has been assigned (#292).
             let mut cols: Vec<u32> = Vec::with_capacity(tile * n);
-            #[allow(clippy::uninit_vec)]
-            unsafe {
-                cols.set_len(tile * n);
-            }
             // Values are transposed as order-preserving integer keys, not
             // as floats: quickselect over `u32` uses the native `Ord`
             // and integer compares instead of a `partial_cmp` closure
@@ -526,11 +544,18 @@ fn compute_tqplus_calibration(
             // `partial_cmp` calls equal; both map to the same quantile
             // arithmetic below (`x - -0.0` and `x - 0.0` agree for every
             // finite x), so that case is a wash too.
-            for i in 0..n {
-                let row = &rotated[i * dim + d0..i * dim + d0 + tile];
-                for (c, &v) in row.iter().enumerate() {
-                    cols[c * n + i] = f32_sort_key(v);
+            {
+                let spare = &mut cols.spare_capacity_mut()[..tile * n];
+                for i in 0..n {
+                    let row = &rotated[i * dim + d0..i * dim + d0 + tile];
+                    for (c, &v) in row.iter().enumerate() {
+                        spare[c * n + i].write(f32_sort_key(v));
+                    }
                 }
+            }
+            // SAFETY: the scatter above assigned all tile*n slots.
+            unsafe {
+                cols.set_len(tile * n);
             }
             for (c, (sh, sc)) in sh_tile.iter_mut().zip(sc_tile.iter_mut()).enumerate() {
                 let coord = &mut cols[c * n..(c + 1) * n];

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -810,7 +810,7 @@ fn read_core_v6<R: Read>(r: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
     let n_levels = 1usize << bit_width;
     let boundaries = read_f32_array(r, n_levels - 1)?;
     let centroids = read_f32_array(r, n_levels)?;
-    validate_codebook(n_vectors, &boundaries, &centroids)?;
+    validate_codebook(bit_width, dim, n_vectors, &boundaries, &centroids)?;
     let blocked_bytes = v6_blocked_len(bit_width, dim, n_vectors)?;
     let blocked = read_exact_vec_capped(r, blocked_bytes, alloc_cap)?;
     let scales = read_scales_validated(r, n_vectors)?;
@@ -827,7 +827,13 @@ fn read_core_v6<R: Read>(r: &mut R, alloc_cap: u64) -> io::Result<CoreLoad> {
 }
 
 /// Codebook value validation shared by the streamed and fast v6 loaders.
-fn validate_codebook(n_vectors: usize, boundaries: &[f32], centroids: &[f32]) -> io::Result<()> {
+fn validate_codebook(
+    bit_width: usize,
+    dim: usize,
+    n_vectors: usize,
+    boundaries: &[f32],
+    centroids: &[f32],
+) -> io::Result<()> {
     // Codebook value validation (skipped for an empty index, whose
     // codebook is an ignored all-zero placeholder): search uses these to
     // decode every score, so a non-finite or out-of-support value would
@@ -856,6 +862,38 @@ fn validate_codebook(n_vectors: usize, boundaries: &[f32], centroids: &[f32]) ->
                     i, boundaries[i], boundaries[i + 1]
                 ),
             ));
+        }
+        // The codebook is not data-fitted — it is a pure function of
+        // (bit_width, dim) (analytic Lloyd-Max against the Beta
+        // marginal), so a well-formed file's embedded arrays must match
+        // a fresh recomputation. Value-level checks above cannot catch a
+        // collapsed or reversed centroid array, which loads structurally
+        // clean and silently mis-scores every query (#320). Compared
+        // with a tolerance (not bit-exact) so files written by builds
+        // whose libm rounds differently still load; any tamper large
+        // enough to change scores exceeds it by orders of magnitude.
+        const CODEBOOK_TOLERANCE: f32 = 1e-4;
+        let (exp_boundaries, exp_centroids) = crate::codebook::codebook(bit_width, dim);
+        for (name, got, expected) in [
+            ("boundaries", boundaries, &exp_boundaries[..]),
+            ("centroids", centroids, &exp_centroids[..]),
+        ] {
+            if let Some((i, (&g, &e))) = got
+                .iter()
+                .zip(expected.iter())
+                .enumerate()
+                .find(|(_, (g, e))| (**g - **e).abs() > CODEBOOK_TOLERANCE)
+            {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "invalid codebook {name} at index {i}: {g} (expected {e} \
+                         for bit_width {bit_width}, dim {dim}; the codebook is a \
+                         pure function of the header and this file's disagrees — \
+                         corrupt or tampered file)",
+                    ),
+                ));
+            }
         }
     }
     Ok(())
@@ -1204,7 +1242,7 @@ fn try_load_v6_fast(
     let n_levels = 1usize << bit_width;
     let boundaries = read_f32_array(&mut r, n_levels - 1)?;
     let centroids = read_f32_array(&mut r, n_levels)?;
-    validate_codebook(n_vectors, &boundaries, &centroids)?;
+    validate_codebook(bit_width, dim, n_vectors, &boundaries, &centroids)?;
     let blocked_bytes = v6_blocked_len(bit_width, dim, n_vectors)?;
     let codes_start = (prefix_len - r.len()) as u64;
     let codes_end = codes_start

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -87,6 +87,42 @@ const FLUSH_EVERY: usize = 256;
 /// magnitude above any realistic embedding value).
 const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 
+/// Norm at or below which a vector has no representable direction.
+///
+/// The encoder stores every vector as (unit direction, norm). At or
+/// below this threshold there is no meaningful direction to store, so
+/// the vector is encoded with scale 0 and scores exactly 0 against
+/// every query. This is documented behaviour, not an error: 0 is the
+/// conventional cosine similarity of a zero vector, so the slot is
+/// counted in `len()` and is returned by `search` only after every
+/// vector that does have a direction. Callers for whom a zero-norm
+/// embedding is a bug should reject it before `add`.
+pub const MIN_INPUT_NORM: f32 = 1e-10;
+
+/// The canonical Lloyd-Max codebook for `(bit_width, dim)` —
+/// `(boundaries, centroids)`. The codebook is a pure function of these
+/// two parameters; the v6 loader verifies a file's embedded codebook
+/// against this function and rejects any disagreement (#320), so
+/// callers serializing through the raw [`io`] writers must embed
+/// exactly these arrays (or use
+/// [`TurboQuantIndex::codebook_for_write`]).
+///
+/// # Panics
+///
+/// If `bit_width` is not 2, 3 or 4, or `dim` is not a positive
+/// multiple of 8 (the same bounds the index constructors enforce).
+pub fn expected_codebook(bit_width: usize, dim: usize) -> (Vec<f32>, Vec<f32>) {
+    assert!(
+        (2..=4).contains(&bit_width),
+        "bit_width must be 2, 3 or 4, got {bit_width}"
+    );
+    assert!(
+        dim >= 8 && dim % 8 == 0,
+        "dim must be a positive multiple of 8, got {dim}"
+    );
+    codebook::codebook(bit_width, dim)
+}
+
 /// Reject non-finite (NaN, +Inf, -Inf) or extremely-large input values.
 /// Returns the first offending vector/coord/value tuple, or `None` if
 /// the input is clean.
@@ -336,6 +372,10 @@ impl TurboQuantIndex {
     ///   magnitude `>= 1e16`. Callers handling untrusted input should
     ///   prefer [`Self::add_2d`], which returns a typed
     ///   [`AddError::InvalidInputValue`] instead.
+    ///
+    /// A vector whose L2 norm is `<= 1e-10` ([`MIN_INPUT_NORM`]) is not
+    /// an error: it is stored with scale 0 and scores 0 against every
+    /// query. See that constant for the rationale.
     pub fn add(&mut self, vectors: &[f32]) {
         let dim = self.dim.expect(
             "TurboQuantIndex dim is not set; use add_2d(vectors, dim) on the \
@@ -495,6 +535,9 @@ impl TurboQuantIndex {
     ///   to a dim that is not a multiple of 8.
     /// - [`AddError::InvalidInputValue`] if any coordinate is non-finite
     ///   or has magnitude `>= 1e16`.
+    ///
+    /// A vector whose L2 norm is `<= 1e-10` ([`MIN_INPUT_NORM`]) is
+    /// accepted and stored with scale 0 — see that constant.
     ///
     /// # Panics
     ///

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -8,6 +8,7 @@
 //!   `is_x86_feature_detected!`
 //! - a scalar fallback for any other target
 
+#[cfg(feature = "mask-skip-counter")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rayon::prelude::*;
@@ -53,8 +54,11 @@ use crate::{BLOCK, FLUSH_EVERY};
 /// because no allowed slots fall within it.
 ///
 /// Process-global. Tests sample before/after a single search to verify
-/// the skip path fires; production callers can read it for hybrid-
-/// retrieval telemetry. Reset is provided for test isolation.
+/// the skip path fires. Gated behind the `mask-skip-counter` feature
+/// (enabled for this crate's own tests via the self dev-dependency):
+/// the per-skip atomic RMW on a shared cache line serialized the masked
+/// hot loop, making selective filtering slower than no filtering (#294).
+#[cfg(feature = "mask-skip-counter")]
 pub static BLOCKS_SKIPPED_BY_MASK: AtomicU64 = AtomicU64::new(0);
 
 /// Test-only switch that forces the x86 dispatch to take the scalar
@@ -67,12 +71,14 @@ pub(crate) static FORCE_SCALAR_FALLBACK: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
 /// Current value of the block-skip counter. See [`BLOCKS_SKIPPED_BY_MASK`].
+#[cfg(feature = "mask-skip-counter")]
 pub fn blocks_skipped_by_mask() -> u64 {
     BLOCKS_SKIPPED_BY_MASK.load(Ordering::Relaxed)
 }
 
 /// Reset the block-skip counter. Tests call this before issuing a
 /// selective search to take a clean delta.
+#[cfg(feature = "mask-skip-counter")]
 pub fn reset_blocks_skipped_by_mask() {
     BLOCKS_SKIPPED_BY_MASK.store(0, Ordering::Relaxed);
 }
@@ -1146,6 +1152,7 @@ pub(crate) fn block_has_allowed(mask: Option<&[u64]>, base_vec: usize) -> bool {
             let word = m[base_vec >> 6];
             let bit_offset = base_vec & 63;
             let allowed = ((word >> bit_offset) & 0xFFFF_FFFF) != 0;
+            #[cfg(feature = "mask-skip-counter")]
             if !allowed {
                 BLOCKS_SKIPPED_BY_MASK.fetch_add(1, Ordering::Relaxed);
             }
@@ -1165,8 +1172,9 @@ pub(crate) fn block_pair_has_allowed(mask: Option<&[u64]>, base_vec_pair: usize)
         None => true,
         Some(m) => {
             let allowed = m[base_vec_pair >> 6] != 0;
+            // A pair-level skip short-circuits two 32-vector blocks.
+            #[cfg(feature = "mask-skip-counter")]
             if !allowed {
-                // A pair-level skip short-circuits two 32-vector blocks.
                 BLOCKS_SKIPPED_BY_MASK.fetch_add(2, Ordering::Relaxed);
             }
             allowed
@@ -1693,9 +1701,17 @@ pub(crate) fn search(
             FORCE_SCALAR_FALLBACK.load(std::sync::atomic::Ordering::Relaxed);
         #[cfg(not(test))]
         let force_scalar_single = false;
-        let use_avx512 =
-            is_x86_feature_detected!("avx512bw") && is_x86_feature_detected!("avx512f");
-        let simd_ok = use_avx512 || is_x86_feature_detected!("avx2");
+        // Every AVX2 kernel (and the AVX-512 kernel's 256-bit epilogue)
+        // declares and executes FMA, so the runtime gate must test it
+        // too — declaring an unchecked feature "would be a lie the
+        // compiler is entitled to act on" (see rotation.rs) and SIGILLs
+        // on avx2-without-fma CPU models (#291).
+        let avx2_fma_ok =
+            is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma");
+        let use_avx512 = is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512f")
+            && avx2_fma_ok;
+        let simd_ok = use_avx512 || avx2_fma_ok;
         if nq == 1
             && mask.is_none()
             && n_blocks >= SINGLE_QUERY_PARALLEL_MIN_BLOCKS
@@ -1747,9 +1763,15 @@ pub(crate) fn search(
                 let force_scalar = false;
 
                 unsafe {
+                    // avx2+fma too: the AVX-512 kernel executes 256-bit
+                    // AVX2/FMA instructions (loads, epilogue helpers),
+                    // and the AVX2 kernel uses _mm256_fmadd_ps — gates
+                    // must match the kernels' declared features (#291).
                     if !force_scalar
                         && is_x86_feature_detected!("avx512bw")
                         && is_x86_feature_detected!("avx512f")
+                        && is_x86_feature_detected!("avx2")
+                        && is_x86_feature_detected!("fma")
                     {
                         search_multi_query_avx512bw(
                             blocked_codes, &lut_refs, &scale_vals, &bias_vals,
@@ -1758,7 +1780,10 @@ pub(crate) fn search(
                             &mut heap_scores, &mut heap_indices,
                             &mut heap_sizes, &mut heap_mins, &mut heap_min_idxs,
                         );
-                    } else if !force_scalar && is_x86_feature_detected!("avx2") {
+                    } else if !force_scalar
+                        && is_x86_feature_detected!("avx2")
+                        && is_x86_feature_detected!("fma")
+                    {
                         search_multi_query_avx2(
                             blocked_codes, &lut_refs, &scale_vals, &bias_vals,
                             n_byte_groups, vec_scales, n_vectors,

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -8,7 +8,6 @@
 //!   `is_x86_feature_detected!`
 //! - a scalar fallback for any other target
 
-#[cfg(feature = "mask-skip-counter")]
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use rayon::prelude::*;
@@ -54,11 +53,15 @@ use crate::{BLOCK, FLUSH_EVERY};
 /// because no allowed slots fall within it.
 ///
 /// Process-global. Tests sample before/after a single search to verify
-/// the skip path fires. Gated behind the `mask-skip-counter` feature
-/// (enabled for this crate's own tests via the self dev-dependency):
-/// the per-skip atomic RMW on a shared cache line serialized the masked
-/// hot loop, making selective filtering slower than no filtering (#294).
-#[cfg(feature = "mask-skip-counter")]
+/// the skip path fires.
+///
+/// **Only incremented when the `mask-skip-counter` feature is enabled**
+/// (this crate's own tests enable it via the self dev-dependency);
+/// otherwise it stays at zero. The per-skip atomic RMW landed on one
+/// shared cache line in the masked hot loop, so counting every skip
+/// made a more selective filter cost more (#294). The item itself stays
+/// unconditionally public so enabling the feature is the only thing
+/// that changes for a downstream caller.
 pub static BLOCKS_SKIPPED_BY_MASK: AtomicU64 = AtomicU64::new(0);
 
 /// Test-only switch that forces the x86 dispatch to take the scalar
@@ -70,15 +73,14 @@ pub static BLOCKS_SKIPPED_BY_MASK: AtomicU64 = AtomicU64::new(0);
 pub(crate) static FORCE_SCALAR_FALLBACK: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
-/// Current value of the block-skip counter. See [`BLOCKS_SKIPPED_BY_MASK`].
-#[cfg(feature = "mask-skip-counter")]
+/// Current value of the block-skip counter — zero unless the
+/// `mask-skip-counter` feature is enabled. See [`BLOCKS_SKIPPED_BY_MASK`].
 pub fn blocks_skipped_by_mask() -> u64 {
     BLOCKS_SKIPPED_BY_MASK.load(Ordering::Relaxed)
 }
 
 /// Reset the block-skip counter. Tests call this before issuing a
 /// selective search to take a clean delta.
-#[cfg(feature = "mask-skip-counter")]
 pub fn reset_blocks_skipped_by_mask() {
     BLOCKS_SKIPPED_BY_MASK.store(0, Ordering::Relaxed);
 }

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -389,6 +389,7 @@ fn block_skip_at_extreme_selectivity_returns_only_allowed() {
 }
 
 #[test]
+#[cfg(feature = "mask-skip-counter")]
 fn block_skip_path_actually_fires_under_selective_mask() {
     // Direct activation test for the block-level early-exit path. The
     // correctness tests above would still pass if the block-skip guard

--- a/turbovec/tests/input_validation.rs
+++ b/turbovec/tests/input_validation.rs
@@ -233,3 +233,37 @@ fn id_map_search_panics_on_nan_query() {
     query[0] = f32::NAN;
     let _ = idx.search(&query, 1);
 }
+
+// ---- #286: near-zero-norm vectors are accepted with documented semantics ----
+//
+// A vector whose norm is <= MIN_INPUT_NORM has no representable
+// direction, so it is stored with scale 0 and scores exactly 0. That is
+// deliberate, not a silent failure: 0 is the conventional cosine of a
+// zero vector, and the framework integrations rely on it (a zero
+// document embedding must be storable and rank last, not raise). These
+// tests pin that contract so the behaviour cannot drift silently.
+
+#[test]
+fn zero_norm_vector_is_stored_and_counted() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    data.extend(vec![0.0f32; DIM]);
+    idx.add_2d(&data, DIM).expect("zero-norm vectors are accepted");
+    assert_eq!(idx.len(), 2);
+}
+
+#[test]
+fn zero_norm_vector_scores_zero_and_ranks_below_real_vectors() {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = ok_vector();
+    // Coords ~1e-23 are finite but x*x underflows f32, so the norm is 0
+    // — the exact input from #286.
+    data.extend(vec![1e-23f32; DIM]);
+    idx.add_2d(&data, DIM).unwrap();
+
+    let res = idx.search(&ok_vector(), 2);
+    assert_eq!(res.indices.len(), 2);
+    let pos = res.indices.iter().position(|&i| i == 1).expect("slot 1 returned");
+    assert_eq!(res.scores[pos], 0.0, "zero-norm vector must score exactly 0");
+    assert_eq!(res.indices[0], 0, "the vector with a real direction ranks first");
+}

--- a/turbovec/tests/io_hardening.rs
+++ b/turbovec/tests/io_hardening.rs
@@ -45,17 +45,11 @@ fn expected_native(seq: &[u8]) -> Vec<u8> {
     seq.to_vec()
 }
 
-fn test_codebook(bit_width: usize) -> (Vec<f32>, Vec<f32>) {
-    // Strictly-increasing boundaries in (-1, 1) — the loader validates
-    // monotonicity; centroids only need to be finite with |v| <= 1.
-    let n_levels = 1usize << bit_width;
-    let boundaries = (0..n_levels - 1)
-        .map(|i| -0.9 + 1.8 * i as f32 / (n_levels - 1) as f32)
-        .collect();
-    let centroids = (0..n_levels)
-        .map(|i| -0.95 + 1.9 * i as f32 / n_levels as f32)
-        .collect();
-    (boundaries, centroids)
+fn test_codebook(bit_width: usize, dim: usize) -> (Vec<f32>, Vec<f32>) {
+    // The v6 loader verifies the embedded codebook against the canonical
+    // codebook(bit_width, dim) (#320), so fixture files must embed the
+    // real one, not a synthetic monotone stand-in.
+    turbovec::expected_codebook(bit_width, dim)
 }
 
 fn blocked_len(bit_width: usize, dim: usize, n_vectors: usize) -> usize {
@@ -80,7 +74,7 @@ fn temp_dir(name: &str) -> PathBuf {
 fn write_good_tv(path: &PathBuf) -> (Vec<u8>, Vec<f32>) {
     let packed = vec![0xABu8; blocked_len(4, 32, 2)];
     let scales = vec![1.5f32, 2.5];
-    let cb = test_codebook(4);
+    let cb = test_codebook(4, 32);
     write(path, 4, 32, 2, &packed, &cb.0, &cb.1, &scales, &[], &[]).unwrap();
     (packed, scales)
 }
@@ -105,7 +99,7 @@ fn tv_panicking_write_leaves_previous_file_intact() {
     // TQ+ calibration length invariant violated (len 3 != dim 32): the
     // write must panic BEFORE creating or truncating anything at `path`.
     let result = catch_unwind(AssertUnwindSafe(|| {
-        write(&path, 4, 32, 2, &packed, &test_codebook(4).0, &test_codebook(4).1, &scales, &[1.0; 3], &[1.0; 3])
+        write(&path, 4, 32, 2, &packed, &test_codebook(4, 32).0, &test_codebook(4, 32).1, &scales, &[1.0; 3], &[1.0; 3])
     }));
     assert!(result.is_err(), "mismatched TQ+ lengths should panic");
 
@@ -115,8 +109,8 @@ fn tv_panicking_write_leaves_previous_file_intact() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(4).0,
-            centroids: test_codebook(4).1,
+            boundaries: test_codebook(4, 32).0,
+            centroids: test_codebook(4, 32).1,
         }
     );
     assert_eq!(s, scales);
@@ -131,11 +125,11 @@ fn tvim_panicking_write_leaves_previous_file_intact() {
     let packed = vec![0x55u8; blocked_len(2, 16, 2)];
     let scales = vec![0.5f32, 1.0];
     let ids = vec![7u64, 9];
-    let cb = test_codebook(2);
+    let cb = test_codebook(2, 16);
     write_id_map(&path, 2, 16, 2, &packed, &cb.0, &cb.1, &scales, &[], &[], &ids).unwrap();
 
     let result = catch_unwind(AssertUnwindSafe(|| {
-        write_id_map(&path, 2, 16, 2, &packed, &test_codebook(2).0, &test_codebook(2).1, &scales, &[1.0; 3], &[1.0; 3], &ids)
+        write_id_map(&path, 2, 16, 2, &packed, &test_codebook(2, 16).0, &test_codebook(2, 16).1, &scales, &[1.0; 3], &[1.0; 3], &ids)
     }));
     assert!(result.is_err(), "mismatched TQ+ lengths should panic");
 
@@ -146,8 +140,8 @@ fn tvim_panicking_write_leaves_previous_file_intact() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(2).0,
-            centroids: test_codebook(2).1,
+            boundaries: test_codebook(2, 16).0,
+            centroids: test_codebook(2, 16).1,
         }
     );
     assert_eq!(s, scales);
@@ -164,7 +158,7 @@ fn tv_successful_overwrite_leaves_no_temp_files() {
 
     let packed = vec![0xCDu8; blocked_len(4, 32, 3)];
     let scales = vec![1.0f32, 2.0, 3.0];
-    let cb = test_codebook(4);
+    let cb = test_codebook(4, 32);
     write(&path, 4, 32, 3, &packed, &cb.0, &cb.1, &scales, &[], &[]).unwrap();
 
     let (_, _, n, p, s, _, _) = load(&path).unwrap();
@@ -173,8 +167,8 @@ fn tv_successful_overwrite_leaves_no_temp_files() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(4).0,
-            centroids: test_codebook(4).1,
+            boundaries: test_codebook(4, 32).0,
+            centroids: test_codebook(4, 32).1,
         }
     );
     assert_eq!(s, scales);
@@ -198,7 +192,7 @@ fn tv_write_stores_n_vectors_over_u32_max_exactly() {
     let path = dir.join("index.tv");
 
     let n = (1usize << 32) + 2;
-    let cb = test_codebook(2);
+    let cb = test_codebook(2, 8);
     write(&path, 2, 8, n, &[], &cb.0, &cb.1, &[], &[], &[])
         .expect("v4 write must accept n_vectors over u32::MAX");
     let bytes = std::fs::read(&path).unwrap();
@@ -223,7 +217,7 @@ fn expect_load_rejects(
 ) {
     let dir = temp_dir(name);
     let path = dir.join("bad.tv");
-    let cb = test_codebook(4);
+    let cb = test_codebook(4, 8);
     write(&path, 4, 8, 1, &[0x12u8; 128], &cb.0, &cb.1, scales, tqplus_shift, tqplus_scale)
         .unwrap();
     let err = load(&path).expect_err("bad float payload must be rejected at load");
@@ -267,7 +261,7 @@ fn load_id_map_rejects_zero_tqplus_scale() {
     // Same core reader as .tv — one case to pin the shared path.
     let dir = temp_dir("tvim-tqscale-zero");
     let path = dir.join("bad.tvim");
-    let cb = test_codebook(4);
+    let cb = test_codebook(4, 8);
     write_id_map(&path, 4, 8, 1, &[0x12u8; 128], &cb.0, &cb.1, &[1.0], &[0.0; 8], &[0.0; 8], &[42])
         .unwrap();
     let err = load_id_map(&path).expect_err("zero tqplus_scale must be rejected at load");
@@ -308,7 +302,7 @@ const EMPTY_BUDGET: Duration = Duration::from_secs(2);
 
 fn load_empty_large_dim(dir: &PathBuf) -> TurboQuantIndex {
     let path = dir.join("empty.tv");
-    let cb = test_codebook(4);
+    let cb = test_codebook(4, EMPTY_DIM);
     write(&path, 4, EMPTY_DIM, 0, &[], &cb.0, &cb.1, &[], &[], &[]).unwrap();
     TurboQuantIndex::load(&path).unwrap()
 }
@@ -400,7 +394,7 @@ fn large_payload_write_matches_streamed_writer_in_both_durability_modes() {
             })
             .collect::<Vec<u8>>()
     };
-    let cb = test_codebook(bit_width);
+    let cb = test_codebook(bit_width, dim);
     let scales = vec![1.0f32; n_vectors];
 
     let mut streamed = Vec::new();

--- a/turbovec/tests/io_v6.rs
+++ b/turbovec/tests/io_v6.rs
@@ -511,3 +511,97 @@ fn incremental_blocked_cache_serializes_identically_to_cold_rebuild() {
     assert_eq!(a.indices, b.indices);
     assert_eq!(a.scores, b.scores);
 }
+
+// ---------------------------------------------------------------------------
+// #320 — the embedded codebook is verified against a recomputation
+// ---------------------------------------------------------------------------
+//
+// The codebook is a pure analytic function of (bit_width, dim), never
+// fitted to data, so a well-formed file's embedded arrays must equal
+// `expected_codebook(bit_width, dim)`. Before this check, centroids were
+// only tested for finiteness and |v| <= 1 (the strict-monotonicity check
+// covered boundaries alone), so a collapsed or reversed centroid array
+// loaded clean and silently mis-scored every query. Chosen behaviour:
+// REJECT the file with a named InvalidData error rather than silently
+// substituting the recomputed arrays — the file is corrupt or tampered
+// and its codes may be untrustworthy too. File-format semantics are
+// unchanged: every file this build (or any prior build) writes still
+// loads.
+
+/// v6 codebook offsets for bit_width=4: boundaries (15 f32) at the
+/// payload start, centroids (16 f32) immediately after.
+const OFF_CENTROIDS: usize = OFF_PAYLOAD + 15 * 4;
+
+fn v6_bytes_with_centroids(f: impl Fn(&mut [f32])) -> Vec<u8> {
+    let mut bytes = build_index().to_bytes();
+    assert_eq!(bytes[OFF_VERSION], 6, "fixture must be a v6 file");
+    let mut centroids: Vec<f32> = (0..16)
+        .map(|i| {
+            let o = OFF_CENTROIDS + i * 4;
+            f32::from_le_bytes(bytes[o..o + 4].try_into().unwrap())
+        })
+        .collect();
+    f(&mut centroids);
+    for (i, &c) in centroids.iter().enumerate() {
+        let o = OFF_CENTROIDS + i * 4;
+        bytes[o..o + 4].copy_from_slice(&c.to_le_bytes());
+    }
+    bytes
+}
+
+fn expect_codebook_rejected(bytes: &[u8], case: &str) {
+    // Streamed loader (from_bytes).
+    let err = TurboQuantIndex::from_bytes(bytes)
+        .expect_err(&format!("{case} centroids must be rejected by from_bytes"));
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid codebook centroids"),
+        "expected a named codebook error for {case}, got: {err}",
+    );
+
+    // Fast path-based loader (load), which validates through the same
+    // helper but on the mmap/pread prefix.
+    let dir = temp_dir(&format!("v6-codebook-{case}"));
+    let path = dir.join("tampered.tv");
+    std::fs::write(&path, bytes).unwrap();
+    let err = TurboQuantIndex::load(&path)
+        .expect_err(&format!("{case} centroids must be rejected by load"));
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+    assert!(
+        err.to_string().contains("invalid codebook centroids"),
+        "expected a named codebook error for {case}, got: {err}",
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn v6_untampered_codebook_still_loads() {
+    let bytes = v6_bytes_with_centroids(|_| {});
+    let idx = TurboQuantIndex::from_bytes(&bytes).expect("pristine file must load");
+    assert_eq!(idx.len(), N);
+}
+
+#[test]
+fn v6_collapsed_centroids_are_rejected() {
+    // All 16 centroids set to the same in-support value: finite,
+    // |v| <= 1, boundaries untouched and still strictly increasing.
+    // Every score collapses to a constant and recall goes to 0.
+    expect_codebook_rejected(&v6_bytes_with_centroids(|c| c.fill(0.05)), "collapsed");
+}
+
+#[test]
+fn v6_reversed_centroids_are_rejected() {
+    // Monotone decreasing instead of increasing — passes every
+    // value-level check, inverts the decode of every code.
+    expect_codebook_rejected(&v6_bytes_with_centroids(|c| c.reverse()), "reversed");
+}
+
+#[test]
+fn v6_single_perturbed_centroid_is_rejected() {
+    // A shift far below the quantizer's spacing but far above the
+    // cross-build float tolerance.
+    expect_codebook_rejected(
+        &v6_bytes_with_centroids(|c| c[7] += 0.01),
+        "perturbed",
+    );
+}

--- a/turbovec/tests/io_versioning.rs
+++ b/turbovec/tests/io_versioning.rs
@@ -40,17 +40,11 @@ fn expected_native(seq: &[u8]) -> Vec<u8> {
     seq.to_vec()
 }
 
-fn test_codebook(bit_width: usize) -> (Vec<f32>, Vec<f32>) {
-    // Strictly-increasing boundaries in (-1, 1) — the loader validates
-    // monotonicity; centroids only need to be finite with |v| <= 1.
-    let n_levels = 1usize << bit_width;
-    let boundaries = (0..n_levels - 1)
-        .map(|i| -0.9 + 1.8 * i as f32 / (n_levels - 1) as f32)
-        .collect();
-    let centroids = (0..n_levels)
-        .map(|i| -0.95 + 1.9 * i as f32 / n_levels as f32)
-        .collect();
-    (boundaries, centroids)
+fn test_codebook(bit_width: usize, dim: usize) -> (Vec<f32>, Vec<f32>) {
+    // The v6 loader verifies the embedded codebook against the canonical
+    // codebook(bit_width, dim) (#320), so fixture files must embed the
+    // real one, not a synthetic monotone stand-in.
+    turbovec::expected_codebook(bit_width, dim)
 }
 
 fn blocked_len(bit_width: usize, dim: usize, n_vectors: usize) -> usize {
@@ -79,7 +73,7 @@ fn tv_round_trip_current_format() {
 
     // Round-trip with empty TQ+ calibration (identity); behaviour identical
     // to a v2 file otherwise. Separate test below covers populated calibration.
-    let cb = test_codebook(bit_width);
+    let cb = test_codebook(bit_width, dim);
     write(&path, bit_width, dim, n_vectors, &packed, &cb.0, &cb.1, &scales, &[], &[]).unwrap();
     let (bw, d, n, p, s, shift, scale_tq) = load(&path).unwrap();
 
@@ -90,8 +84,8 @@ fn tv_round_trip_current_format() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(bit_width).0,
-            centroids: test_codebook(bit_width).1,
+            boundaries: test_codebook(bit_width, dim).0,
+            centroids: test_codebook(bit_width, dim).1,
         }
     );
     assert_eq!(s, scales);
@@ -111,7 +105,7 @@ fn tv_round_trip_with_tqplus_calibration() {
     let shift: Vec<f32> = (0..dim).map(|d| d as f32 * 0.01).collect();
     let scale_tq: Vec<f32> = (0..dim).map(|d| 1.0 + d as f32 * 0.02).collect();
 
-    let cb = test_codebook(bit_width);
+    let cb = test_codebook(bit_width, dim);
     write(&path, bit_width, dim, n_vectors, &packed, &cb.0, &cb.1, &scales, &shift, &scale_tq).unwrap();
     let (bw, d, n, p, s, loaded_shift, loaded_scale) = load(&path).unwrap();
 
@@ -122,8 +116,8 @@ fn tv_round_trip_with_tqplus_calibration() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(bit_width).0,
-            centroids: test_codebook(bit_width).1,
+            boundaries: test_codebook(bit_width, dim).0,
+            centroids: test_codebook(bit_width, dim).1,
         }
     );
     assert_eq!(s, scales);
@@ -167,7 +161,7 @@ fn tvim_round_trip_current_format() {
     let scales = vec![0.5f32, 1.0, 1.5, 2.0];
     let ids = vec![100u64, 200, 300, 400];
 
-    let cb = test_codebook(bit_width);
+    let cb = test_codebook(bit_width, dim);
     write_id_map(&path, bit_width, dim, n_vectors, &packed, &cb.0, &cb.1, &scales, &[], &[], &ids).unwrap();
     let (bw, d, n, p, s, shift, scale_tq, slot_to_id) = load_id_map(&path).unwrap();
 
@@ -178,8 +172,8 @@ fn tvim_round_trip_current_format() {
         p,
         CodePayload::BlockedNative {
             codes: expected_native(&packed),
-            boundaries: test_codebook(bit_width).0,
-            centroids: test_codebook(bit_width).1,
+            boundaries: test_codebook(bit_width, dim).0,
+            centroids: test_codebook(bit_width, dim).1,
         }
     );
     assert_eq!(s, scales);
@@ -227,7 +221,7 @@ fn tv_truncated_payload_errors_cleanly() {
     let n_vectors = 5;
     let packed = vec![0xCDu8; blocked_len(bit_width, dim, n_vectors)];
     let scales = vec![1.0f32; n_vectors];
-    let cb = test_codebook(bit_width);
+    let cb = test_codebook(bit_width, dim);
     write(&path, bit_width, dim, n_vectors, &packed, &cb.0, &cb.1, &scales, &[], &[]).unwrap();
 
     // Truncate the file to half its size.


### PR DESCRIPTION
Batch of small, independent, confirmed core-crate bugs. Each fix is one commit-sized change with its own test evidence.

## #294 — masked-search atomic in the hot loop (perf)

`BLOCKS_SKIPPED_BY_MASK.fetch_add` fired once per *skipped* block on a process-global `AtomicU64` that was live in release builds, so the more selective the allowlist the more RMWs contended on one cache line.

Gated behind a new off-by-default `mask-skip-counter` feature. A self dev-dependency (`turbovec = { path = ".", features = [...] }`) keeps the crate's own `block_skip_path_actually_fires_under_selective_mask` test running, so the skip path is still activation-tested.

**Bench (M-series, D=128, bw=4, allowlist = 10 of n slots, best of 20 reps, external crate so the feature is genuinely off in one build):**

| case | n | counter live | counter removed |
|---|---|---|---|
| nq=1 masked, default threads | 1.6M | 1.689 ms | 1.669 ms |
| nq=8 masked, default threads | 1.6M | 5.473 ms | 5.214 ms |
| nq=1 masked, `RAYON_NUM_THREADS=1` | 1.6M | 1.779 ms | 1.595 ms |
| nq=8 masked, `RAYON_NUM_THREADS=1` | 1.6M | 8.457 ms | 8.188 ms |
| nq=8 masked, default threads | 800k | 2.670 ms | 2.473 ms |

**No regression at either thread count, ~1–10% better.** Note the caveat below: the issue's headline 4–7x did not reproduce here.

## #292 — `set_len` before write publishes uninitialized memory

`encode.rs` created live `&mut [f32]` / `&mut [u8]` slices over uninitialized bytes at three sites (rotation buffer, packed output, calibration column scratch). No uninit read existed, but the pattern is UB by the letter of the model and defeats Miri.

All three now use `spare_capacity_mut()` + `MaybeUninit::write`, setting the length only after every element is written — the pattern `par_copy.rs` already uses. This also closes the wrinkle the issue noted: a panic mid-rotation now leaves an *empty* scratch for `add_2d`'s unwind guard rather than an uninit-length `Vec`.

The rotation and pack loops write through a per-worker staging row, costing one extra memcpy per row. Interleaved A/B of `add_2d` (n=200k, D=128) put before and after **within measurement noise at both default threads and `RAYON_NUM_THREADS=1`** (MT ~92 ms both; ST ~185 ms both). Removing the copy entirely would require a `MaybeUninit` variant of every NEON/AVX/scalar `permute_gather` kernel — noted in a code comment as the follow-up if it ever shows up in a profile.

## #300 — `with_pool` leaks `POOL_IN_FLIGHT` on unwind

`fetch_add` → `install(f)` → `fetch_sub` skipped the decrement when `f` unwound, leaving `pool_idle()` false forever and silently demoting every later `add()` to the serial copy path. Replaced with a `struct InFlight` Drop guard. Latent (no current call site can panic), so this is hardening — verified by construction and by the full Python suite still passing.

## #291 — x86 dispatch gates don't check all declared CPU features

The AVX2 paths gated on `is_x86_feature_detected!("avx2")` alone while the kernels are `#[target_feature(enable = "avx2", enable = "fma")]` and call `_mm256_fmadd_ps`; the AVX-512 path gated on `avx512bw && avx512f` alone while `search_multi_query_avx512bw` executes 256-bit AVX2/FMA loads and epilogue helpers. Added the missing terms at all three gates, matching the house pattern documented at `rotation.rs:410-414`.

## #320 — `validate_codebook` never checks centroids

Centroids were validated only for finiteness and `|v| <= 1`; the strict-monotonicity check applied to boundaries only. A collapsed or reversed centroid array in an untrusted v6 file loaded clean and silently returned garbage (recall 0).

The codebook is not data-fitted — it is a pure analytic function of `(bit_width, dim)` — so the loader now recomputes `codebook(bit_width, dim)` and **rejects** any file whose embedded arrays disagree.

- **Chosen behaviour: reject, not silently substitute.** A file whose codebook is wrong is corrupt or tampered, and its codes are not trustworthy either; a named `InvalidData` error is better than quietly loading different data than the file describes. Documented at the check.
- **File-format semantics are unchanged** — every file this or any prior build writes still loads. Comparison uses a `1e-4` tolerance so a build whose libm rounds differently still loads; any tamper large enough to move scores exceeds it by orders of magnitude.
- Applied to **both** v6 loaders (streamed `from_bytes` and the fast mmap path).
- `TurboQuantIndex`-external callers that serialize through the raw `io` writers now need the real codebook, so `turbovec::expected_codebook(bit_width, dim)` is exposed; the in-tree test fixtures were switched to it.

New tests in `io_v6.rs` build a real index, tamper the embedded centroids at the known file offset, and assert both loaders reject: `collapsed` (all 16 set to 0.05), `reversed`, and `perturbed` (one centroid +0.01), plus a pristine-file control that must still load.

## #286 — deliberately NOT converted to an error

The issue proposed an `AddError` for sub-threshold norms. **I did not make that change, and this PR does not close #286.**

Implementing it broke four existing Python tests — `test_{langchain,llama,haystack,agno}_zero_vectors_score_zero_under_cosine` — which pin *as desired behaviour* that a zero document embedding is storable and scores 0 under cosine. That is the conventional cosine similarity of a zero vector, and the framework integrations rely on it, so a hard error would be a breaking change to the integrations rather than a bug fix — not something to slip into a batch of small independent fixes.

Instead this PR takes the issue's stated fallback ("or at minimum document the threshold"): the threshold is now the documented public constant `MIN_INPUT_NORM` with the rationale, `add`/`add_2d` docs state the behaviour explicitly, and two tests in `input_validation.rs` pin it (a zero-norm vector is stored, counted in `len()`, scores exactly 0, and ranks below every vector with a real direction). **#286 should stay open** for Ryan to decide whether the integrations' contract or a hard error wins.

## Test evidence

- `cargo test --release -p turbovec` — **all 20 test binaries green** (245 tests + 3 doctests).
- Python suite — `maturin develop --release` in a venv, then `pytest turbovec-python/tests/` with the four integration extras installed: **664 passed, 12 skipped**.
- `cargo check -p turbovec --target x86_64-unknown-linux-gnu` — clean (see caveats).
- `cargo clippy --release -p turbovec --all-targets` — no new warnings (the ~40 lib warnings are pre-existing on `main`).

## Caveats

- **The #294 benchmark does not reproduce the issue's headline numbers.** #294 reports 4.0x/7.1x at n=1.6M on M-series; I measure 1–10%. The counter *is* firing at the expected rate (verified: 24,999 atomics for one nq=1 query at n=800k, 25,000 total blocks). The likely reason the nq=1 case barely moves is that a masked nq=1 search does not take the block-parallel path (that gate requires `mask.is_none()`), so those RMWs are uncontended. The change is still unambiguously correct — removing a global atomic from a hot loop — and regresses nothing, but the 4–7x claim should be treated as unconfirmed.
- **#291 and the AVX-512 half of #294/#320 could not be executed** — this is an arm64 machine. Verified by careful reading plus `cargo check --target x86_64-unknown-linux-gnu` (lib, tests, and with the new feature enabled). The gate changes need a real x86 run, ideally on a `-cpu Haswell,-fma`-style model, to be confirmed end to end.
- `cargo test --release` on the **workspace** fails to link `turbovec-python`'s lib tests on macOS (pyo3 `extension-module`). This is **pre-existing on `main`** — verified by stashing — and is why the core crate and the Python suite were run separately, matching CI.
- The `mask-skip-counter` self dev-dependency means the counter is compiled into all of the crate's *own* dev targets (tests, examples, benches). Downstream release builds are unaffected, but in-tree benchmarks must be run from an external crate to measure the counter-free path — that is how the numbers above were produced.

Closes #294, Closes #292, Closes #300, Closes #291, Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)
