### PR TITLE
fix: AVX-512 tail handling (#314), wheel build residue + PyPI links (#305), mutation-coverage tests (#307)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="docs/header.png" alt="turbovec — Google's TurboQuant for vector search" width="100%">
+  <img src="https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/header.png" alt="turbovec — Google's TurboQuant for vector search" width="100%">
 </p>
 
 <p align="center">
@@ -82,16 +82,16 @@ Filtering happens inside the SIMD kernel at 32-vector block granularity: blocks 
 
 The output length is `min(k, len(allowed))` — when the allowlist is smaller than `k` you get exactly `len(allowed)` results rather than padded fallbacks.
 
-See [`docs/api.md`](docs/api.md) for the full reference.
+See [`docs/api.md`](https://github.com/RyanCodrai/turbovec/blob/main/docs/api.md) for the full reference.
 
 ### Framework integrations
 
 Drop-in replacements for the in-tree reference vector / document stores in each framework. Same public surface, same persistence semantics, same retriever and pipeline wiring — swap the import and keep your pipeline.
 
-- [LangChain](docs/integrations/langchain.md) — `pip install turbovec[langchain]` · replaces `langchain_core.vectorstores.InMemoryVectorStore`
-- [LlamaIndex](docs/integrations/llama_index.md) — `pip install turbovec[llama-index]` · replaces `llama_index.core.vector_stores.SimpleVectorStore`
-- [Haystack](docs/integrations/haystack.md) — `pip install turbovec[haystack]` · replaces `haystack.document_stores.in_memory.InMemoryDocumentStore`
-- [Agno](docs/integrations/agno.md) — `pip install turbovec[agno]` · replaces `agno.vectordb.lancedb.LanceDb`
+- [LangChain](https://github.com/RyanCodrai/turbovec/blob/main/docs/integrations/langchain.md) — `pip install turbovec[langchain]` · replaces `langchain_core.vectorstores.InMemoryVectorStore`
+- [LlamaIndex](https://github.com/RyanCodrai/turbovec/blob/main/docs/integrations/llama_index.md) — `pip install turbovec[llama-index]` · replaces `llama_index.core.vector_stores.SimpleVectorStore`
+- [Haystack](https://github.com/RyanCodrai/turbovec/blob/main/docs/integrations/haystack.md) — `pip install turbovec[haystack]` · replaces `haystack.document_stores.in_memory.InMemoryDocumentStore`
+- [Agno](https://github.com/RyanCodrai/turbovec/blob/main/docs/integrations/agno.md) — `pip install turbovec[agno]` · replaces `agno.vectordb.lancedb.LanceDb`
 
 ## Rust
 
@@ -126,21 +126,21 @@ let loaded = IdMapIndex::load("index.tvim").unwrap();
 
 TurboQuant vs FAISS `IndexPQ` (LUT256, nbits=8) — the paper's Section 4.4 baseline. 100K vectors, k=64. FAISS PQ sub-quantizer counts sized to match TurboQuant's bit rate (m=d/4 at 2-bit, m=d/2 at 4-bit).
 
-![Recall GloVe d=200](docs/recall_glove.svg)
+![Recall GloVe d=200](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/recall_glove.svg)
 
-![Recall d=1536](docs/recall_d1536.svg)
+![Recall d=1536](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/recall_d1536.svg)
 
-![Recall d=3072](docs/recall_d3072.svg)
+![Recall d=3072](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/recall_d3072.svg)
 
 Across OpenAI d=1536 and d=3072, TurboQuant beats FAISS by 0.2–1.9 points at R@1 across 2-bit and 4-bit, and both reach 1.0 by k=8 (≥0.997 already at k=4). GloVe d=200 is the harder regime — at low dim the asymptotic Beta assumption is looser. TurboQuant beats FAISS by 0.9 points at 4-bit and is effectively tied at 2-bit (within 0.1 points) at R@1, both tracking FAISS closely by k≈16.
 
 **A note on baselines.** We compare against FAISS `IndexPQ` (LUT256, nbits=8, float32 LUT) because it's the default production-grade PQ most users would reach for. This is a stronger baseline than the custom u8-LUT PQ in the [TurboQuant paper](https://arxiv.org/abs/2504.19874) — FAISS uses a higher-precision LUT at scoring time and k-means++ for codebook training. We reproduce the paper's TurboQuant numbers on OpenAI d=1536 / d=3072 and hit similar numbers to other community reference implementations on low-dim embeddings (see [`turboquant-py`](https://pypi.org/project/turboquant-py/) at d=384). On GloVe (d=200) — the low-dim regime where the asymptotic Beta assumption is loosest — TurboQuant lands level with FAISS at 2-bit and ahead at 4-bit; TQ+ calibration closes the low-dim gap the base algorithm leaves.
 
-Full results: [d=1536 2-bit](benchmarks/results/recall_d1536_2bit.json), [d=1536 4-bit](benchmarks/results/recall_d1536_4bit.json), [d=3072 2-bit](benchmarks/results/recall_d3072_2bit.json), [d=3072 4-bit](benchmarks/results/recall_d3072_4bit.json), [GloVe 2-bit](benchmarks/results/recall_glove_2bit.json), [GloVe 4-bit](benchmarks/results/recall_glove_4bit.json).
+Full results: [d=1536 2-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_d1536_2bit.json), [d=1536 4-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_d1536_4bit.json), [d=3072 2-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_d3072_2bit.json), [d=3072 4-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_d3072_4bit.json), [GloVe 2-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_glove_2bit.json), [GloVe 4-bit](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/recall_glove_4bit.json).
 
 ## Compression
 
-![Compression](docs/compression.svg)
+![Compression](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/compression.svg)
 
 ## Search Speed
 
@@ -148,63 +148,63 @@ All benchmarks: 100K vectors, 1K queries, k=64, median of 5 runs.
 
 ### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
-![ARM Speed — Single-threaded](docs/arm_speed_st.svg)
+![ARM Speed — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_speed_st.svg)
 
-![ARM Speed — Multi-threaded](docs/arm_speed_mt.svg)
+![ARM Speed — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_speed_mt.svg)
 
 On ARM, TurboQuant beats FAISS FastScan by 16–24% across every config.
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 
-![x86 Speed — Single-threaded](docs/x86_speed_st.svg)
+![x86 Speed — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_speed_st.svg)
 
-![x86 Speed — Multi-threaded](docs/x86_speed_mt.svg)
+![x86 Speed — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_speed_mt.svg)
 
 On x86, TurboQuant wins the 4-bit configs by up to ~5% (d=3072 multi-threaded ties) and is modestly behind FAISS on 2-bit — most visibly d=1536 single-threaded (~8%), within a few percent on the rest — where FAISS's AVX-512 VBMI path has the edge on the short 2-bit accumulate loop.
 
 ## Insertion & Removal Speed
 
-Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs, fresh index per timed run. Insertion measures bulk `add()` into an empty index (one-time rotation/codebook init and TQ+ calibration fit included) and a warm 10K append with calibration frozen (the steady-state encode path), against FAISS `IndexPQFastScan` bulk add (training untimed). Removal measures per-op latency of `IdMapIndex.remove(id)` against raw `TurboQuantIndex.swap_remove` — both O(1) swap-and-pop; the gap is the id-map bookkeeping. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/). On ARM the FAISS baseline is the generic aarch64 `faiss-cpu` wheel, so its insert figure partly reflects that wheel's PQ-training path on Axion (the previous ARM environment linked Apple's Accelerate BLAS instead), which is a build/BLAS difference rather than a like-for-like algorithmic gap.
+Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs, fresh index per timed run. Insertion measures bulk `add()` into an empty index (one-time rotation/codebook init and TQ+ calibration fit included) and a warm 10K append with calibration frozen (the steady-state encode path), against FAISS `IndexPQFastScan` bulk add (training untimed). Removal measures per-op latency of `IdMapIndex.remove(id)` against raw `TurboQuantIndex.swap_remove` — both O(1) swap-and-pop; the gap is the id-map bookkeeping. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](https://github.com/RyanCodrai/turbovec/tree/main/benchmarks/suite/). On ARM the FAISS baseline is the generic aarch64 `faiss-cpu` wheel, so its insert figure partly reflects that wheel's PQ-training path on Axion (the previous ARM environment linked Apple's Accelerate BLAS instead), which is a build/BLAS difference rather than a like-for-like algorithmic gap.
 
 ### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
-![ARM Insertion — Single-threaded](docs/arm_insert_st.svg)
+![ARM Insertion — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_insert_st.svg)
 
-![ARM Insertion — Multi-threaded](docs/arm_insert_mt.svg)
+![ARM Insertion — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_insert_mt.svg)
 
-![ARM Removal — Single-threaded](docs/arm_remove_st.svg)
+![ARM Removal — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_remove_st.svg)
 
-Full results: [d=1536 2-bit insert ST](benchmarks/results/speed_insert_d1536_2bit_arm_st.json), [MT](benchmarks/results/speed_insert_d1536_2bit_arm_mt.json), [d=1536 4-bit insert ST](benchmarks/results/speed_insert_d1536_4bit_arm_st.json), [MT](benchmarks/results/speed_insert_d1536_4bit_arm_mt.json), [d=3072 2-bit insert ST](benchmarks/results/speed_insert_d3072_2bit_arm_st.json), [MT](benchmarks/results/speed_insert_d3072_2bit_arm_mt.json), [d=3072 4-bit insert ST](benchmarks/results/speed_insert_d3072_4bit_arm_st.json), [MT](benchmarks/results/speed_insert_d3072_4bit_arm_mt.json), and the matching [`speed_remove_*`](benchmarks/results/) files.
+Full results: [d=1536 2-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_2bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_2bit_arm_mt.json), [d=1536 4-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_4bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_4bit_arm_mt.json), [d=3072 2-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_2bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_2bit_arm_mt.json), [d=3072 4-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_4bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_4bit_arm_mt.json), and the matching [`speed_remove_*`](https://github.com/RyanCodrai/turbovec/tree/main/benchmarks/results/) files.
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 
-![x86 Insertion — Single-threaded](docs/x86_insert_st.svg)
+![x86 Insertion — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_insert_st.svg)
 
-![x86 Insertion — Multi-threaded](docs/x86_insert_mt.svg)
+![x86 Insertion — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_insert_mt.svg)
 
-![x86 Removal — Single-threaded](docs/x86_remove_st.svg)
+![x86 Removal — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_remove_st.svg)
 
-Full results: [d=1536 2-bit insert ST](benchmarks/results/speed_insert_d1536_2bit_x86_st.json), [MT](benchmarks/results/speed_insert_d1536_2bit_x86_mt.json), [d=1536 4-bit insert ST](benchmarks/results/speed_insert_d1536_4bit_x86_st.json), [MT](benchmarks/results/speed_insert_d1536_4bit_x86_mt.json), [d=3072 2-bit insert ST](benchmarks/results/speed_insert_d3072_2bit_x86_st.json), [MT](benchmarks/results/speed_insert_d3072_2bit_x86_mt.json), [d=3072 4-bit insert ST](benchmarks/results/speed_insert_d3072_4bit_x86_st.json), [MT](benchmarks/results/speed_insert_d3072_4bit_x86_mt.json), and the matching [`speed_remove_*`](benchmarks/results/) files.
+Full results: [d=1536 2-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_2bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_2bit_x86_mt.json), [d=1536 4-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_4bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d1536_4bit_x86_mt.json), [d=3072 2-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_2bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_2bit_x86_mt.json), [d=3072 4-bit insert ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_4bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_insert_d3072_4bit_x86_mt.json), and the matching [`speed_remove_*`](https://github.com/RyanCodrai/turbovec/tree/main/benchmarks/results/) files.
 
 ## Save & Load
 
-Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs. TurboQuant serializes to a single `.tv` file with an fsync + atomic rename; FAISS is `write_index` / `read_index` on the precision-matched `IndexPQFastScan` (sub-quantizer count matched to TurboQuant's bit rate, as in the search cells). **Save (warm)** is a write after a search has run, so the blocked layout cache is populated. **Load → first search** opens a fresh index and times the first query — separating bare deserialization (the page cache is warm throughout, so this is layout work, not cold-storage I/O) from the first-query cost. **Round-trip** chains the checkpoint/resume cycle an embedding store actually pays — mutate 1K vectors → save → reopen → serve the first query; FAISS has no measured equivalent for this path, so it is shown for TurboQuant only. On the smaller payloads the round-trip can come in *below* the isolated post-mutation ("dirty") write: the two are timed in separate suite steps, and at small file sizes the standalone `fsync` in the dirty-write step dominates and inflates it — a measurement artifact of the harness, not a repack win in the combined path. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](benchmarks/suite/).
+Same corpus as the search cells: 100K OpenAI vectors, median of 5 runs. TurboQuant serializes to a single `.tv` file with an fsync + atomic rename; FAISS is `write_index` / `read_index` on the precision-matched `IndexPQFastScan` (sub-quantizer count matched to TurboQuant's bit rate, as in the search cells). **Save (warm)** is a write after a search has run, so the blocked layout cache is populated. **Load → first search** opens a fresh index and times the first query — separating bare deserialization (the page cache is warm throughout, so this is layout work, not cold-storage I/O) from the first-query cost. **Round-trip** chains the checkpoint/resume cycle an embedding store actually pays — mutate 1K vectors → save → reopen → serve the first query; FAISS has no measured equivalent for this path, so it is shown for TurboQuant only. On the smaller payloads the round-trip can come in *below* the isolated post-mutation ("dirty") write: the two are timed in separate suite steps, and at small file sizes the standalone `fsync` in the dirty-write step dominates and inflates it — a measurement artifact of the harness, not a repack win in the combined path. Single-threaded cells pin `RAYON_NUM_THREADS=1`. Scripts: [`benchmarks/suite/`](https://github.com/RyanCodrai/turbovec/tree/main/benchmarks/suite/).
 
 ### ARM (GCP c4a-standard-8, Google Axion, 8 vCPUs)
 
-![ARM Save/Load — Single-threaded](docs/arm_persist_st.svg)
+![ARM Save/Load — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_persist_st.svg)
 
-![ARM Save/Load — Multi-threaded](docs/arm_persist_mt.svg)
+![ARM Save/Load — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/arm_persist_mt.svg)
 
-Full results: [d=1536 2-bit persist ST](benchmarks/results/speed_persist_d1536_2bit_arm_st.json), [MT](benchmarks/results/speed_persist_d1536_2bit_arm_mt.json), [d=1536 4-bit persist ST](benchmarks/results/speed_persist_d1536_4bit_arm_st.json), [MT](benchmarks/results/speed_persist_d1536_4bit_arm_mt.json), [d=3072 2-bit persist ST](benchmarks/results/speed_persist_d3072_2bit_arm_st.json), [MT](benchmarks/results/speed_persist_d3072_2bit_arm_mt.json), [d=3072 4-bit persist ST](benchmarks/results/speed_persist_d3072_4bit_arm_st.json), [MT](benchmarks/results/speed_persist_d3072_4bit_arm_mt.json).
+Full results: [d=1536 2-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_2bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_2bit_arm_mt.json), [d=1536 4-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_4bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_4bit_arm_mt.json), [d=3072 2-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_2bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_2bit_arm_mt.json), [d=3072 4-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_4bit_arm_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_4bit_arm_mt.json).
 
 ### x86 (Intel Xeon Platinum 8481C / Sapphire Rapids, 8 vCPUs)
 
-![x86 Save/Load — Single-threaded](docs/x86_persist_st.svg)
+![x86 Save/Load — Single-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_persist_st.svg)
 
-![x86 Save/Load — Multi-threaded](docs/x86_persist_mt.svg)
+![x86 Save/Load — Multi-threaded](https://raw.githubusercontent.com/RyanCodrai/turbovec/main/docs/x86_persist_mt.svg)
 
-Full results: [d=1536 2-bit persist ST](benchmarks/results/speed_persist_d1536_2bit_x86_st.json), [MT](benchmarks/results/speed_persist_d1536_2bit_x86_mt.json), [d=1536 4-bit persist ST](benchmarks/results/speed_persist_d1536_4bit_x86_st.json), [MT](benchmarks/results/speed_persist_d1536_4bit_x86_mt.json), [d=3072 2-bit persist ST](benchmarks/results/speed_persist_d3072_2bit_x86_st.json), [MT](benchmarks/results/speed_persist_d3072_2bit_x86_mt.json), [d=3072 4-bit persist ST](benchmarks/results/speed_persist_d3072_4bit_x86_st.json), [MT](benchmarks/results/speed_persist_d3072_4bit_x86_mt.json).
+Full results: [d=1536 2-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_2bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_2bit_x86_mt.json), [d=1536 4-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_4bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d1536_4bit_x86_mt.json), [d=3072 2-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_2bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_2bit_x86_mt.json), [d=3072 4-bit persist ST](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_4bit_x86_st.json), [MT](https://github.com/RyanCodrai/turbovec/blob/main/benchmarks/results/speed_persist_d3072_4bit_x86_mt.json).
 
 ## How it works
 

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -61,3 +61,10 @@ manifest-path = "Cargo.toml"
 features = ["pyo3/extension-module"]
 python-source = "python"
 module-name = "turbovec._turbovec"
+# `python-source` copies the directory verbatim, so a maintainer's working
+# checkout would otherwise ship untracked build residue: stale per-version
+# `__pycache__` bytecode inside an abi3 3.9-3.14 wheel, and a phantom
+# `turbovec.mlx` namespace package left behind by deleted sources (#305).
+# The compiled extension is produced by maturin itself and injected after
+# this copy, so `**/*.so` does not exclude `_turbovec.abi3.so`.
+exclude = ["**/__pycache__/**", "**/*.so", "**/*.dSYM/**"]

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -780,3 +780,59 @@ mod core_encode_hardening {
         assert_eq!(index.dim_opt(), Some(8));
     }
 }
+
+/// #307(2): the NEON partial-block tail clamp at `search.rs:171`.
+///
+/// The kernel writes `BLOCK` scores per block, so on a final partial block
+/// it must clamp at `n_vectors` and pad the remaining lanes with
+/// `NEG_INFINITY` (the invariant documented at `search.rs:1016`). Dropping
+/// the `.min(n_vectors)` takes the full-block fast path instead, which both
+/// reads past the end of `vec_scales` and fills the pad lanes with real
+/// products. Nothing downstream notices, because `neon_block_topk_update`
+/// clamps independently — hence this direct assertion on the kernel output.
+/// `vec_scales` is sized to exactly `n_vectors` so the over-read is also a
+/// genuine heap overflow under ASAN.
+#[cfg(target_arch = "aarch64")]
+mod neon_tail_clamp {
+    use crate::search::score_4bit_block_neon;
+    use crate::BLOCK;
+
+    #[test]
+    fn partial_block_pads_with_neg_infinity() {
+        let n_byte_groups = 4;
+        let n_vectors = 20;
+        assert!(n_vectors % BLOCK != 0, "test needs a partial final block");
+
+        let codes: Vec<u8> = (0..n_byte_groups * BLOCK).map(|i| (i * 37 % 256) as u8).collect();
+        let luts: Vec<u8> = (0..n_byte_groups * 32).map(|i| (i * 13 % 128) as u8).collect();
+        let vec_scales: Vec<f32> = (0..n_vectors).map(|i| 1.0 + i as f32 * 0.01).collect();
+
+        let mut out = [0.0f32; BLOCK];
+        unsafe {
+            score_4bit_block_neon(
+                &codes,
+                &luts,
+                0,
+                n_byte_groups,
+                0.01,
+                -1.0,
+                &vec_scales,
+                0,
+                n_vectors,
+                &mut out,
+            );
+        }
+
+        for (lane, &v) in out.iter().enumerate() {
+            if lane < n_vectors {
+                assert!(v.is_finite(), "lane {lane} should hold a real score, got {v}");
+            } else {
+                assert_eq!(
+                    v,
+                    f32::NEG_INFINITY,
+                    "pad lane {lane} past n_vectors={n_vectors} must be NEG_INFINITY"
+                );
+            }
+        }
+    }
+}

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -78,7 +78,7 @@ pub fn reset_blocks_skipped_by_mask() {
 }
 
 #[cfg(target_arch = "aarch64")]
-unsafe fn score_4bit_block_neon(
+pub(crate) unsafe fn score_4bit_block_neon(
     blocked_codes: &[u8],
     uint8_luts: &[u8],
     block_offset: usize,
@@ -496,27 +496,26 @@ unsafe fn search_multi_query_avx512bw(
         ];
         let mut fa_b1 = fa_b0;
 
-        // Batch the inner loop by FLUSH_EVERY=256 byte-groups. The inner loop
-        // already processes byte-groups in pairs for ILP (2 groups per `gp`),
-        // so we step by `n_pairs_per_flush = FLUSH_EVERY / 2 = 128` pairs.
-        let n_group_pairs_inner = n_byte_groups / 2;
-        let n_pairs_per_flush = FLUSH_EVERY / 2;
-        let n_batches = if n_group_pairs_inner == 0 {
-            0
-        } else {
-            (n_group_pairs_inner + n_pairs_per_flush - 1) / n_pairs_per_flush
-        };
+        // Batch the inner loop by FLUSH_EVERY=256 byte-groups, exactly as the
+        // NEON and AVX2 kernels do, so the f32 fmadd flush boundaries — and
+        // therefore the rounding — are identical across architectures. The
+        // inner loop consumes two byte-groups per iteration for ILP; because
+        // FLUSH_EVERY is even, every batch starts on an even group index and
+        // the odd-group tail below can only fire on the final batch.
+        debug_assert!(FLUSH_EVERY % 2 == 0);
+        let n_batches = (n_byte_groups + FLUSH_EVERY - 1) / FLUSH_EVERY;
 
         for batch in 0..n_batches {
-            let gp_start = batch * n_pairs_per_flush;
-            let gp_end = ((batch + 1) * n_pairs_per_flush).min(n_group_pairs_inner);
+            let g_start = batch * FLUSH_EVERY;
+            let g_end = (g_start + FLUSH_EVERY).min(n_byte_groups);
 
             // Each zmm holds 32 u16 values: lower 256 bits = block b0's state,
             // upper 256 bits = block b1's. Reset per batch.
             let mut accus = [[_mm512_setzero_si512(); 4]; 4];
 
-            for gp in gp_start..gp_end {
-                let g0 = gp * 2;
+            let mut g_pair = g_start;
+            while g_pair + 1 < g_end {
+                let g0 = g_pair;
                 let g1 = g0 + 1;
 
                 let cp0_a = codes_base.add((b0 * n_byte_groups + g0) * BLOCK);
@@ -564,38 +563,37 @@ unsafe fn search_multi_query_avx512bw(
                         _mm512_add_epi16(_mm512_srli_epi16(res1_a, 8), _mm512_srli_epi16(res1_b, 8)),
                     );
                 }
+
+                g_pair += 2;
             }
 
-            // Tail: any odd last byte-group of this BATCH that isn't part of
-            // a pair. Only fires on the very last batch when n_byte_groups is
-            // odd — current codebook shapes always produce even n_byte_groups
-            // so this is defensive only.
-            if batch == n_batches - 1 {
-                let tail_start = n_group_pairs_inner * 2;
-                for g in tail_start..n_byte_groups {
-                    let cp0 = codes_base.add((b0 * n_byte_groups + g) * BLOCK);
-                    let cp1 = codes_base.add((b1 * n_byte_groups + g) * BLOCK);
-                    let codes_low = _mm256_loadu_si256(cp0 as *const __m256i);
-                    let codes_high = _mm256_loadu_si256(cp1 as *const __m256i);
-                    let codes_v = _mm512_inserti64x4(
-                        _mm512_castsi256_si512(codes_low),
-                        codes_high,
-                        1,
-                    );
-                    let clo = _mm512_and_si512(codes_v, mask512);
-                    let chi = _mm512_and_si512(_mm512_srli_epi16(codes_v, 4), mask512);
+            // Tail: the odd last byte-group of this batch, when the batch holds
+            // an odd number of groups. Only reachable on the final batch (see
+            // the FLUSH_EVERY parity note above); current codebook shapes
+            // always produce even n_byte_groups so this is defensive only.
+            for g in g_pair..g_end {
+                let cp0 = codes_base.add((b0 * n_byte_groups + g) * BLOCK);
+                let cp1 = codes_base.add((b1 * n_byte_groups + g) * BLOCK);
+                let codes_low = _mm256_loadu_si256(cp0 as *const __m256i);
+                let codes_high = _mm256_loadu_si256(cp1 as *const __m256i);
+                let codes_v = _mm512_inserti64x4(
+                    _mm512_castsi256_si512(codes_low),
+                    codes_high,
+                    1,
+                );
+                let clo = _mm512_and_si512(codes_v, mask512);
+                let chi = _mm512_and_si512(_mm512_srli_epi16(codes_v, 4), mask512);
 
-                    for qi in 0..4 {
-                        let lut_low =
-                            _mm256_loadu_si256(luts[qi].as_ptr().add(g * 32) as *const __m256i);
-                        let lut = _mm512_broadcast_i64x4(lut_low);
-                        let res0 = _mm512_shuffle_epi8(lut, clo);
-                        let res1 = _mm512_shuffle_epi8(lut, chi);
-                        accus[qi][0] = _mm512_add_epi16(accus[qi][0], res0);
-                        accus[qi][1] = _mm512_add_epi16(accus[qi][1], _mm512_srli_epi16(res0, 8));
-                        accus[qi][2] = _mm512_add_epi16(accus[qi][2], res1);
-                        accus[qi][3] = _mm512_add_epi16(accus[qi][3], _mm512_srli_epi16(res1, 8));
-                    }
+                for qi in 0..4 {
+                    let lut_low =
+                        _mm256_loadu_si256(luts[qi].as_ptr().add(g * 32) as *const __m256i);
+                    let lut = _mm512_broadcast_i64x4(lut_low);
+                    let res0 = _mm512_shuffle_epi8(lut, clo);
+                    let res1 = _mm512_shuffle_epi8(lut, chi);
+                    accus[qi][0] = _mm512_add_epi16(accus[qi][0], res0);
+                    accus[qi][1] = _mm512_add_epi16(accus[qi][1], _mm512_srli_epi16(res0, 8));
+                    accus[qi][2] = _mm512_add_epi16(accus[qi][2], res1);
+                    accus[qi][3] = _mm512_add_epi16(accus[qi][3], _mm512_srli_epi16(res1, 8));
                 }
             }
 

--- a/turbovec/tests/avx512_tail_simulation.rs
+++ b/turbovec/tests/avx512_tail_simulation.rs
@@ -1,0 +1,210 @@
+//! Differential simulation of the AVX-512BW paired-block kernel's
+//! batch/tail structure against the NEON reference (issue #314).
+//!
+//! AVX-512 cannot be executed on the CI/dev ARM hosts, and CI has no AVX-512
+//! leg at all, so these tests model the *semantics* of the two kernels'
+//! accumulate/flush schedules in scalar arithmetic rather than running them.
+//! What matters for correctness is which byte-groups land in which u16
+//! accumulation batch, because every batch boundary is an f32 `fmadd` flush:
+//! a schedule that drops groups scores nothing, and a schedule that merely
+//! flushes at different points diverges from ARM in the last f32 ulp.
+//!
+//! The plan builders below mirror the loop bounds in
+//! `search.rs::score_4bit_block_neon` and
+//! `search.rs::search_multi_query_avx512bw` line for line. If those bounds
+//! change, these must change with them.
+
+const FLUSH_EVERY: usize = 256;
+
+/// Groups visited per accumulation batch by `score_4bit_block_neon`, which is
+/// also the AVX2 kernel's schedule and (post-#314) the AVX-512 kernel's.
+fn neon_plan(n_byte_groups: usize) -> Vec<Vec<usize>> {
+    let n_batches = (n_byte_groups + FLUSH_EVERY - 1) / FLUSH_EVERY;
+    (0..n_batches)
+        .map(|batch| {
+            let g_start = batch * FLUSH_EVERY;
+            let g_end = (g_start + FLUSH_EVERY).min(n_byte_groups);
+            (g_start..g_end).collect()
+        })
+        .collect()
+}
+
+/// Post-fix AVX-512 schedule: batch over byte-groups by FLUSH_EVERY, consume
+/// two groups per inner iteration, and take any odd trailing group of *this*
+/// batch as a single-group tail.
+fn avx512_plan(n_byte_groups: usize) -> Vec<Vec<usize>> {
+    assert_eq!(FLUSH_EVERY % 2, 0, "pair-stepped inner loop needs even batches");
+    let n_batches = (n_byte_groups + FLUSH_EVERY - 1) / FLUSH_EVERY;
+    (0..n_batches)
+        .map(|batch| {
+            let g_start = batch * FLUSH_EVERY;
+            let g_end = (g_start + FLUSH_EVERY).min(n_byte_groups);
+            let mut groups = Vec::new();
+            let mut g_pair = g_start;
+            while g_pair + 1 < g_end {
+                groups.push(g_pair);
+                groups.push(g_pair + 1);
+                g_pair += 2;
+            }
+            groups.extend(g_pair..g_end);
+            groups
+        })
+        .collect()
+}
+
+/// Pre-fix AVX-512 schedule, retained so the tests below demonstrate that the
+/// two defects in #314 are actually detected rather than merely asserted away.
+/// Batching was driven by *group pairs*, and the odd tail was appended to
+/// whichever batch happened to be last.
+fn avx512_plan_prefix(n_byte_groups: usize) -> Vec<Vec<usize>> {
+    let n_group_pairs_inner = n_byte_groups / 2;
+    let n_pairs_per_flush = FLUSH_EVERY / 2;
+    let n_batches = if n_group_pairs_inner == 0 {
+        0
+    } else {
+        (n_group_pairs_inner + n_pairs_per_flush - 1) / n_pairs_per_flush
+    };
+    (0..n_batches)
+        .map(|batch| {
+            let gp_start = batch * n_pairs_per_flush;
+            let gp_end = ((batch + 1) * n_pairs_per_flush).min(n_group_pairs_inner);
+            let mut groups: Vec<usize> = (gp_start..gp_end).flat_map(|gp| [gp * 2, gp * 2 + 1]).collect();
+            if batch == n_batches - 1 {
+                groups.extend(n_group_pairs_inner * 2..n_byte_groups);
+            }
+            groups
+        })
+        .collect()
+}
+
+/// One output lane of a scored block. `luts[g]` is the u8 the group-`g` table
+/// lookup produces for this lane; the kernels sum those into a u16 lane
+/// accumulator, then flush with `fa = fmadd(scale, acc as f32, fa)` at every
+/// batch boundary. Reproduces the arithmetic exactly, including f32 rounding.
+fn simulate(plan: &[Vec<usize>], luts: &[u8], scale: f32, bias: f32) -> f32 {
+    let mut fa = bias;
+    for batch in plan {
+        let mut acc: u16 = 0;
+        for &g in batch {
+            acc = acc.wrapping_add(luts[g] as u16);
+        }
+        fa = scale.mul_add(acc as f32, fa);
+    }
+    fa
+}
+
+#[test]
+fn avx512_batch_schedule_matches_neon() {
+    // Legal geometries (n_byte_groups = dim / (8 / bits)) plus every shape
+    // that stresses a batch boundary, an odd group count, or both.
+    for ng in [
+        1usize, 2, 3, 4, 5, 7, 8, 16, 32, 64, 128, 254, 255, 256, 257, 258, 511, 512, 513, 767, 768,
+        769, 1024, 1025, 2048,
+    ] {
+        assert_eq!(
+            avx512_plan(ng),
+            neon_plan(ng),
+            "AVX-512 batch schedule diverges from NEON at n_byte_groups={ng}"
+        );
+        // Every group is scored exactly once, in order.
+        let visited: Vec<usize> = avx512_plan(ng).into_iter().flatten().collect();
+        assert_eq!(visited, (0..ng).collect::<Vec<_>>(), "group coverage at ng={ng}");
+    }
+}
+
+/// #314(1): with `n_byte_groups == 1` the pre-fix kernel produced zero
+/// batches, so the paired-block path scored every vector as `bias` alone.
+#[test]
+fn single_byte_group_is_scored_not_dropped() {
+    let luts = [33u8];
+    let (scale, bias) = (0.001f32, 0.0f32);
+
+    let neon = simulate(&neon_plan(1), &luts, scale, bias);
+    let fixed = simulate(&avx512_plan(1), &luts, scale, bias);
+    let prefix = simulate(&avx512_plan_prefix(1), &luts, scale, bias);
+
+    assert_eq!(neon, 0.033);
+    assert_eq!(fixed, neon);
+    // The defect this guards against: no batches at all, so score == bias.
+    assert_eq!(prefix, 0.0);
+}
+
+/// #314(2): when `ng % 512 == 1` the last pre-fix batch already held 256
+/// groups and the tail appended a 257th, moving the fmadd flush boundary off
+/// NEON's and producing a cross-arch f32 tie-break divergence.
+#[test]
+fn odd_tail_does_not_overfill_a_full_batch() {
+    let ng = 257;
+    let luts = vec![3u8; ng];
+    let (scale, bias) = (5e-5f32, 0.0f32);
+
+    let neon = simulate(&neon_plan(ng), &luts, scale, bias);
+    let fixed = simulate(&avx512_plan(ng), &luts, scale, bias);
+    let prefix = simulate(&avx512_plan_prefix(ng), &luts, scale, bias);
+
+    // One f32 ulp apart: NEON flushes 256 groups then 1, the pre-fix AVX-512
+    // schedule flushed all 257 at once.
+    assert_eq!(neon, 0.038549997);
+    assert_eq!(fixed, neon);
+    assert_eq!(prefix, 0.03855);
+
+    // The pre-fix batch boundary, not an overflow: 257 * 254 < u16::MAX.
+    assert_eq!(avx512_plan_prefix(ng)[0].len(), 257);
+    assert_eq!(avx512_plan(ng)[0].len(), 256);
+    assert_eq!(avx512_plan(ng)[1].len(), 1);
+}
+
+/// Randomized differential sweep: for legal and adversarial group counts, the
+/// fixed AVX-512 schedule must be bit-identical to NEON on every lane, while
+/// the pre-fix schedule must be observably wrong on at least one.
+#[test]
+fn randomized_differential_against_neon() {
+    let mut state = 0x243f_6a88_85a3_08d3u64;
+    let mut rng = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+
+    let mut prefix_divergences = 0;
+    for ng in [1usize, 2, 3, 5, 255, 256, 257, 511, 512, 513, 769, 1024] {
+        for _ in 0..64 {
+            // max_lut = 127 per nibble, two nibbles per group.
+            let luts: Vec<u8> = (0..ng).map(|_| (rng() % 255) as u8).collect();
+            let scale = (rng() % 100_000) as f32 * 1e-7 + 1e-7;
+            let bias = -((rng() % 1000) as f32) * 1e-3;
+
+            let neon = simulate(&neon_plan(ng), &luts, scale, bias);
+            assert_eq!(
+                simulate(&avx512_plan(ng), &luts, scale, bias),
+                neon,
+                "AVX-512 diverges from NEON at ng={ng}"
+            );
+            if simulate(&avx512_plan_prefix(ng), &luts, scale, bias) != neon {
+                prefix_divergences += 1;
+            }
+        }
+    }
+    assert!(
+        prefix_divergences > 0,
+        "pre-fix schedule should be detectably wrong somewhere"
+    );
+}
+
+/// A u16 lane accumulator must not wrap within a batch. `max_lut = 127` and
+/// two nibbles per group give at most 254 per group per lane, so any schedule
+/// that keeps batches at FLUSH_EVERY groups stays under 65535 — the argument
+/// that justifies the cap in `encode.rs`.
+#[test]
+fn no_batch_can_overflow_the_u16_lane_accumulator() {
+    for ng in [1usize, 255, 256, 257, 512, 1024, 2048, 4096] {
+        for batch in avx512_plan(ng) {
+            assert!(
+                batch.len() * 254 <= u16::MAX as usize,
+                "batch of {} groups can overflow u16 at ng={ng}",
+                batch.len()
+            );
+        }
+    }
+}

--- a/turbovec/tests/kernel_correctness.rs
+++ b/turbovec/tests/kernel_correctness.rs
@@ -345,3 +345,53 @@ fn concurrent_search_matches_serial() {
         h.join().expect("worker panicked");
     }
 }
+
+#[test]
+fn multi_batch_accumulator_flush_at_high_dim() {
+    // #307(3): every other searching test tops out at dim=512, i.e.
+    // n_byte_groups = 256 = FLUSH_EVERY exactly, so `n_batches == 1` on
+    // every arch and the flush/accumulate-reset logic never runs a second
+    // time. dim 1024 and 2048 at 4-bit give 2 and 4 batches.
+    //
+    // This is also the test for the u16-overflow argument behind
+    // `max_lut = 127`: without a flush every 256 groups a 512-group scan
+    // accumulates up to 512*254 = 130048 into a u16 lane, which wraps and
+    // destroys the self-match below.
+    let bits = 4;
+    for &dim in &[1024usize, 2048] {
+        assert!(dim / 2 > 256, "dim={dim} must exceed one FLUSH_EVERY batch");
+        for &n in &[64usize, 100] {
+            let data = gaussian_normalized(n, dim, 0xF105_4000 ^ dim as u64 ^ n as u64);
+            let mut idx = TurboQuantIndex::new(dim, bits).unwrap();
+            idx.add(&data);
+
+            // nq=1 and nq=4 take different NEON/AVX2 kernels (single-query
+            // block-parallel vs 4-query fused), each with its own batch loop.
+            for &nq in &[1usize, 4, 8] {
+                let q = &data[..nq * dim];
+                let res = idx.search(q, 5);
+
+                for qi in 0..nq {
+                    assert_eq!(
+                        res.indices_for_query(qi)[0],
+                        qi as i64,
+                        "self-match failed across a batch flush: dim={dim} n={n} nq={nq} qi={qi}"
+                    );
+                    let scores = res.scores_for_query(qi);
+                    assert!(
+                        scores.iter().all(|s| s.is_finite()),
+                        "non-finite score: dim={dim} n={n} nq={nq} qi={qi} {scores:?}"
+                    );
+                    // A wrapped u16 accumulator produces a wildly off-scale
+                    // self-score; the true value sits near cosine 1.0.
+                    assert!(
+                        (scores[0] - 1.0).abs() < 0.25,
+                        "self-score {} off scale (wrap or missed flush?): \
+                         dim={dim} n={n} nq={nq} qi={qi}",
+                        scores[0]
+                    );
+                }
+            }
+        }
+    }
+}

--- a/turbovec/tests/recall_sanity.rs
+++ b/turbovec/tests/recall_sanity.rs
@@ -104,5 +104,15 @@ fn recall_clears_floor_across_cells_including_collapse_to_8() {
         assert!(r4 >= 0.70, "recall@10 4-bit dim={dim} = {r4:.3} below floor 0.70");
         let r2 = recall_at(dim, 2);
         assert!(r2 >= 0.40, "recall@10 2-bit dim={dim} = {r2:.3} below floor 0.40");
+        // 3-bit had no accuracy assertion anywhere (#307): it appeared only
+        // in shape, finiteness and codebook-property tests, so a 3-bit path
+        // returning plausible-but-wrong rankings passed the whole suite.
+        // Measured ~0.82; the floor sits between the 2- and 4-bit floors.
+        let r3 = recall_at(dim, 3);
+        assert!(r3 >= 0.58, "recall@10 3-bit dim={dim} = {r3:.3} below floor 0.58");
+        assert!(
+            r3 > r2,
+            "3-bit recall {r3:.3} must beat 2-bit {r2:.3} at dim={dim}"
+        );
     }
 }


### PR DESCRIPTION
Three independent issues, one commit each.

## #314 — AVX-512 tail handling (latent, silently-wrong)

`search_multi_query_avx512bw` batched its u16 accumulator by *group pairs* instead of by byte-groups. Two consequences, both unreachable with legal geometry today (`ng = dim/(8/bits) >= 4`, and `ng` is always even for bits in {2,4}) but silently wrong rather than a panic if reached:

- **`n_byte_groups == 1`** ⇒ `n_group_pairs_inner = 0` ⇒ `n_batches = 0`, so neither the inner loop nor the odd-tail handler (guarded by `batch == n_batches - 1`) ran. Every vector in every paired block scored `bias` alone.
- **`ng % 512 == 1`** ⇒ the last batch already held 256 groups and the tail appended a 257th, so the f32 fmadd flush boundary sat one group off NEON's — a cross-arch tie-break divergence (no overflow; 257×254 < 65535).

The fix makes the AVX-512 schedule structurally identical to NEON's and AVX2's: batch over byte-groups by `FLUSH_EVERY`, step pairs *within* a batch, and let the odd group fall out as that batch's tail. Because `FLUSH_EVERY` is even, every batch starts on an even group index, so the tail can only fire on the final batch — that constraint is now pinned by a `debug_assert!(FLUSH_EVERY % 2 == 0)` rather than by an unstated assumption about legal dims.

### Executed vs reasoned (this is an arm64 host — no AVX-512 was run)

**Executed:**
- `cargo check -p turbovec --target x86_64-unknown-linux-gnu` — clean.
- `turbovec/tests/avx512_tail_simulation.rs` (5 tests, run on arm64): scalar lane-level simulation of the three accumulate/flush schedules — NEON, post-fix AVX-512, and the pre-fix AVX-512 — compared differentially. It asserts schedule equality and full group coverage across 24 group counts, replays the f32 `mul_add` flush sequence per lane, and includes a randomized differential sweep (12 group counts × 64 random LUT/scale/bias draws) requiring bit-identical results against NEON.
- Full `cargo test --release -p turbovec` suite.

**Reasoned (not executed):**
- That the emitted AVX-512 machine code matches the intrinsics' documented semantics. The simulation models semantics, not codegen, and cannot catch `#[target_feature]` mis-gating (#291).
- That the restructured loop preserves the per-`gp` two-group body verbatim — verified by reading the diff; the body is byte-identical, only its loop bounds and the tail's placement changed.
- The tail body itself was moved and re-indented, not rewritten.

**Caveat on the issue's headline numbers.** Case (a) reproduces exactly: NEON `0.033` vs pre-fix AVX-512 `0.0`. Case (b) does **not** reproduce at the issue's stated constants — at `ng=257` with a uniform LUT of 128 and `scale=0.001`, both schedules land on `32.896` under an f32 fused multiply-add. The divergence is real but parameter-dependent; the test uses a reproducing pair found by search (`lut=3, scale=5e-5`: NEON `0.038549997`, pre-fix `0.03855`, one ulp apart) rather than asserting numbers I could not reproduce.

## #305 — wheels ship build residue; PyPI links are dead

`python-source = "python"` copies the directory verbatim, so a wheel built from a working checkout ships untracked residue. Reproduced exactly as reported by recreating the residue in a fresh worktree and building:

```
# before
turbovec/__pycache__/{__init__,_dedup,_interruptible,_persist,_similarity,agno,haystack,langchain,llama_index}.cpython-311.pyc
turbovec/mlx/__pycache__/__init__.cpython-311.pyc      # sources no longer exist
turbovec/_stray.so
turbovec/_turbovec.abi3.so                             # the real extension
```

After `exclude = ["**/__pycache__/**", "**/*.so", "**/*.dSYM/**"]`:

```
# after
turbovec/{__init__,_dedup,_interruptible,_persist,_similarity,agno,haystack,langchain,llama_index}.py
turbovec/_turbovec.abi3.so                             # still present
```

**The `**/*.so` concern is checked, not assumed.** `_turbovec.abi3.so` is built by maturin and injected *after* the `python-source` copy, so the exclude does not touch it. Verified by building a wheel before and after, diffing the namelists, installing the after-wheel into a clean venv, and running an actual add + search through it. `import turbovec.mlx` now raises `ModuleNotFoundError` instead of resolving to an empty namespace package.

`turbovec-python/README.md` is a symlink to the root `README.md`, whose `docs/...` and `benchmarks/...` references land verbatim in wheel METADATA while no `docs/` is shipped. All 67 of them are now absolute — `raw.githubusercontent.com/.../main/` for images so they render on PyPI, `github.com/.../blob/main/` and `/tree/main/` for files and directories. Both forms render identically on GitHub. Confirmed: **0** relative `docs/`/`benchmarks/` references remain in the built wheel's METADATA.

Not addressed here: the same issue's third gap (no `py.typed`, no `.pyi`). That is a distinct, larger piece of work — flagging it as a follow-up rather than bundling it.

## #307 — surviving mutations

Each mutation was applied locally, the test confirmed failing, then reverted and confirmed passing.

| # | Mutation | Result |
|---|---|---|
| 2 | `search.rs:171`: `let end = base_vec + BLOCK;` (drop `.min(n_vectors)`) | `neon_tail_clamp::partial_block_pads_with_neg_infinity` **FAILED** under mutation, passes reverted |
| 3 | Hoist `let mut accum = [vdupq_n_u16(0); 4];` out of the batch loop in `score_4bit_block_neon` (a no-op at `n_batches == 1`) | `multi_batch_accumulator_flush_at_high_dim` **FAILED**; the other 7 tests in the file stayed green, confirming they are blind to it |
| 3 | Same hoist in `score_4query_block_neon` | `multi_batch_accumulator_flush_at_high_dim` **FAILED**; other 7 green |

**#307(2)** could not be killed by a behavioural end-to-end test — `neon_block_topk_update` clamps independently, so the over-read is invisible from the public API, and Miri does not support NEON intrinsics. Instead the kernel is exercised directly from an in-crate unit test (`score_4bit_block_neon` is now `pub(crate)`) and the `NEG_INFINITY` pad invariant documented at `search.rs:1016` is asserted on the output buffer. `vec_scales` is sized to exactly `n_vectors`, so the over-read is a genuine heap overflow that ASAN would also flag — but that would need a CI leg, which is deliberately out of scope here (#306/#282). Suggested as a follow-up.

**#307(3)**: `FLUSH_EVERY = 256` bumping to `512` did *not* break anything, because real LUT values stay well below the 254/group worst case, so the u16-overflow argument alone is not a usable kill criterion. The accumulator-reset mutations above are, and they only bite when the loop runs more than once — which is precisely the coverage hole. The test also runs at `nq` 1, 4 and 8, since those take three different kernels each with its own batch loop; the original single-`nq` version missed the single-query kernel entirely.

**#307(4)**: a 3-bit recall@10 floor plus an assertion that 3-bit beats 2-bit. Honest caveat: **I could not construct a 3-bit mutation that survives the pre-existing suite.** Four attempts (adjacent-centroid swap, central-centroid swap, hi-nibble sub-table reading the wrong coordinate, and `max_lut = 3` for 3-bit only) were all caught by `kernel_tests::distortion::pipeline_self_score_is_unbiased`, which does cover `bits = 3`. So the issue's premise that 3-bit has no accuracy assertion is stale for *scoring magnitude*; the added floor is still a genuine and cheap *ranking-quality* guard, which nothing else asserts. My new test failed alongside the pre-existing one in every case.

**#307(1) is superseded by #331** and is not addressed here. That PR changes `validate_codebook` to recompute the canonical codebook from `(bit_width, dim)` and reject any disagreement beyond `1e-4`. A finite-but-out-of-support centroid such as `1e6` disagrees by six orders of magnitude, so the recompute check subsumes the `|v| <= 1.0` bound entirely and a dedicated test for that clause would be redundant once #331 lands.

## Test runs

- `cargo test --release -p turbovec` — all green (43 lib + 14 integration binaries).
- Python suite via a clean venv against the freshly built wheel.
- `cargo test --release -p turbovec-python --lib` fails to link on macOS — pre-existing on `main`, unrelated.
- No CI workflow changes (#306/#282 out of scope).

Closes #314
Closes #305

Partially addresses #307 (items 2, 3, 4; item 1 superseded by #331, items 5 and 6 not addressed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
