### PR TITLE
fix: scope the test-only encode-panic switch to the calling thread (#373)

### DIFF
--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -949,6 +949,36 @@ mod warmup_unwind {
         v
     }
 
+    /// Arming the switch must not leak into any other test in this
+    /// binary: `cargo test` runs them in parallel threads, and this one
+    /// does full validation plus `packed()` before the check, so a
+    /// process-global flag could be consumed by a concurrent `add`
+    /// instead (#373). Spawning adds on other threads while armed pins
+    /// that the scoping is thread-local.
+    #[test]
+    fn the_panic_switch_does_not_leak_to_other_threads() {
+        let dim = 32;
+        TurboQuantIndex::force_encode_panic(true);
+        let handles: Vec<_> = (0..4)
+            .map(|k| {
+                std::thread::spawn(move || {
+                    let mut other = TurboQuantIndex::new(dim, 4).unwrap();
+                    other.add_2d(&rows(50, dim, 100 + k), dim).unwrap();
+                    other.len()
+                })
+            })
+            .collect();
+        for h in handles {
+            assert_eq!(h.join().expect("a concurrent add consumed the switch"), 50);
+        }
+        // Still armed for THIS thread.
+        let mut mine = TurboQuantIndex::new(dim, 4).unwrap();
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mine.add_2d(&rows(10, dim, 1), dim)
+        }));
+        assert!(failed.is_err(), "the switch was consumed by another thread");
+    }
+
     #[test]
     fn a_panicking_add_does_not_grow_the_warmup_buffer() {
         let dim = 64;

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -88,9 +88,20 @@ const FLUSH_EVERY: usize = 256;
 const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 
 /// See [`TurboQuantIndex::force_encode_panic`].
+///
+/// Thread-local, not a global: this switch *panics*, so a stray set would
+/// take down whichever test happened to reach `encode` next. `cargo test`
+/// runs the unit binary's tests in parallel threads, and the arming test
+/// does full input validation plus `packed()` before the check, leaving a
+/// wide window for another test to consume a global flag (#373). The
+/// check runs on the calling thread inside `catch_unwind`, before
+/// `encode` fans out to rayon, so thread-local scoping is sufficient.
+/// (`search::FORCE_SCALAR_FALLBACK` can be global because taking the
+/// scalar path still produces correct results; this one cannot.)
 #[cfg(test)]
-static FORCE_ENCODE_PANIC: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    static FORCE_ENCODE_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
 
 /// Norm at or below which a vector has no representable direction.
 ///
@@ -544,21 +555,23 @@ impl TurboQuantIndex {
         self.encode_and_append(vectors, n, dim);
     }
 
-    /// Encode `n` rows and append them to the stored codes, using the
-    /// committed calibration when there is one and fitting (and
-    /// committing) a fresh one otherwise. Assumes the caller has already
-    /// validated `vectors` and resolved `dim`.
     /// Test-only switch that makes the next `encode` call panic, so tests
     /// can exercise the unwind guard below — and the ordering that guard
     /// depends on (#353). Panics inside `encode` are otherwise only
     /// reachable via a kernel invariant assert or a rayon worker fault,
     /// neither of which is inducible through the public API. Compiled only
-    /// under `cfg(test)`, like `search::FORCE_SCALAR_FALLBACK`.
+    /// under `cfg(test)`, and thread-local — see the static's note on why
+    /// this one cannot be a process-global the way
+    /// `search::FORCE_SCALAR_FALLBACK` is (#373).
     #[cfg(test)]
     pub(crate) fn force_encode_panic(on: bool) {
-        FORCE_ENCODE_PANIC.store(on, std::sync::atomic::Ordering::Relaxed);
+        FORCE_ENCODE_PANIC.with(|f| f.set(on));
     }
 
+    /// Encode `n` rows and append them to the stored codes, using the
+    /// committed calibration when there is one and fitting (and
+    /// committing) a fresh one otherwise. Assumes the caller has already
+    /// validated `vectors` and resolved `dim`.
     fn encode_and_append(&mut self, vectors: &[f32], n: usize, dim: usize) {
         let rotation = self
             .rotation
@@ -608,8 +621,7 @@ impl TurboQuantIndex {
         let bit_width = self.bit_width;
         let encode_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             #[cfg(test)]
-            if FORCE_ENCODE_PANIC.load(std::sync::atomic::Ordering::Relaxed) {
-                FORCE_ENCODE_PANIC.store(false, std::sync::atomic::Ordering::Relaxed);
+            if FORCE_ENCODE_PANIC.with(|f| f.replace(false)) {
                 panic!("forced encode panic (test)");
             }
             encode::encode(


### PR DESCRIPTION
Fixes a defect in my own recent fix (`f90e43c`, PR #363).

## The finding is correct

I added `FORCE_ENCODE_PANIC` as a process-global `AtomicBool`, justifying it by analogy to `search::FORCE_SCALAR_FALLBACK`. **That analogy does not carry.** Taking the scalar fallback still computes correct results, so leaking that flag across tests is harmless. This one *panics* — a stray set takes down whichever test reaches `encode` next.

The window is wide, exactly as #373 describes: the arming test runs full input validation over ~19,200 floats plus `self.packed()` before reaching the check, and `cargo test` runs the unit binary's tests in parallel threads with at least eight other tests calling `add`/`add_2d`.

## Fix

`thread_local!` instead of a global. The check runs on the calling thread inside `catch_unwind`, **before** `encode` fans out to rayon, so thread-local scoping is both sufficient and necessary. Arm/consume is now `Cell::set` / `Cell::replace(false)`.

## Evidence it actually matters

Added `the_panic_switch_does_not_leak_to_other_threads`: arm the switch, spawn four threads each doing a normal `add`, require all four to succeed, then confirm the switch is *still armed for this thread*.

Restoring the global `AtomicBool` fails **both** tests in the module:

```
test kernel_tests::warmup_unwind::a_panicking_add_does_not_grow_the_warmup_buffer ... FAILED
test kernel_tests::warmup_unwind::the_panic_switch_does_not_leak_to_other_threads ... FAILED
    the switch was consumed by another thread
```

The second failure is the leak test doing its job; the first is the #353 test taken out as collateral — which is precisely the spurious cross-test failure #373 predicted, reproduced on demand.

With the fix: 22 suites green, and the lib binary run three times in a row with no flake.

## Also

`force_encode_panic` had been inserted *between* `encode_and_append`'s doc comment and the function, so that doc was attached to the wrong item. Moved above it. (This is the cosmetic point #373 raises.)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)