### PR TITLE
fix: half-present agno store no longer loads silently empty; error messages name the real condition (#328, #329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,21 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Add-path and loader error messages now name the condition that
+  actually occurred (#329).** An id repeated inside a single
+  `add_with_ids` batch reported "id N already present in index" — false
+  on an empty index, and it sent callers hunting for a phantom prior
+  insert; it is now the new `AddError::DuplicateIdInBatch`, "duplicate
+  id N appears more than once in this batch". A zero-width batch
+  (`dim == 0`, usually an embedder returning empty embeddings) was folded
+  into "vector buffer length 0 not a multiple of dim 0" — mathematically
+  nonsense and the wrong cause — and is now the new `AddError::ZeroDim`
+  on both `TurboQuantIndex::add_2d` and `IdMapIndex::add_with_ids_2d`.
+  The pre-v5 rejection hint no longer names a version number: it pointed
+  at a release that does not exist and at a remedy the reader was already
+  running. The `.tvim` wrong-magic error now reads "not a turbovec .tvim
+  file", matching its `.tv` counterpart.
+
 - **TQ+ calibration is now a warm-up lifecycle instead of hidden
   first-add state (#107, #284, #285, #303, #317).** An index buffers its
   raw rows until it has seen 1000 vectors, then fits the calibration and
@@ -603,6 +618,26 @@ appears under each surface it touches.
   unchanged. (#167)
 
 #### Fixed
+
+- **agno: a half-present save loaded silently empty and was then
+  overwritten (#328).** `create()` caught the `FileNotFoundError` that
+  `_load_from` raises for a folder holding only one of
+  `index.tvim` / `docstore.json` and built a fresh empty index instead,
+  so the next `save()` overwrote the surviving file and the data was
+  gone. Only a folder with *neither* artifact is treated as a fresh
+  path now; a partial store propagates the "missing one of ..." error.
+  The other three stores load through explicit classmethods that already
+  propagate, and are unchanged.
+
+- **`write()` errors now name the file and use `FileNotFoundError`
+  (#329).** `TurboQuantIndex.write` / `IdMapIndex.write` raised a bare
+  `OSError: No such file or directory (os error 2)` identifying no path,
+  so a batch job writing several paths could not tell which failed and
+  `except FileNotFoundError:` around a write never matched. Both now go
+  through the same path-appending helper `load` uses. Duplicate-id and
+  zero-width-batch messages from the add path are corrected with the
+  Rust-side change above, and a persisted-store corruption message no
+  longer leads with the internal "handle" vocabulary.
 
 - **Framework integrations: four parallel implementations of the same
   semantics, brought back into line (#321, #302, #322, #301).** The

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -138,6 +138,8 @@ Writes two files under the given folder path:
 - `index.tvim` — the `IdMapIndex` payload.
 - `docstore.json` — JSON-encoded document text, metadata, and id maps.
 
+`create()` starts a fresh empty index only when the folder holds neither file. A folder holding just one of them is a partial save, and `create()` raises `FileNotFoundError` rather than starting empty — starting empty there would let the next `save()` overwrite the surviving file.
+
 Document metadata must be JSON-serializable — same constraint Agno's `LanceDb` imposes on its payload column. The side-car carries a `schema_version` field; loaders refuse to deserialize unknown versions, and validate that the side-car's id maps are consistent with the loaded `index.tvim` (a mismatched or out-of-sync pair raises at load rather than failing later at query time).
 
 The similarity mode is recorded in `docstore.json`. Because the store is constructed (with a `distance`) before `create()` loads the files, a recorded mode that conflicts with the constructor's raises `ValueError` — construct with the matching `distance` to load. A save written before the mode field existed holds raw, unnormalized vectors: it loads as `Distance.max_inner_product` — exactly the scoring it was written under — and `self.distance` is updated to reflect that.

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -141,9 +141,9 @@ def check_persisted_handles(
     for h in handle_list:
         if not index.contains(h):
             raise ValueError(
-                f"persisted store is inconsistent with its index: {what} handle "
-                f"{h} is not present in the index. The .tvim index and its JSON "
-                f"side-car are out of sync."
+                f"persisted store is inconsistent with its index: a {what} in "
+                f"the side-car has no vector in the index (internal record id "
+                f"{h}). The .tvim index and its JSON side-car are out of sync."
             )
     if next_u64 is not None and handle_list and int(next_u64) < max(handle_list):
         raise ValueError(

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -219,18 +219,27 @@ class TurboQuantVectorDb(VectorDb):
         If ``path`` was set on the constructor and a previous save exists
         under it, ``create()`` loads that save; otherwise it instantiates
         a fresh empty index sized to ``embedder.dimensions``.
+
+        Raises:
+            FileNotFoundError: if the folder holds only *part* of a save
+                (one of ``index.tvim`` / ``docstore.json``). Starting
+                fresh there would look empty and the next ``save()``
+                would overwrite the surviving file, so a partial store is
+                a hard error instead (issue #328).
         """
         with self._write_lock:
             if self._index is not None:
                 return
-            # Try loading from path first if one was set; fall through to a
-            # fresh index if the path doesn't contain a previous save.
+            # Only a folder with neither artifact is a genuinely fresh
+            # path; anything else must load, and any load failure
+            # propagates rather than defaulting to an empty index.
             if self.path is not None and Path(self.path).is_dir():
-                try:
-                    self._load_from(Path(self.path))
+                folder = Path(self.path)
+                if (folder / _INDEX_FILENAME).exists() or (
+                    folder / _STORE_FILENAME
+                ).exists():
+                    self._load_from(folder)
                     return
-                except FileNotFoundError:
-                    pass
             self._index = IdMapIndex(self.dimensions, self.bit_width)
 
     async def async_create(self) -> None:

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -209,12 +209,13 @@ fn from_bytes_err(e: std::io::Error) -> PyErr {
     pyo3::exceptions::PyValueError::new_err(e.to_string())
 }
 
-/// Map an `io::Error` from `load` to Python: `ErrorKind::NotFound`
-/// becomes `FileNotFoundError` (so `except FileNotFoundError:` works,
-/// matching what the integrations' Python-side `open()` of their JSON
-/// side-cars raises for a missing path); every other kind — including
-/// permission errors — stays plain `OSError`, as before. The path is
-/// appended because the io::Error alone doesn't name the file.
+/// Map an `io::Error` from `load` or `write` to Python:
+/// `ErrorKind::NotFound` becomes `FileNotFoundError` (so
+/// `except FileNotFoundError:` works, matching what the integrations'
+/// Python-side `open()` of their JSON side-cars raises for a missing
+/// path); every other kind — including permission errors — stays plain
+/// `OSError`, as before. The path is appended because the io::Error
+/// alone doesn't name the file.
 fn load_err(path: &str, e: std::io::Error) -> PyErr {
     let msg = format!("{e}: {path}");
     if e.kind() == std::io::ErrorKind::NotFound {
@@ -548,7 +549,7 @@ impl TurboQuantIndex {
             let guard = lock_read(&self.inner);
             with_pool(|| guard.write_with_durability(path, durability))
         })?
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
+        .map_err(|e| load_err(path, e))
     }
 
     #[classmethod]
@@ -760,8 +761,9 @@ impl IdMapIndex {
     ///
     /// `ids` must be a 1-D array of `uint64` with length equal to
     /// `vectors.shape[0]`. Raises `ValueError` if any id is already
-    /// present or if the lengths don't match. On a lazy index, this
-    /// call commits the dimensionality from `vectors.shape[1]`.
+    /// present in the index, if an id is repeated within this batch, or
+    /// if the lengths don't match. On a lazy index, this call commits
+    /// the dimensionality from `vectors.shape[1]`.
     fn add_with_ids(
         &self,
         py: Python<'_>,
@@ -1008,7 +1010,7 @@ impl IdMapIndex {
             let guard = lock_read(&self.inner);
             with_pool(|| guard.write_with_durability(path, durability))
         })?
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
+        .map_err(|e| load_err(path, e))
     }
 
     /// Load an ``IdMapIndex`` from a ``.tvim`` file previously written

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -915,6 +915,38 @@ def test_save_and_load_via_path_param(tmp_path):
     assert len(results) == 3
 
 
+@pytest.mark.parametrize("missing", ["docstore.json", "index.tvim"])
+def test_create_on_a_half_present_save_raises_instead_of_starting_empty(tmp_path, missing):
+    # Issue #328: create() swallowed _load_from's FileNotFoundError and
+    # built a fresh empty index, so a folder holding only one of the two
+    # artifacts loaded silently empty — and the next save() overwrote
+    # the surviving file, destroying the data permanently.
+    embedder = StubEmbedder()
+    db = TurboQuantVectorDb(embedder=embedder, path=str(tmp_path))
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b"), _doc("c")])
+    db.save()
+    (tmp_path / missing).unlink()
+    survivor = "index.tvim" if missing == "docstore.json" else "docstore.json"
+    before = (tmp_path / survivor).read_bytes()
+
+    db2 = TurboQuantVectorDb(embedder=embedder, path=str(tmp_path))
+    with pytest.raises(FileNotFoundError) as exc:
+        db2.create()
+    assert "missing one of" in str(exc.value)
+    assert str(tmp_path) in str(exc.value)
+    # The surviving artifact is untouched, so the store is recoverable.
+    assert (tmp_path / survivor).read_bytes() == before
+
+
+def test_create_on_an_empty_folder_still_starts_fresh(tmp_path):
+    # The genuinely-fresh path — neither artifact present — must keep
+    # working; only a *partial* save is an error.
+    db = TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path))
+    db.create()
+    assert len(db._index) == 0
+
+
 def test_failed_save_preserves_previous_store(tmp_path):
     # Regression test for #159: a save that fails mid-serialization
     # (non-JSON-serializable meta_data) must not destroy a previously

--- a/turbovec-python/tests/test_id_map.py
+++ b/turbovec-python/tests/test_id_map.py
@@ -84,6 +84,46 @@ def test_add_with_ids_rejects_duplicate_id():
         idx.add_with_ids(unit_vectors(1, 128, seed=1), np.array([2], dtype=np.uint64))
 
 
+def test_intra_batch_duplicate_id_does_not_claim_it_is_in_the_index():
+    # The id is repeated inside the batch, not present in the index —
+    # "already present in index" pointed at a phantom insert (#329).
+    idx = IdMapIndex(dim=64)
+    with pytest.raises(ValueError) as exc:
+        idx.add_with_ids(np.zeros((2, 64), dtype=np.float32), np.array([7, 7], dtype=np.uint64))
+    msg = str(exc.value)
+    assert "duplicate id 7 appears more than once in this batch" in msg
+    assert "already present" not in msg
+    assert len(idx) == 0
+
+
+def test_already_present_id_still_says_already_present():
+    idx = IdMapIndex(dim=64)
+    idx.add_with_ids(unit_vectors(1, 64), np.array([7], dtype=np.uint64))
+    with pytest.raises(ValueError) as exc:
+        idx.add_with_ids(unit_vectors(1, 64, seed=1), np.array([7], dtype=np.uint64))
+    assert "id 7 already present in index" in str(exc.value)
+
+
+def test_zero_width_batch_names_the_empty_embedding_cause():
+    # dim == 0 used to be folded into "not a multiple of dim 0" (#329).
+    idx = IdMapIndex()
+    with pytest.raises(ValueError) as exc:
+        idx.add_with_ids(np.zeros((3, 0), dtype=np.float32), np.array([1, 2, 3], dtype=np.uint64))
+    msg = str(exc.value)
+    assert "dim is 0" in msg
+    assert "multiple of" not in msg
+
+
+def test_write_to_missing_directory_names_the_path_and_raises_filenotfound():
+    # write() used to raise a bare OSError naming no file (#329).
+    idx = IdMapIndex(dim=64)
+    idx.add_with_ids(unit_vectors(1, 64), np.array([1], dtype=np.uint64))
+    missing = "/nonexistent-dir-xyz-turbovec/idx.tvim"
+    with pytest.raises(FileNotFoundError) as exc:
+        idx.write(missing)
+    assert missing in str(exc.value)
+
+
 def test_write_and_load_round_trip(tmp_path):
     idx = IdMapIndex(dim=256, bit_width=4)
     vectors = unit_vectors(10, 256, seed=0)

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -104,6 +104,18 @@ def test_load_missing_file_raises_file_not_found():
         TurboQuantIndex.load("/nonexistent/path/does-not-exist.tv")
 
 
+def test_write_to_missing_directory_names_the_path_and_raises_file_not_found():
+    # Issue #329: write() reported a bare OSError naming no file, so a
+    # batch job saving several paths couldn't tell which one failed and
+    # `except FileNotFoundError:` around a write never matched.
+    idx = TurboQuantIndex(dim=64, bit_width=4)
+    idx.add(unit_vectors(4, 64))
+    missing = "/nonexistent/path/does-not-exist.tv"
+    with pytest.raises(FileNotFoundError) as exc_info:
+        idx.write(missing)
+    assert missing in str(exc_info.value)
+
+
 def test_load_corrupt_file_stays_plain_oserror(tmp_path):
     # Pin: only the missing-file case narrows to FileNotFoundError; an
     # existing-but-corrupt file keeps raising the OSError family.

--- a/turbovec-python/tests/test_pickle_copy.py
+++ b/turbovec-python/tests/test_pickle_copy.py
@@ -111,7 +111,7 @@ def test_from_bytes_rejects_corrupt_and_wrong_type():
     with pytest.raises(ValueError, match="magic"):
         TurboQuantIndex.from_bytes(b"\x00\x01\x02\x03\x04\x05\x06\x07")
     # A .tv payload is not a .tvim payload.
-    with pytest.raises(ValueError, match="TVIM"):
+    with pytest.raises(ValueError, match=r"not a turbovec \.tvim file"):
         IdMapIndex.from_bytes(TurboQuantIndex(DIM, 4).to_bytes())
 
 

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -46,11 +46,24 @@ pub enum AddError {
     /// `vectors.len()` is not a whole multiple of `dim`.
     VectorBufferNotMultipleOfDim { vectors_len: usize, dim: usize },
 
+    /// `dim` is 0 — the batch has no columns at all. Kept distinct from
+    /// [`Self::VectorBufferNotMultipleOfDim`] and
+    /// [`Self::DimNotMultipleOf8`]: neither describes a zero dim
+    /// truthfully (every length is a multiple of 0, and `% 0` is
+    /// undefined), and the real cause is almost always an embedder that
+    /// returned empty embeddings.
+    ZeroDim,
+
     /// Number of ids does not equal number of vectors (`vectors.len() / dim`).
     IdsCountMismatch { expected: usize, got: usize },
 
     /// External id was already present in the index.
     IdAlreadyPresent(u64),
+
+    /// External id appears more than once within the same batch. Kept
+    /// distinct from [`Self::IdAlreadyPresent`], which would send the
+    /// caller hunting for a prior insert that never happened.
+    DuplicateIdInBatch(u64),
 
     /// A coordinate in the input vectors is not finite (NaN, +Inf, -Inf)
     /// or has magnitude `>= 1e16`. Either silently corrupts the index:
@@ -83,11 +96,19 @@ impl fmt::Display for AddError {
                 f,
                 "vector buffer length {vectors_len} not a multiple of dim {dim}",
             ),
+            Self::ZeroDim => write!(
+                f,
+                "dim is 0: the vectors have no columns (an embedder that \
+                 returned empty embeddings is the usual cause)",
+            ),
             Self::IdsCountMismatch { expected, got } => {
                 write!(f, "expected {expected} ids, got {got}")
             }
             Self::IdAlreadyPresent(id) => {
                 write!(f, "id {id} already present in index")
+            }
+            Self::DuplicateIdInBatch(id) => {
+                write!(f, "duplicate id {id} appears more than once in this batch")
             }
             Self::InvalidInputValue {
                 vector_index,

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -181,7 +181,9 @@ impl IdMapIndex {
     /// Returns
     /// [`AddError::VectorBufferNotMultipleOfDim`](crate::AddError::VectorBufferNotMultipleOfDim),
     /// [`AddError::IdsCountMismatch`](crate::AddError::IdsCountMismatch),
+    /// [`AddError::ZeroDim`](crate::AddError::ZeroDim),
     /// [`AddError::IdAlreadyPresent`](crate::AddError::IdAlreadyPresent),
+    /// [`AddError::DuplicateIdInBatch`](crate::AddError::DuplicateIdInBatch),
     /// or any error returned by
     /// [`TurboQuantIndex::add_2d`](crate::TurboQuantIndex::add_2d).
     pub fn add_with_ids_2d(
@@ -190,7 +192,10 @@ impl IdMapIndex {
         dim: usize,
         ids: &[u64],
     ) -> Result<(), AddError> {
-        if dim == 0 || vectors.len() % dim != 0 {
+        if dim == 0 {
+            return Err(AddError::ZeroDim);
+        }
+        if vectors.len() % dim != 0 {
             return Err(AddError::VectorBufferNotMultipleOfDim {
                 vectors_len: vectors.len(),
                 dim,
@@ -210,8 +215,11 @@ impl IdMapIndex {
         let mut seen_this_call: std::collections::HashSet<u64, IdBuildHasher> =
             std::collections::HashSet::with_capacity_and_hasher(n, IdBuildHasher::default());
         for &id in ids {
-            if self.ids().contains_key(&id) || !seen_this_call.insert(id) {
+            if self.ids().contains_key(&id) {
                 return Err(AddError::IdAlreadyPresent(id));
+            }
+            if !seen_this_call.insert(id) {
+                return Err(AddError::DuplicateIdInBatch(id));
             }
         }
 

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -83,10 +83,10 @@ const TVIM_VERSION: u8 = 6;
 /// Recovery hint for any index written before the v5 rotation break
 /// (format versions 1 through 4).
 const REBUILD_HINT: &str =
-    "Rebuild this index from the source vectors using turbovec 0.10.0 or later. \
-     turbovec 0.10.0 replaced the index rotation with a deterministic \
-     block-Hadamard transform, which changes every encoded byte; there is no \
-     in-place migration.";
+    "Rebuild this index from the source vectors using the turbovec build that \
+     produced this error. The v5 format replaced the index rotation with a \
+     deterministic block-Hadamard transform, which changes every encoded byte; \
+     there is no in-place migration.";
 
 /// Durability level for path-based writes.
 ///
@@ -305,9 +305,9 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
         io::ErrorKind::InvalidData,
         format!(
             "this {label} index is format version {version}, which is \
-             incompatible with the turbovec 0.10.0 (v5) rotation. Loading it \
-             against the v5 rotation would silently return near-zero recall, \
-             so it is refused. {REBUILD_HINT}"
+             incompatible with the v5 rotation. Loading it against the v5 \
+             rotation would silently return near-zero recall, so it is \
+             refused. {REBUILD_HINT}"
         ),
     )
 }
@@ -490,7 +490,7 @@ fn load_id_map_from_capped<R: Read>(
     if &magic != TVIM_MAGIC {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
-            "not a TVIM file: wrong magic",
+            "not a turbovec .tvim file: wrong magic",
         ));
     }
     let mut version = [0u8; 1];

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -670,8 +670,9 @@ impl TurboQuantIndex {
     /// Returns:
     /// - [`AddError::DimMismatch`] if `dim` does not match the
     ///   already-locked dim.
+    /// - [`AddError::ZeroDim`] when committing a lazy index to `dim == 0`.
     /// - [`AddError::DimNotMultipleOf8`] when committing a lazy index
-    ///   to a dim that is not a multiple of 8.
+    ///   to a nonzero dim that is not a multiple of 8.
     /// - [`AddError::InvalidInputValue`] if any coordinate is non-finite
     ///   or has magnitude `>= 1e16`.
     ///
@@ -693,8 +694,13 @@ impl TurboQuantIndex {
                 // `dim == 0` slips past the `% 8` check (0 % 8 == 0) but is a
                 // degenerate dim: committing it wedges the lazy index and the
                 // first `add` divides by zero (`vectors.len() / dim`). Reject
-                // it here, mirroring IdMapIndex::add_with_ids_2d.
-                if dim == 0 || dim % 8 != 0 {
+                // it here, mirroring IdMapIndex::add_with_ids_2d — and as
+                // its own variant, since "must be a multiple of 8" names
+                // the wrong cause for an empty-embedding batch.
+                if dim == 0 {
+                    return Err(AddError::ZeroDim);
+                }
+                if dim % 8 != 0 {
                     return Err(AddError::DimNotMultipleOf8(dim));
                 }
                 if dim > MAX_DIM {

--- a/turbovec/tests/bytes_io.rs
+++ b/turbovec/tests/bytes_io.rs
@@ -303,6 +303,6 @@ fn tvim_from_bytes_rejects_duplicate_ids_like_load() {
     // A .tv payload fed to the .tvim reader is the wrong-magic error.
     let tv_bytes = build_index().to_bytes();
     let e = IdMapIndex::from_bytes(&tv_bytes).expect_err(".tv bytes are not a TVIM payload");
-    assert!(e.to_string().contains("not a TVIM file"), "got: {e}");
+    assert!(e.to_string().contains("not a turbovec .tvim file"), "got: {e}");
     std::fs::remove_dir_all(&dir).ok();
 }

--- a/turbovec/tests/id_map.rs
+++ b/turbovec/tests/id_map.rs
@@ -311,13 +311,32 @@ fn add_with_ids_2d_rejects_non_multiple_buffer() {
 
 #[test]
 fn add_with_ids_2d_rejects_zero_dim() {
-    // Same error variant, dim=0 sub-branch.
+    // dim == 0 is its own variant: folding it into
+    // VectorBufferNotMultipleOfDim produced a message that is
+    // mathematically nonsense and named the wrong cause (issue #329).
     let mut idx = IdMapIndex::new_lazy(4).unwrap();
     let err = idx.add_with_ids_2d(&[], 0, &[]).unwrap_err();
-    assert!(
-        matches!(err, turbovec::AddError::VectorBufferNotMultipleOfDim { .. }),
-        "expected VectorBufferNotMultipleOfDim, got {err:?}",
-    );
+    assert_eq!(err, turbovec::AddError::ZeroDim);
+    let msg = err.to_string();
+    assert!(msg.contains("dim is 0"), "got: {msg}");
+    assert!(!msg.contains("multiple of"), "got: {msg}");
+}
+
+#[test]
+fn add_with_ids_intra_batch_duplicate_is_not_reported_as_already_present() {
+    // An id repeated inside one batch is not present in the index, so
+    // "already present in index" sent users hunting for a phantom
+    // insert (issue #329).
+    let dim = 128;
+    let data = gaussian_normalized(2, dim, 0xA11D_0329);
+    let mut idx = IdMapIndex::new(dim, 4).unwrap();
+    let err = idx.add_with_ids(&data, &[7, 7]).unwrap_err();
+    assert_eq!(err, turbovec::AddError::DuplicateIdInBatch(7));
+    let msg = err.to_string();
+    assert!(msg.contains("more than once in this batch"), "got: {msg}");
+    assert!(!msg.contains("already present"), "got: {msg}");
+    // Rejection is still all-or-nothing.
+    assert_eq!(idx.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## #328 — agno `create()` swallowed a half-present save, then overwrote it

`create()` caught the `FileNotFoundError` that `_load_from` raises for a folder holding only one of `index.tvim` / `docstore.json` and fell through to `IdMapIndex(self.dimensions, self.bit_width)`. The store came up silently empty and the next `save()` overwrote the surviving file — permanent data loss from a caught-and-defaulted error.

Now only a folder with *neither* artifact counts as a fresh path. If either file is present, `create()` loads and any load failure propagates with `_load_from`'s existing "missing one of docstore.json/index.tvim under &lt;folder&gt;" message. `IdMapIndex.load`'s own `FileNotFoundError`, which was swallowed identically, propagates too.

### Sibling-site audit — the other three integrations are already correct

They have no auto-load-on-create path at all: loading is an explicit classmethod (`TurboQuantVectorStore.load`, `TurboQuantVectorStore.from_persist_path`, `TurboQuantDocumentStore.load_from_disk`) with no `try`/`except` around the side-car `open()` or the `IdMapIndex.load`, so a partial store already raises. `grep -n "FileNotFoundError\|except OSError" langchain.py llama_index.py haystack.py` returns nothing. Verified by deleting one artifact from a real saved store of each:

```
langchain   docstore.json -> FileNotFoundError [Errno 2] No such file or directory: ...
langchain   index.tvim    -> FileNotFoundError No such file or directory (os error 2): ...
llama_index .nodes.json   -> FileNotFoundError [Errno 2] No such file or directory: ...
llama_index .tvim         -> FileNotFoundError No such file or directory (os error 2): ...
haystack    docstore.json -> FileNotFoundError [Errno 2] No such file or directory: ...
haystack    index.tvim    -> FileNotFoundError No such file or directory (os error 2): ...
```

No changes were needed there and none were made.

## #329 — error messages that named the wrong condition

1. **Intra-batch duplicate id (HIGH).** `IdMapIndex::add_with_ids_2d` returned `IdAlreadyPresent` for both "in the index" and "repeated in this batch". New `AddError::DuplicateIdInBatch` → `duplicate id 7 appears more than once in this batch`; the genuine case keeps `id 7 already present in index`.
2. **Pre-v5 rejection hint.** Dropped the `0.10.0` version number from `REBUILD_HINT` and `incompatible_version_error` — that release doesn't exist, the Rust crate and the PyPI distribution version independently, and the reader is already running a build that does the right thing. The hint now says to rebuild "using the turbovec build that produced this error".
3. **Zero-width batch.** `dim == 0` was folded into `vector buffer length 0 not a multiple of dim 0` (0 is a multiple of everything; `% 0` is undefined). New `AddError::ZeroDim` → `dim is 0: the vectors have no columns (an embedder that returned empty embeddings is the usual cause)`. Applied at both sites — `IdMapIndex::add_with_ids_2d` and `TurboQuantIndex::add_2d`, where it was reported as `dim must be a multiple of 8, got 0`.
4. **`write()` named no file.** Both `write` implementations mapped their `io::Error` straight to `PyIOError` with no path. They now go through the same `load_err` helper `load` uses, so the path is appended and `NotFound` narrows to `FileNotFoundError`.
5. **Handle vocabulary.** The side-car/index mismatch error now reads "a document in the side-car has no vector in the index (internal record id N)".
6. **Cosmetic.** `not a TVIM file: wrong magic` → `not a turbovec .tvim file: wrong magic`, matching the `.tv` wording.

## Test evidence

New tests: `test_create_on_a_half_present_save_raises_instead_of_starting_empty` (parametrized over each missing artifact, and asserting the survivor's bytes are untouched) plus `test_create_on_an_empty_folder_still_starts_fresh` in `test_agno.py`; `test_intra_batch_duplicate_id_does_not_claim_it_is_in_the_index`, `test_already_present_id_still_says_already_present`, `test_zero_width_batch_names_the_empty_embedding_cause`, `test_write_to_missing_directory_names_the_path_and_raises_filenotfound` in `test_id_map.py`; the write-path counterpart in `test_index.py`; and `add_with_ids_intra_batch_duplicate_is_not_reported_as_already_present` in `turbovec/tests/id_map.rs`.

Repros confirmed failing before the fix — with `agno.py` reverted to `origin/main`, both half-present parametrizations report `DID NOT RAISE <class 'FileNotFoundError'>`; the message assertions likewise fail against the pre-fix strings. All pass after.

- `cargo test --release -p turbovec`: 20/20 test binaries green.
- Python suite (extension built from this branch): 700 passed, 13 skipped. The one remaining failure, `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, is pre-existing on unmodified main — a locally-installed llama-index version artifact that passes on CI.

Two existing message assertions were updated to the corrected strings (`turbovec/tests/bytes_io.rs`, `test_pickle_copy.py`). CHANGELOG and the agno integration doc record the new behaviour.

Closes #328, Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)