### PR TITLE
fix: close the gaps found auditing today's fix commits (#353, #354, #355)

### DIFF
--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -26,6 +26,7 @@ import itertools
 import json
 import os
 import secrets
+import time
 from typing import Any, Iterable, Optional
 
 # Mirrors the Rust writer's TMP_SEQ (turbovec/src/io.rs): a pid suffix
@@ -36,11 +37,55 @@ from typing import Any, Iterable, Optional
 _TMP_SEQ = itertools.count()
 
 
+# NAME_MAX on every filesystem we target (ext4, APFS, NTFS component).
+_TMP_NAME_MAX = 255
+
+
 def _tmp_path(path: str) -> str:
     """Sibling temp-file name ``<path>.tmp.{pid}.{seq}.{rand}`` in the
     same directory as ``path`` — unique per save, even across concurrent
-    saves from one process."""
-    return f"{path}.tmp.{os.getpid()}.{next(_TMP_SEQ)}.{secrets.token_hex(4)}"
+    saves from one process.
+
+    Mirrors the Rust writer's ``tmp_sibling``: when the destination's own
+    filename would push the sibling past NAME_MAX, the *base* portion of
+    the temp name is truncated to fit. Without this a legal destination
+    name of ~232-255 bytes saves fine but its temp does not, so the save
+    fails with ENAMETOOLONG (#299/#355). The destination name itself is
+    never touched — the temp only has to be unique and recognizable.
+    """
+    directory, base = os.path.split(path)
+    suffix = f".tmp.{os.getpid()}.{next(_TMP_SEQ)}.{secrets.token_hex(4)}"
+    encoded = base.encode()
+    budget = _TMP_NAME_MAX - len(suffix.encode())
+    if len(encoded) > budget:
+        # Cut on a character boundary so the name stays valid text.
+        base = encoded[: max(budget, 0)].decode(errors="ignore")
+    return os.path.join(directory, base + suffix)
+
+
+def _replace_atomic(src: str, dst: str) -> None:
+    """``os.replace`` with a short retry on Windows sharing violations.
+
+    On Windows the rename fails with ERROR_SHARING_VIOLATION (winerror 32)
+    while any other handle to the destination lacks FILE_SHARE_DELETE —
+    CPython's own ``open()`` qualifies, as do antivirus and indexer scans.
+    The Rust writer already retries (``rename_atomic``); the Python side
+    needs the same posture or the integrations still hit #313 (#355).
+    """
+    if os.name != "nt":
+        os.replace(src, dst)
+        return
+    delay = 0.001
+    for _ in range(10):
+        try:
+            os.replace(src, dst)
+            return
+        except OSError as exc:  # pragma: no cover - Windows-only path
+            if getattr(exc, "winerror", None) != 32:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 0.064)
+    os.replace(src, dst)
 
 
 def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
@@ -92,8 +137,8 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
             f.write(payload_str)
             f.flush()
             os.fsync(f.fileno())
-        os.replace(index_tmp, index_path)
-        os.replace(sidecar_tmp, sidecar_path)
+        _replace_atomic(index_tmp, index_path)
+        _replace_atomic(sidecar_tmp, sidecar_path)
     finally:
         for tmp in (index_tmp, sidecar_tmp):
             try:

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -540,15 +540,22 @@ impl TurboQuantIndex {
         // Lock on the calling thread, never inside `with_pool` (see its
         // invariant); the v6 write path parallelizes the layout
         // transform, so it must run in the fork-safe pool.
-        {
+        // Probe under the SAME detached lock acquisition that does the
+        // write: acquiring it while still attached to the GIL blocks every
+        // Python thread for the duration of a concurrent bulk add (the
+        // #289 class, see this file's lock discipline note), and a
+        // separate probe could also report a state another thread has
+        // already moved on from. Warn once back under the GIL (#354).
+        let (state, len, result) = py.detach(|| {
             let guard = lock_read(&self.inner);
-            warn_if_warming_up(py, guard.calibration_state(), guard.len());
-        }
-        py.detach(|| {
-            let guard = lock_read(&self.inner);
-            with_pool(|| guard.write_with_durability(path, durability))
-        })?
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
+            let state = guard.calibration_state();
+            let len = guard.len();
+            let result = with_pool(|| guard.write_with_durability(path, durability));
+            (state, len, result)
+        });
+        warn_if_warming_up(py, state, len);
+        result?
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
     #[classmethod]
@@ -573,14 +580,17 @@ impl TurboQuantIndex {
         // Serialize under the read lock with the GIL released (the
         // payload scales with the index size); wrap into a PyBytes
         // only once back under the GIL.
-        {
+        // See `write`: the calibration probe must not acquire the lock
+        // while attached to the GIL (#354).
+        let (state, len, buf) = py.detach(|| {
             let guard = lock_read(&self.inner);
-            warn_if_warming_up(py, guard.calibration_state(), guard.len());
-        }
-        let buf = py.detach(|| {
-            let guard = lock_read(&self.inner);
-            with_pool(|| guard.to_bytes())
-        })?;
+            let state = guard.calibration_state();
+            let len = guard.len();
+            let buf = with_pool(|| guard.to_bytes());
+            (state, len, buf)
+        });
+        warn_if_warming_up(py, state, len);
+        let buf = buf?;
         Ok(PyBytes::new(py, &buf))
     }
 
@@ -1010,15 +1020,22 @@ impl IdMapIndex {
         // Lock on the calling thread, never inside `with_pool` (see its
         // invariant); the v6 write path parallelizes the layout
         // transform, so it must run in the fork-safe pool.
-        {
+        // Probe under the SAME detached lock acquisition that does the
+        // write: acquiring it while still attached to the GIL blocks every
+        // Python thread for the duration of a concurrent bulk add (the
+        // #289 class, see this file's lock discipline note), and a
+        // separate probe could also report a state another thread has
+        // already moved on from. Warn once back under the GIL (#354).
+        let (state, len, result) = py.detach(|| {
             let guard = lock_read(&self.inner);
-            warn_if_warming_up(py, guard.calibration_state(), guard.len());
-        }
-        py.detach(|| {
-            let guard = lock_read(&self.inner);
-            with_pool(|| guard.write_with_durability(path, durability))
-        })?
-        .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
+            let state = guard.calibration_state();
+            let len = guard.len();
+            let result = with_pool(|| guard.write_with_durability(path, durability));
+            (state, len, result)
+        });
+        warn_if_warming_up(py, state, len);
+        result?
+            .map_err(|e| pyo3::exceptions::PyIOError::new_err(format!("{}", e)))
     }
 
     /// Load an ``IdMapIndex`` from a ``.tvim`` file previously written
@@ -1045,14 +1062,17 @@ impl IdMapIndex {
         // Serialize under the read lock with the GIL released (the
         // payload scales with the index size); wrap into a PyBytes
         // only once back under the GIL.
-        {
+        // See `write`: the calibration probe must not acquire the lock
+        // while attached to the GIL (#354).
+        let (state, len, buf) = py.detach(|| {
             let guard = lock_read(&self.inner);
-            warn_if_warming_up(py, guard.calibration_state(), guard.len());
-        }
-        let buf = py.detach(|| {
-            let guard = lock_read(&self.inner);
-            with_pool(|| guard.to_bytes())
-        })?;
+            let state = guard.calibration_state();
+            let len = guard.len();
+            let buf = with_pool(|| guard.to_bytes());
+            (state, len, buf)
+        });
+        warn_if_warming_up(py, state, len);
+        let buf = buf?;
         Ok(PyBytes::new(py, &buf))
     }
 

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -120,3 +120,50 @@ def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
     # No temp strays.
     strays = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
     assert strays == []
+
+
+def test_tmp_path_fits_name_max_for_long_destinations():
+    # #299/#355: the temp suffix grew from ~10 to ~24 bytes, so a legal
+    # destination filename of ~232-255 bytes produced a temp name past
+    # NAME_MAX and the save failed with ENAMETOOLONG — for names that had
+    # saved fine before. The base is truncated to fit; the destination
+    # name itself is untouched.
+    import os
+
+    from turbovec._persist import _tmp_path
+
+    for n in (10, 200, 232, 245, 255):
+        dest = os.path.join("/tmp", "x" * n + ".json")
+        tmp = _tmp_path(dest)
+        base = os.path.basename(tmp)
+        assert len(base.encode()) <= 255, f"{n}: temp name is {len(base.encode())} bytes"
+        assert ".tmp." in base, "temp must stay recognizable to the sweep"
+    # Distinct per call even after truncation.
+    dest = os.path.join("/tmp", "y" * 250 + ".json")
+    assert _tmp_path(dest) != _tmp_path(dest)
+
+
+def test_atomic_save_round_trips_a_long_sidecar_name(tmp_path):
+    # End-to-end: the whole save path must work for a destination whose
+    # name is close to NAME_MAX (#355).
+    import json
+
+    import numpy as np
+
+    from turbovec import IdMapIndex
+    from turbovec._persist import atomic_save
+
+    rng = np.random.default_rng(0)
+    v = rng.standard_normal((4, 32)).astype(np.float32)
+    v /= np.linalg.norm(v, axis=1, keepdims=True)
+    idx = IdMapIndex(dim=32, bit_width=4)
+    idx.add_with_ids(v, np.arange(4, dtype=np.uint64))
+
+    stem = "s" * 200
+    index_path = tmp_path / f"{stem}.tvim"
+    sidecar_path = tmp_path / f"{stem}.json"
+    atomic_save(idx, index_path, {"docs": [1, 2, 3]}, sidecar_path)
+
+    assert len(IdMapIndex.load(str(index_path))) == 4
+    assert json.loads(sidecar_path.read_text()) == {"docs": [1, 2, 3]}
+    assert [p.name for p in tmp_path.iterdir() if ".tmp." in p.name] == []

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -836,3 +836,60 @@ mod neon_tail_clamp {
         }
     }
 }
+
+
+/// #353: the warm-up buffer must only grow after a *successful* encode.
+///
+/// `encode_and_append`'s unwind guard restores the index without
+/// incrementing `n_vectors`, so extending the buffer beforehand leaves
+/// `warmup.len()/dim` permanently ahead of `n_vectors` — breaking the
+/// documented "buffer row i is slot i" invariant and replaying the failed
+/// batch's rows into the threshold re-encode, which resurrects rows the
+/// index never accepted.
+mod warmup_unwind {
+    use crate::TurboQuantIndex;
+
+    fn rows(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+        let mut v = vec![0.0f32; n * dim];
+        let mut s = seed | 1;
+        for x in v.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+        }
+        v
+    }
+
+    #[test]
+    fn a_panicking_add_does_not_grow_the_warmup_buffer() {
+        let dim = 64;
+        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+        idx.add_2d(&rows(200, dim, 1), dim).unwrap();
+        assert_eq!(idx.len(), 200);
+
+        // A batch that panics inside encode must leave the index exactly
+        // as it was — including the warm-up buffer.
+        TurboQuantIndex::force_encode_panic(true);
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            idx.add_2d(&rows(300, dim, 2), dim)
+        }));
+        assert!(failed.is_err(), "the forced panic should have propagated");
+        assert_eq!(idx.len(), 200, "a panicking add changed the row count");
+
+        // Cross the threshold. If the buffer had grown by the failed
+        // batch's 300 rows, the re-encode would replay 500 buffered rows
+        // against 200 real slots and the total would overshoot.
+        idx.add_2d(&rows(900, dim, 3), dim).unwrap();
+        assert_eq!(
+            idx.len(),
+            200 + 900,
+            "the failed batch's rows were resurrected by the re-encode"
+        );
+        let res = idx.search(&rows(1, dim, 4), 10);
+        assert!(
+            res.indices.iter().all(|&i| (i as usize) < idx.len()),
+            "search returned a slot past the end of the index"
+        );
+    }
+}

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -87,6 +87,11 @@ const FLUSH_EVERY: usize = 256;
 /// magnitude above any realistic embedding value).
 const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 
+/// See [`TurboQuantIndex::force_encode_panic`].
+#[cfg(test)]
+static FORCE_ENCODE_PANIC: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Norm at or below which a vector has no representable direction.
 ///
 /// The encoder stores every vector as (unit direction, norm). At or
@@ -543,6 +548,17 @@ impl TurboQuantIndex {
     /// committed calibration when there is one and fitting (and
     /// committing) a fresh one otherwise. Assumes the caller has already
     /// validated `vectors` and resolved `dim`.
+    /// Test-only switch that makes the next `encode` call panic, so tests
+    /// can exercise the unwind guard below — and the ordering that guard
+    /// depends on (#353). Panics inside `encode` are otherwise only
+    /// reachable via a kernel invariant assert or a rayon worker fault,
+    /// neither of which is inducible through the public API. Compiled only
+    /// under `cfg(test)`, like `search::FORCE_SCALAR_FALLBACK`.
+    #[cfg(test)]
+    pub(crate) fn force_encode_panic(on: bool) {
+        FORCE_ENCODE_PANIC.store(on, std::sync::atomic::Ordering::Relaxed);
+    }
+
     fn encode_and_append(&mut self, vectors: &[f32], n: usize, dim: usize) {
         let rotation = self
             .rotation
@@ -591,6 +607,11 @@ impl TurboQuantIndex {
         let scales_len_before = scales_buf.len();
         let bit_width = self.bit_width;
         let encode_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            #[cfg(test)]
+            if FORCE_ENCODE_PANIC.load(std::sync::atomic::Ordering::Relaxed) {
+                FORCE_ENCODE_PANIC.store(false, std::sync::atomic::Ordering::Relaxed);
+                panic!("forced encode panic (test)");
+            }
             encode::encode(
                 vectors,
                 n,

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -477,11 +477,18 @@ impl TurboQuantIndex {
                 // searchable and serializable in the meantime. Declared
                 // calibration stays identity, which is exactly how these
                 // codes were produced.
+                // Encode FIRST. `encode_and_append` has an unwind guard
+                // that restores the index to its pre-call state without
+                // incrementing `n_vectors`, so extending the buffer
+                // before it would leave `warmup.len()/dim` ahead of
+                // `n_vectors` after a caught panic — permanently breaking
+                // "buffer row i is slot i" and resurrecting the failed
+                // batch's rows into the re-encode (#353).
+                self.encode_and_append(vectors, n, dim);
                 self.warmup
                     .as_mut()
                     .expect("warmup is Some in this branch")
                     .extend_from_slice(vectors);
-                self.encode_and_append(vectors, n, dim);
                 return;
             }
             // Threshold crossed. Leave warm-up for good.

--- a/turbovec/tests/tqplus_calibration.rs
+++ b/turbovec/tests/tqplus_calibration.rs
@@ -388,3 +388,55 @@ fn exact_topk(query: &[f32], data: &[f32], dim: usize, k: usize) -> Vec<usize> {
     scored.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
     scored.into_iter().take(k).map(|(_, i)| i).collect()
 }
+
+
+/// #353: the warm-up buffer must never run ahead of `n_vectors`. The
+/// documented invariant is "buffer row i is the index's slot i", and
+/// `encode_and_append` has an unwind guard that restores the index
+/// without incrementing `n_vectors` — so the buffer may only be extended
+/// *after* a successful encode. If it is extended first, a caught panic
+/// leaves the buffer longer than the index and the failed batch's rows
+/// are resurrected into the threshold re-encode.
+///
+/// The panic path itself is not reachable through the public API (input
+/// is validated before encoding), so this pins the observable half: a
+/// rejected add must leave the buffer untouched, and every accepted add
+/// must leave it exactly in step with the index.
+#[test]
+fn warmup_buffer_stays_in_step_with_n_vectors() {
+    let dim = 64;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+
+    // Four 100-row batches: 400 total, comfortably under the 1000-row
+    // threshold so the index stays in warm-up.
+    for batch in 1..=4u64 {
+        idx.add_2d(&gaussian_normalized(100, dim, batch), dim).unwrap();
+        assert_eq!(idx.calibration_state(), CalibrationState::WarmingUp);
+    }
+    let committed = idx.len();
+
+    // A rejected batch must not move anything: NaN fails validation
+    // before any encoding happens.
+    let mut bad = gaussian_normalized(10, dim, 99);
+    bad[5] = f32::NAN;
+    assert!(idx.add_2d(&bad, dim).is_err());
+    assert_eq!(idx.len(), committed, "a rejected add changed the index length");
+
+    // Crossing the threshold re-encodes exactly the buffered rows plus
+    // the new batch — if the buffer had drifted, the total would not
+    // match and earlier rows would be unreachable.
+    idx.add_2d(&gaussian_normalized(600, dim, 7), dim).unwrap();
+    assert_eq!(idx.calibration_state(), CalibrationState::Fitted);
+    assert_eq!(idx.len(), committed + 600, "re-encode changed the row count");
+
+    // The phantom-vector symptom of #353 is a re-encode replaying more
+    // rows than the index holds, so the post-crossing length above is the
+    // load-bearing assertion. Also confirm the index stays coherent: no
+    // returned slot may point past the end.
+    let res = idx.search(&gaussian_normalized(1, dim, 7), 20);
+    assert_eq!(res.indices.len(), 20);
+    assert!(
+        res.indices.iter().all(|&i| (i as usize) < idx.len()),
+        "search returned a slot past the end of the index"
+    );
+}


### PR DESCRIPTION
Three follow-ups from the wave-31 audit of the recent fix series. All three are live on `main`, and two of them are defects **I introduced** in that series.

## #353 (high) — warm-up buffer grown before an encode that can unwind

`turbovec/src/lib.rs`: the buffer was extended *before* `encode_and_append`, whose whole purpose is an unwind guard that restores the index — without incrementing `n_vectors` — so a caught panic leaves `self` consistent. Extending first meant `warmup.len()/dim` stayed permanently ahead of `n_vectors`, breaking the documented "buffer row `i` is slot `i`" invariant and replaying the failed batch's rows into the threshold re-encode.

Fix: encode first, extend only on success. Three lines, and the ordering now matches the guarantee the guard exists to provide.

Test: `warmup_buffer_stays_in_step_with_n_vectors`. Note the panic path itself is **not reachable through the public API** — input is validated before encoding — so the test pins the observable half: a rejected add leaves the length untouched, the threshold crossing produces exactly `buffered + batch` rows, and no returned slot points past the end.

## #354 (high) — the calibration probe took the lock under the GIL

The calibration-warning probe ran as its own `{ let guard = lock_read(...); warn_if_warming_up(...) }` block, still attached to the GIL, at four sites: `write` and `to_bytes` on both index types. That is exactly the #289 class, re-introduced by the calibration commit and missed by the pool-discipline commit that landed on top of it.

Fix: the probe now shares the **single** detached lock acquisition that does the actual work, and the warning is emitted after re-attaching. That removes the GIL-held acquisition and, as a bonus, makes the reported state consistent with what was actually written — two separate acquisitions could report a state another thread had already moved past.

**Honest caveat on severity:** I could not reproduce the "freezes the whole interpreter" impact. Instrumenting the repo's own `_blocked_behind_add` harness against a concurrent `chunk_size=0` bulk add, the ticker gap was ~35–49 ms **with and without the fix**, against a ~150–190 ms block — i.e. the probe is not the dominant stall in that scenario. I wrote a regression test, found it passed against the unfixed binary too, and **removed it rather than ship a test that proves nothing**. The fix still stands on the structural argument: it restores the invariant the file states at its own lock-discipline note, and removes a lock acquisition made while holding the GIL.

## #355 (medium) — the temp-file protocol was fixed on the Rust side only

`turbovec-python/python/turbovec/_persist.py`:

1. **NAME_MAX regressed.** Rust's `tmp_sibling` truncates the base to fit 255 bytes; `_tmp_path` never did, and the suffix grew from ~10 bytes (`.tmp.{pid}`) to ~24. Side-car names of roughly 232–255 bytes therefore started raising `ENAMETOOLONG` — **names that saved fine before that commit**. `_tmp_path` now truncates the base the same way, on a character boundary, leaving the destination name untouched.

   Verified across the boundary: destination basenames of 15/205/237/245/255/260 bytes all yield temp names ≤ 255 bytes with the `.tmp.` marker intact, so the Rust sweep still recognises them.

2. **Windows rename retry was missing.** `rename_atomic` retries `ERROR_SHARING_VIOLATION`; `atomic_save`'s two `os.replace` calls did not, so the integrations still hit #313 on Windows. Both now go through `_replace_atomic`, same posture (10 attempts, 1→64 ms backoff), no-op on non-Windows.

Tests: `test_tmp_path_fits_name_max_for_long_destinations` and an end-to-end `test_atomic_save_round_trips_a_long_sidecar_name` (200-char stem, asserts both artifacts load and no temp strays).

## Verification

- `cargo test --release -p turbovec`: 21 suites green.
- Python: 697 passed, 13 skipped, plus the one pre-existing `test_llama_index.py::test_query_returns_node_with_full_field_fidelity` failure that also fails on unmodified `main` locally and passes on CI.

Closes #353
Closes #354
Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)