### PR TITLE
fix: enforce pool and GIL discipline at the binding's remaining un-guarded sites

### DIFF
--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -151,6 +151,10 @@ fn shape_err(e: numpy::ndarray::ShapeError) -> PyErr {
 /// Rust contract), which would otherwise surface to Python as an uncatchable
 /// `PanicException`. `add` already maps the same condition to `ValueError`;
 /// this keeps `search` consistent.
+///
+/// The scan splits across the current rayon pool once the input exceeds one
+/// chunk, so callers route it through [`with_pool`] then — see
+/// [`validate_queries_pooled`].
 fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
     if let Some((vi, ci, v)) = turbovec_core::first_invalid_coord(values, dim) {
         return Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -159,6 +163,25 @@ fn validate_queries(values: &[f32], dim: usize) -> PyResult<()> {
         )));
     }
     Ok(())
+}
+
+/// [`validate_queries`], run in the fork-safe pool when — and only when —
+/// the scan actually splits (issue #288). A splitting scan on the calling
+/// thread injects work into rayon's global pool, which this module pins to
+/// a one-thread sentinel whose worker is dead in a forked child: the #147
+/// deadlock, reachable from an ordinary `search` with >64K query floats.
+///
+/// The gate is the chunk threshold rather than the search's own pooling
+/// predicate: a sub-chunk buffer is a single `par_chunks` item that rayon
+/// folds inline without entering any pool, so the small path is safe *and*
+/// must stay free of the ~70 us `install` handoff — routing it through
+/// `with_pool_if` instead measurably regresses small searches.
+fn validate_queries_pooled(values: &[f32], dim: usize) -> PyResult<()> {
+    if turbovec_core::validation_parallelizes(values.len()) {
+        with_pool(|| validate_queries(values, dim))?
+    } else {
+        validate_queries(values, dim)
+    }
 }
 
 /// Extract a bytes-like argument (`bytes` / `bytearray`) into an owned
@@ -334,18 +357,24 @@ impl TurboQuantIndex {
         // dim on first call) cases.
         //
         // Single-row adds take the same inline bypass as nq==1 search —
-        // every rayon bridge in a one-row *encode* has length 1 and
-        // folds on the calling thread — but only when the packed rows
-        // are already materialized. The first mutation after a v6 load
-        // lazily rebuilds them from the blocked cache, a payload-sized
-        // parallel job regardless of row count, so that one call must
-        // run in the fork-safe pool. Probing under the write guard makes
-        // the check race-free.
+        // the rayon bridges in a one-row *encode* have length 1 and fold
+        // on the calling thread — but three conditions must hold. The
+        // packed rows must already be materialized: the first mutation
+        // after a v6 load rebuilds them from the blocked cache, a
+        // payload-sized parallel job regardless of row count. And the
+        // input-validation scan must not split — it chunks by float
+        // count, not by row, so a single wide row can exceed one chunk
+        // and inject work into the global sentinel pool (issue #321;
+        // #288 is the same hole on the search side). Gating on
+        // `validation_parallelizes` states that dependency instead of
+        // resting on `MAX_DIM` happening to be below the chunk length.
+        // Probing under the write guard makes the check race-free.
         let n_rows = if dim == 0 { 0 } else { slice.len() / dim };
+        let validation_splits = turbovec_core::validation_parallelizes(owned.len());
         py.detach(|| {
             let mut guard = lock_write(&self.inner);
             let inner = &mut *guard;
-            let pooled = n_rows > 1 || !inner.packed_ready();
+            let pooled = n_rows > 1 || validation_splits || !inner.packed_ready();
             with_pool_if(pooled, || inner.add_2d(&owned, dim))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
@@ -418,7 +447,7 @@ impl TurboQuantIndex {
                     )));
                 }
             }
-            validate_queries(&q_owned, ncols)?;
+            validate_queries_pooled(&q_owned, ncols)?;
             if let Some(m) = mask_owned.as_deref() {
                 let expected = inner.len();
                 if m.len() != expected {
@@ -554,7 +583,11 @@ impl TurboQuantIndex {
             // fork-safe pool (lock on the calling thread, never inside
             // `with_pool`). The probe can only go false→true, so a race
             // merely sends a ready index down the slow path harmlessly.
-            let ready = lock_read(&self.inner).packed_ready();
+            //
+            // The probe itself runs detached: `read()` blocks for the
+            // whole duration of a concurrent bulk add, and blocking with
+            // the GIL held stalls every Python thread (issue #289).
+            let ready = py.detach(|| lock_read(&self.inner).packed_ready());
             let removed = if ready {
                 let mut inner = lock_write_gil_aware(py, &self.inner);
                 let len = inner.len();
@@ -712,15 +745,22 @@ impl IdMapIndex {
     /// never present, so they return `False`.
     fn remove(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            // Fast path: packed rows materialized (every case except the
-            // first mutation after a v6 load) — O(1), no detach, no
-            // pool. Slow path: the mutation lazily rebuilds the packed
-            // rows from the blocked cache (parallel O(n·dim)), so it
-            // detaches and runs in the fork-safe pool. The probe can
-            // only go false→true, so a race merely sends a ready index
-            // down the slow path harmlessly.
+            // Fast path: both lazy structures already materialized —
+            // O(1), no pool. Slow path (the first mutation after a v6
+            // load): the mutation rebuilds the packed rows from the
+            // blocked cache (parallel O(n·dim)) and materializes the
+            // id → slot map (serial O(n) — issue #319), so it detaches
+            // and runs in the fork-safe pool. Both probes only go
+            // false→true, so a race merely sends a ready index down the
+            // slow path harmlessly; they run detached because `read()`
+            // blocks for the duration of a concurrent bulk add and doing
+            // that with the GIL held stalls every Python thread (#289).
             Some(v) => {
-                if lock_read(&self.inner).packed_ready() {
+                let ready = py.detach(|| {
+                    let guard = lock_read(&self.inner);
+                    guard.packed_ready() && guard.slots_ready()
+                });
+                if ready {
                     lock_write_gil_aware(py, &self.inner).remove(v)
                 } else {
                     py.detach(|| {
@@ -804,7 +844,7 @@ impl IdMapIndex {
                     )));
                 }
             }
-            validate_queries(&q_owned, ncols)?;
+            validate_queries_pooled(&q_owned, ncols)?;
             if let Some(allow) = allow_owned.as_deref() {
                 let mut unknown: Vec<u64> = Vec::new();
                 for &id in allow {
@@ -1016,11 +1056,15 @@ impl IdMapIndex {
 //      handlers somehow miss, a changed PID forces a rebuild on any modern
 //      glibc where getpid is a live syscall.
 //
-// The nq==1 inline fast path (see `with_pool_if`) never enters any pool, so
-// a missed detection there is still safe: length-1 parallel bridges fold on
-// the calling thread. Only splitting workloads (nq>1 search, add, prepare)
-// enter a pool, and those all go through `current_pool`'s generation+PID
-// gate.
+// The inline fast paths (see `with_pool_if`) never enter any pool, so a
+// missed detection there is still safe: length-1 parallel bridges fold on
+// the calling thread. Every workload that can actually split enters a pool
+// and goes through `current_pool`'s generation+PID gate — nq>1 search,
+// prepare, and any add beyond a single row. The two remaining bypasses,
+// nq==1 search and a single-row add into a packed-ready index, are gated
+// so that they also pool whenever the input-validation scan would split
+// (`validation_parallelizes`); that gate is what closed #288/#321, where
+// the scan's chunking is by float count and does not follow row count.
 
 /// Bumped by every fork-detecting handler. A child's copy is CoW-inherited
 /// from the parent then incremented, so within a fork lineage the child's

--- a/turbovec-python/tests/test_fork_safety.py
+++ b/turbovec-python/tests/test_fork_safety.py
@@ -335,8 +335,44 @@ def scenario_v6_mutate_after_fork():
     emit(True, "v6-loaded mutations survive fork")
 
 
+def scenario_large_batch_search():
+    """Query validation is a `par_chunks(64K)` scan: above one chunk it
+    splits, and an un-pooled split injects work into the global sentinel
+    pool whose worker is dead in the child (issue #288). `scenario_probe`
+    tops out at nq=512 x DIM=96 = 49152 floats — one chunk, one short of
+    splitting — so this case is the one that hangs on the baseline.
+
+    `chunk_size=0` disables the Python-side interruptibility chunking so the
+    binding sees the whole batch regardless of BATCH_CHUNK_SIZE."""
+    np = _np()
+    import turbovec
+    n = 5000
+    tv = build_index(n, 0)
+    im = turbovec.IdMapIndex(dim=DIM)
+    im.add_with_ids(make_vecs(n, 1), np.arange(n, dtype=np.uint64))
+    # 1024 * 96 = 98304 floats -> 2 chunks. 683 is the exact boundary
+    # (65568 floats, one float past 64K).
+    ops = []
+    for nq in (683, 1024):
+        q = make_vecs(nq, nq)
+        ops.append(
+            ("TurboQuantIndex nq=%d" % nq,
+             lambda q=q: int(tv.search(q, k=5, chunk_size=0)[0].shape[0]))
+        )
+        ops.append(
+            ("IdMapIndex nq=%d" % nq,
+             lambda q=q: int(im.search(q, k=5, chunk_size=0)[0].shape[0]))
+        )
+    for name, fn in ops:
+        res = run_forked(fn)
+        if res[0] != "ok":
+            return emit(False, "child op %r -> %r" % (name, res))
+    emit(True, "splitting-validation searches survive fork")
+
+
 SCENARIOS = {
     "probe": scenario_probe,
+    "large_batch_search": scenario_large_batch_search,
     "correctness": scenario_correctness,
     "osfork_fresh": scenario_osfork_fresh,
     "fork_before_use": scenario_fork_before_use,
@@ -412,6 +448,14 @@ def test_mp_fork_fresh():
 def test_child_probe_ops():
     """nq=1/64/512 search, add 1/64, fresh-index add — all must survive fork."""
     _run("probe")
+
+
+@pytest.mark.skipif(not _IS_LINUX, reason="fork-safety is a Linux concern; macOS aborts a forked child after framework (Accelerate) init and defaults multiprocessing to spawn, so these fork cases only run on the Linux CI gate")
+def test_child_large_batch_search():
+    """A batch big enough to split query validation (>64K floats) must not
+    wedge a forked child — issue #288, the #147 invariant re-broken at the
+    validation call site."""
+    _run("large_batch_search")
 
 
 @pytest.mark.skipif(not _IS_LINUX, reason="fork-safety is a Linux concern; macOS aborts a forked child after framework (Accelerate) init and defaults multiprocessing to spawn, so these fork cases only run on the Linux CI gate")

--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -16,6 +16,7 @@ absolute floor, not a throughput ratio.
 """
 from __future__ import annotations
 
+import sys
 import threading
 import time
 
@@ -150,6 +151,157 @@ def test_len_blocked_on_add_does_not_hold_gil(vectors):
         f"background thread made no mid-window progress while len() was "
         f"blocked, on every attempt ({details}): the blocked call is "
         "holding the GIL"
+    )
+
+
+def _blocked_behind_add(make_index, seed, bulk, op):
+    """Run ``op()`` while ``bulk()`` holds the index write lock on another
+    thread, with a pure-Python ticker measuring interpreter starvation.
+
+    Returns ``(block_seconds, worst_ticker_gap_seconds)`` from the attempt
+    whose block was longest. The assertion is *relative* — a detached block
+    leaves the ticker running, a GIL-held one freezes it for the whole block
+    — so it holds on any machine speed without a tuned absolute threshold.
+    """
+    best = (0.0, 0.0)
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(0.0005)  # keep baseline ticker gaps well under 1 ms
+    try:
+        for _ in range(8):
+            idx = make_index()
+            seed(idx)
+            errors: list[BaseException] = []
+            stop = threading.Event()
+            gaps: list[float] = []
+
+            def ticker() -> None:
+                last = time.perf_counter()
+                while not stop.is_set():
+                    now = time.perf_counter()
+                    gaps.append(now - last)
+                    last = now
+
+            def adder() -> None:
+                try:
+                    bulk(idx)
+                except BaseException as exc:  # pragma: no cover - failure path
+                    errors.append(exc)
+
+            tk = threading.Thread(target=ticker)
+            tk.start()
+            t = threading.Thread(target=adder)
+            t.start()
+            time.sleep(0.002)  # let the add reach the write lock
+            del gaps[:]
+            t0 = time.perf_counter()
+            op(idx)
+            block = time.perf_counter() - t0
+            gap = max(gaps) if gaps else 0.0
+            stop.set()
+            tk.join()
+            t.join()
+            assert not errors, f"add raised: {errors}"
+            if block > best[0]:
+                best = (block, gap)
+    finally:
+        sys.setswitchinterval(old_interval)
+    return best
+
+
+# ``chunk_size=0`` disables the Python-side interruptibility chunking, so the
+# bulk add is one call holding the write lock for its whole duration —
+# chunked, it releases between slices and never blocks anything long enough
+# to measure.
+_ID_MAP_CASES = {
+    "remove": lambda idx: idx.remove(0),
+    "swap_remove": lambda idx: idx.swap_remove(0),
+}
+
+
+@pytest.mark.parametrize("op_name", sorted(_ID_MAP_CASES))
+def test_removal_blocked_on_add_does_not_hold_gil(vectors, op_name):
+    """``remove`` / ``swap_remove`` probe ``packed_ready()`` before taking
+    the write lock. That probe blocks for the full duration of a concurrent
+    bulk add, so it must run detached — with the GIL held it freezes every
+    Python thread (issue #289).
+    """
+    ids = np.arange(N, dtype=np.uint64)
+    if op_name == "swap_remove":
+        block, gap = _blocked_behind_add(
+            lambda: TurboQuantIndex(dim=DIM, bit_width=4),
+            lambda idx: idx.add(vectors[:1000]),
+            lambda idx: idx.add(vectors, chunk_size=0),
+            _ID_MAP_CASES[op_name],
+        )
+    else:
+        block, gap = _blocked_behind_add(
+            lambda: IdMapIndex(dim=DIM, bit_width=4),
+            lambda idx: idx.add_with_ids(vectors[:1000], ids[:1000]),
+            lambda idx: idx.add_with_ids(vectors[1000:], ids[1000:], chunk_size=0),
+            _ID_MAP_CASES[op_name],
+        )
+
+    if block < 0.01:
+        pytest.skip(
+            f"{op_name} never blocked behind the add (max {block * 1e3:.1f} ms); "
+            "nothing to measure on this machine"
+        )
+    assert gap < 0.5 * block, (
+        f"{op_name} blocked {block * 1e3:.0f} ms and the ticker thread stalled "
+        f"{gap * 1e3:.0f} ms of it: the probe is blocking with the GIL held"
+    )
+
+
+def test_first_removal_after_load_does_not_hold_gil(tmp_path, vectors):
+    """The first mutation after a load materializes both lazy structures —
+    the packed rows and (issue #319) the O(n) id -> slot map. Neither may be
+    built with the GIL held, so ``remove`` must only take its attached fast
+    path once *both* are already materialized.
+    """
+    n = 200_000
+    ids = np.arange(n, dtype=np.uint64)
+    src = IdMapIndex(dim=DIM, bit_width=4)
+    src.add_with_ids(vectors[:n], ids)
+    path = str(tmp_path / "i.tvim")
+    src.write(path)
+    del src
+
+    idx = IdMapIndex.load(path)
+    stop = threading.Event()
+    gaps: list[float] = []
+
+    def ticker() -> None:
+        last = time.perf_counter()
+        while not stop.is_set():
+            now = time.perf_counter()
+            gaps.append(now - last)
+            last = now
+
+    old_interval = sys.getswitchinterval()
+    sys.setswitchinterval(0.0005)
+    try:
+        tk = threading.Thread(target=ticker)
+        tk.start()
+        time.sleep(0.05)
+        del gaps[:]
+        t0 = time.perf_counter()
+        idx.remove(7)
+        block = time.perf_counter() - t0
+        gap = max(gaps) if gaps else 0.0
+        stop.set()
+        tk.join()
+    finally:
+        sys.setswitchinterval(old_interval)
+
+    if block < 0.01:
+        pytest.skip(
+            f"first remove after load took only {block * 1e3:.1f} ms; "
+            "nothing to measure on this machine"
+        )
+    assert gap < 0.5 * block, (
+        f"the first remove after a load took {block * 1e3:.0f} ms and froze "
+        f"the ticker thread for {gap * 1e3:.0f} ms of it: the lazy rebuild is "
+        "running with the GIL held"
     )
 
 

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -31,6 +31,14 @@ use statrs::distribution::{Beta, ContinuousCDF};
 
 use crate::rotation::Rotation;
 
+/// Chunk length of the invalid-coordinate scan. Public through
+/// [`crate::validation_parallelizes`] because the Python binding must know
+/// whether a given input splits: at or below one chunk the scan folds on the
+/// calling thread and enters no pool, above it rayon injects work into
+/// whatever pool is current (issue #288). Retuning this therefore changes
+/// where the binding routes validation — the two move together.
+pub(crate) const VALIDATE_CHUNK: usize = 64 * 1024;
+
 /// Parallel invalid-coordinate scan backing
 /// [`crate::first_invalid_coord`]. Fixed chunks reduced by minimum flat
 /// index, so the reported (vector, coord, value) is identical to a
@@ -41,7 +49,6 @@ pub(crate) fn par_first_invalid_coord(
     dim: usize,
     max_magnitude: f32,
 ) -> Option<(usize, usize, f32)> {
-    const VALIDATE_CHUNK: usize = 64 * 1024;
     let first = values
         .par_chunks(VALIDATE_CHUNK)
         .enumerate()

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -342,6 +342,15 @@ impl IdMapIndex {
         self.inner.packed_ready()
     }
 
+    /// True when the lazy id → slot map is already materialized. A v6 load
+    /// leaves it empty (see [`Self::ids`]), so the first `remove` after a
+    /// load pays an O(n) map build; callers that must not stall on that
+    /// (the Python binding, which would hold the GIL — issue #319) probe
+    /// this first. Like [`Self::packed_ready`] it only goes false → true.
+    pub fn slots_ready(&self) -> bool {
+        self.id_to_slot.get().is_some()
+    }
+
     /// Serialize to a `.tvim` file — the inner quantized index plus the
     /// id-map side-tables. Round-trips exactly through [`Self::load`].
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -101,9 +101,19 @@ const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 ///     top-k against every query.
 pub fn first_invalid_coord(values: &[f32], dim: usize) -> Option<(usize, usize, f32)> {
     // The parallel scan lives in encode.rs — one of the audited rayon
-    // chokepoint files (fork safety, issue #147); binding entry points
-    // reach it inside `with_pool`.
+    // chokepoint files (fork safety, issue #147). Binding entry points
+    // must reach it inside `with_pool` whenever
+    // [`validation_parallelizes`] is true; below that threshold the scan
+    // is a single chunk folded on the calling thread and touches no pool.
     encode::par_first_invalid_coord(values, dim, MAX_INPUT_MAGNITUDE)
+}
+
+/// True when [`first_invalid_coord`] on `len` values splits into more than
+/// one rayon chunk, i.e. injects work into the current pool. Callers that
+/// must control which pool that is (the Python binding, whose global pool
+/// is a fork-unsafe sentinel — issue #288) gate on this.
+pub fn validation_parallelizes(len: usize) -> bool {
+    len > encode::VALIDATE_CHUNK
 }
 
 /// SIMD-blocked cache derived from `packed_codes`.

--- a/turbovec/tests/input_validation.rs
+++ b/turbovec/tests/input_validation.rs
@@ -233,3 +233,31 @@ fn id_map_search_panics_on_nan_query() {
     query[0] = f32::NAN;
     let _ = idx.search(&query, 1);
 }
+
+/// `validation_parallelizes` must mark the exact boundary at which
+/// `first_invalid_coord` splits across the current rayon pool. The Python
+/// binding gates its fork-safe-pool routing on this predicate (issues #288,
+/// #321), so the two must not drift: a buffer at the threshold folds on the
+/// calling thread and is safe to validate inline, one float past it injects
+/// work into whatever pool is current. If the underlying chunk length is
+/// retuned, update this test and re-check every binding call site that
+/// validates outside `with_pool`.
+#[test]
+fn validation_parallelizes_marks_the_chunk_boundary() {
+    const CHUNK: usize = 64 * 1024;
+    assert!(!turbovec::validation_parallelizes(0));
+    assert!(!turbovec::validation_parallelizes(CHUNK - 1));
+    assert!(!turbovec::validation_parallelizes(CHUNK));
+    assert!(turbovec::validation_parallelizes(CHUNK + 1));
+    assert!(turbovec::validation_parallelizes(CHUNK * 4));
+}
+
+/// A single maximum-width row must stay inside one validation chunk. The
+/// binding's single-row add bypass no longer *relies* on this (it gates on
+/// `validation_parallelizes` directly), but if this stops holding, one-row
+/// adds start paying a pool `install` — a silent latency change worth
+/// noticing deliberately rather than discovering in a benchmark.
+#[test]
+fn one_max_width_row_does_not_split_validation() {
+    assert!(!turbovec::validation_parallelizes(turbovec::MAX_DIM));
+}

--- a/turbovec/tests/lazy_init.rs
+++ b/turbovec/tests/lazy_init.rs
@@ -335,3 +335,42 @@ fn id_map_new_rejects_bad_dim() {
     let err = IdMapIndex::new(0, 4).err().unwrap();
     assert_eq!(err, turbovec::ConstructError::DimNotPositiveMultipleOf8(0));
 }
+
+/// `slots_ready()` must track the id → slot map's materialization exactly:
+/// the Python binding uses it to decide whether `remove` can run attached
+/// to the GIL, and a probe that reported "ready" while the map was still
+/// empty would put the O(n) build back under the GIL (issue #319).
+#[test]
+fn id_map_slots_ready_tracks_the_lazy_map() {
+    let n = 64;
+    let vectors = unit_vectors(n, DIM, 3);
+    let ids: Vec<u64> = (0..n as u64).collect();
+
+    // Every non-load construction path materializes the map eagerly.
+    let mut index = IdMapIndex::new(DIM, 4).unwrap();
+    assert!(index.slots_ready());
+    index.add_with_ids(&vectors, &ids).unwrap();
+    assert!(index.slots_ready());
+
+    let dir = std::env::temp_dir().join(format!("tv_slots_ready_{}", std::process::id()));
+    fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("i.tvim");
+    index.write(&path).unwrap();
+
+    // A load defers the build, and searching never triggers it.
+    let mut loaded = IdMapIndex::load(&path).unwrap();
+    assert!(!loaded.slots_ready());
+    loaded.search(&vectors[..DIM], 5);
+    assert!(!loaded.slots_ready());
+
+    // The first slot-consuming op pays for it, and it stays ready after.
+    assert!(loaded.remove(0));
+    assert!(loaded.slots_ready());
+
+    let mut loaded = IdMapIndex::load(&path).unwrap();
+    assert!(!loaded.slots_ready());
+    assert!(loaded.contains(1));
+    assert!(loaded.slots_ready());
+
+    fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Shared root cause

`turbovec-python/src/lib.rs` states both of the invariants these four defects break, and enforces neither:

- **:250-253** — *"Every method acquires the lock INSIDE `py.detach(..)` — even trivial O(1) calls"*, with `lock_write_gil_aware` at **:224** built specifically to honour it.
- **#147** — no work may reach the global rayon pool after a fork, because this module pins that pool to a one-thread sentinel whose worker does not exist in a forked child.

Because nothing *enforces* either one, every fix so far has landed at one call site while identical siblings stayed broken — the repo's most-repeated bug class. **#288 is literally the #147 invariant re-broken at a new site**, and the core's own doc comment at `turbovec/src/lib.rs:103-106` asserted the invariant held (*"binding entry points reach it inside `with_pool`"*) while it was being violated at two of them. #321's third item is the same hole a third time, surviving only on a coincidence.

The unifying fix is a single explicit predicate. `encode::VALIDATE_CHUNK` is now surfaced as `turbovec::validation_parallelizes(len)`, and **every** binding path that can reach `first_invalid_coord` outside a pool gates on it. The rule is no longer "this input is probably small enough" but "this input splits, therefore it pools".

---

## #288 — search with >64K query floats hangs forever in a forked child (HIGH)

**What.** `TurboQuantIndex.search` and `IdMapIndex.search` called `validate_queries` *outside* `with_pool_if`. That reaches `encode::par_first_invalid_coord`, a `par_chunks(64 * 1024)` with no size gate: at or below one chunk it folds on the calling thread, above it rayon splits onto the **global** sentinel pool. In a forked child that pool's worker is gone, so the call blocks on the latch forever — reachable from the most ordinary API call there is.

**Why it was missed.** `scenario_probe`'s largest batch is nq=512 × DIM=96 = 49152 floats — one chunk, *one short* of splitting. `test_rayon_chokepoint_completeness` cannot catch it either: the parallel site lives in allowlisted `encode.rs`; the defect is the call site.

**Fix.** New `validate_queries_pooled` routes validation through `with_pool` when — and only when — `validation_parallelizes(len)` is true.

Gating on the chunk threshold rather than on the search's own `pooled` predicate is deliberate, and matches the analysis already recorded on the issue: reusing `pooled` makes nq=1 on a large index pay a *second* `install` handoff, and routing the small path through `with_pool_if` costs the `in_forked_child()` check plus lost inlining. Staying inline below the threshold is safe because a sub-chunk buffer is a single `par_chunks` item that rayon folds on the calling thread without entering any pool. Validation also stays *before* the mask-length and allowlist-membership checks, so error messages are unchanged for inputs that violate both.

**Before / after** (macOS arm64, DIM=96, parent primes an index then forks; 15 s watchdog):

| queries | floats | before | after |
|---|---|---|---|
| nq=512 | 49152 | ok | ok |
| nq=683 | 65568 | **HANG** | ok |
| nq=1024 | 98304 | **HANG** | ok |
| nq=4096 | 393216 | **HANG** | ok |

**No latency regression** (same box, median of 200–2000 reps, 20k-vector index, `chunk_size=0`; two independent rounds each):

| | nq=1 | nq=8 | nq=512 | nq=1024 |
|---|---|---|---|---|
| main | 77.4 / 84.1 us | 373.1 / 369.2 us | 2562 / 2587 us | 4678 / 4700 us |
| this PR | 84.5 / 79.6 us | 374.4 / 372.2 us | 2548 / 2603 us | 4812 / 4934 us |

The small paths are byte-identical code and measure as noise. nq=1024 sits ~3% above main — one extra `install` on a call that already pays one, against a ~2.5% run-to-run spread within each build. I did not treat that as separable from noise on this machine.

---

## #321 (item 3) — the same hole in the single-row `add` path (LOW/latent)

**#334 deliberately left this item open for this PR**; its other two items (agno insert unwind, `next_u64` watermark validation) are not touched here.

**What.** `lib.rs:344` gated the pool on `n_rows > 1 || !inner.packed_ready()`, so a **1-row add into a packed-ready index runs outside the pool** while `add_2d` reaches `par_first_invalid_coord`. It is correct today only incidentally: `MAX_DIM = 16384` keeps one row under the 65536-float threshold. Nothing encoded that dependency — raising `MAX_DIM` past 65536 would have silently reintroduced the #288 hang here.

**Fix.** The predicate is now `n_rows > 1 || validation_splits || !inner.packed_ready()`. **Behaviour is unchanged at today's `MAX_DIM`** — this closes a latent hole and replaces a coincidence with a stated rule.

**Stale comments corrected**, as requested:
- `turbovec/src/lib.rs:103-106` claimed binding entry points reach `first_invalid_coord` inside `with_pool` — i.e. asserted #288 was fixed while it was live. Now states the threshold condition.
- `turbovec-python/src/lib.rs:990-993` claimed *"Only splitting workloads (nq>1 search, add, prepare) enter a pool"*, listing `add` unconditionally when a 1-row add bypassed it. Now names the two remaining bypasses and the gate on each.

---

## #289 — removals block on the index lock with the GIL held (MEDIUM)

**What.** `IdMapIndex::remove` (:723) and `TurboQuantIndex::swap_remove` (:557) called `lock_read(&self.inner).packed_ready()` while still attached to the GIL. If a bulk `add` holds the write lock, that probe blocks for the writer's full duration **with the GIL held**, stopping every Python thread — defeating the `lock_write_gil_aware` that runs immediately after it, which guards only the *write* acquisition and not the probe.

**Fix.** Both probes moved inside `py.detach`.

**Before / after** (400k × 256 bulk add holding the write lock via `chunk_size=0`, independent pure-Python ticker thread, `switchinterval=0.5 ms`, worst of 12 attempts). A detached block leaves the ticker running; a GIL-held one freezes it for the whole block:

| op | before: block / ticker gap | after: block / ticker gap |
|---|---|---|
| baseline (no op) | 0.000 s / 0.000 s | 0.005 s / 0.002 s |
| `len` (already correct) | 0.112 s / 0.007 s | 0.048 s / 0.005 s |
| `contains` (already correct) | 0.113 s / 0.010 s | 0.047 s / 0.002 s |
| **`remove`** | 0.085 s / **0.085 s** ← frozen | 0.092 s / **0.005 s** |
| **`swap_remove`** | 0.064 s / **0.064 s** ← frozen | 0.048 s / **0.009 s** |

Both now behave exactly like the already-correct `len` / `contains`.

---

## #319 — `IdMapIndex.remove` holds the GIL across an O(n) id-map build (MEDIUM)

**What.** H8 (`f20df40`) removed the `py.detach` from `remove()`, justified by *"a removal is O(dim) lane ops … it no longer triggers the lazy O(n·dim) rebuild"* — true when written. H21 (`66bff30`) then deferred the id→slot map build to *"the first remove/contains that actually needs slots"*, putting an O(n) `HashMap` build back onto exactly the path H8 had just un-detached. The fast-path predicate probed only `packed_ready()`, which says nothing about the id map.

**Fix.** The attached fast path now requires **both** lazy structures: `packed_ready() && slots_ready()`, using a new `IdMapIndex::slots_ready()` in the core (an `is_some()` on the existing `OnceLock`, monotone false→true exactly like `packed_ready`). The now-false comment at :698-701 is rewritten. `contains` / `__contains__` (:837, :938) already detached correctly and are untouched.

**Reachability — please read, this refines the issue.** On **current-format (v6)** files the freeze does **not** reproduce, and I could not make it: a v6 load leaves the *packed rows* lazy too, so `packed_ready()` is already false and `remove` was taking the detached slow path anyway. Measured on a 1M × 128 v6 index, before and after this PR alike:

```
contains  first  10.2 ms (ticker gap 1.6 ms) | second 0.011 ms
remove    first 1635.4 ms (ticker gap 1.6 ms) | second 0.72 ms   <- detached, not frozen
```

The site is genuinely reachable through a **v5 `.tvim`**, which the loader still accepts (`io.rs:22` — "the loader accepts versions 5 and 6"). A v5 file carries per-vector packed rows, so it loads via `CodePayload::Packed` → `packed_ready() == true` **with `id_to_slot` empty** — the exact `packed && !slots` state, and the ~5.79 ms/1M build the issue measured. There is no v5 writer in-tree, so I could not construct that fixture without hand-crafting format bytes, and I did not think a brittle byte-level fixture earned its place here.

So: the defect was real but *masked* by the two lazinesses coinciding on v6, and the fast-path predicate was only accidentally safe. The fix makes it correct by construction on every load path.

---

## Tests

Added, all failing before and passing after where the defect is reachable:

- **`test_fork_safety.py::test_child_large_batch_search`** (#288) — new `large_batch_search` harness scenario: nq=683 (65568 floats, one past the boundary) and nq=1024, on both index types, in a forked child. `chunk_size=0` disables the Python-side interruptibility chunking so the binding sees the whole batch regardless of `BATCH_CHUNK_SIZE`. Runs in a fresh subprocess with a hard `subprocess.run(timeout=...)`, and every child wait inside the harness is `select` + `SIGKILL` bounded — **a regression fails loudly instead of hanging CI**.
  - on `main`: `RESULT: FAIL child op 'TurboQuantIndex nq=683' -> ('hang',)`
  - with the fix: `RESULT: PASS splitting-validation searches survive fork`
- **`test_gil_release.py::test_removal_blocked_on_add_does_not_hold_gil[remove|swap_remove]`** (#289) — the measurement above, as an assertion. The threshold is **relative**, `ticker_gap < 0.5 * block`, not absolute: a GIL-held block freezes the ticker for ~100% of its duration and a detached one for <10%, so the 50% line has ~5x margin on either side and needs no per-machine tuning. Best-of-8 attempts, and it `skip`s (rather than failing) if the add finished before the op could block. Both cases fail on `main` — `swap_remove blocked 16 ms and the ticker thread stalled 16 ms of it`.
- **`test_gil_release.py::test_first_removal_after_load_does_not_hold_gil`** (#319) — same relative-threshold shape for the first `remove` after a load. **This one passes on `main` too**, for the v6-masking reason above; it is a standing guard on the end-to-end property, not a failing repro.
- **`lazy_init.rs::id_map_slots_ready_tracks_the_lazy_map`** (#319) — the actual regression guard for the site: `slots_ready()` is true on every non-load construction path, false after a load, still false after a search, and true after the first `remove` *and* after the first `contains`. This is what would fail if the probe ever drifted from the map it reports on.
- **`input_validation.rs::validation_parallelizes_marks_the_chunk_boundary`** (#288/#321) — pins the predicate to the chunk boundary exactly (`CHUNK` inline, `CHUNK+1` splits). The core→binding threshold coupling is a real hidden dependency; if anyone retunes `VALIDATE_CHUNK`, this test fires and its doc comment says to re-check every binding call site.
- **`input_validation.rs::one_max_width_row_does_not_split_validation`** (#321) — the `MAX_DIM` vs chunk-length relationship, now recorded as an explicit *latency* expectation rather than a load-bearing safety assumption.

**Suites** (run separately, as CI does — `cargo test --release` at the workspace level fails to link the turbovec-python lib tests on macOS, pre-existing on `main`):

- `cargo test --release -p turbovec` — **0 failures** (all 20 targets, incl. 3 doc-tests)
- `pytest turbovec-python/tests -q` — **189 passed, 125 skipped**

`cargo fmt --check` and `cargo clippy` both report pre-existing findings across ~30 files untouched by this PR; neither runs in CI. I confirmed no new clippy finding points at any line this PR adds, and did not reformat unrelated code.

---

## Follow-up recommendation (deliberately NOT in this PR)

The brief asked whether a structural guard could stop this class recurring. I looked at wrapping acquisition so that detach-then-lock is the only way to take the lock — but a guard cannot cross a `py.detach` boundary, which is precisely why `lock_write_gil_aware` exists in its current retry-loop shape, so the wrapper would have to be closure-passing and would rewrite all ~26 lock sites. That is a much larger diff than the fix, in a file other branches are actively touching. Recommended as separate work:

1. **A closure-passing lock API** (`with_read(py, |idx| …)`) making detach-then-lock unforgettable, retiring the prose invariant at :250-253.
2. **Extend `test_rayon_chokepoint_completeness` to call sites.** It audits *where parallel code lives*; all four defects here were about *who calls it*. A check that every core function transitively reaching a `par_*` site is invoked from inside `with_pool`/`with_pool_if` would have caught #288 and #321 mechanically.
3. **A v5 `.tvim` test fixture.** v5 remains a supported load path with a materially different laziness profile, and it is currently untested from Python — it is what makes #319 reachable.

Per repo convention I have not bundled any CI or regression-prevention infrastructure with the fix.

Closes #288, Closes #289, Closes #319, Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)
