### PR TITLE
fix: don't publish codes or scales before the eager add's cache repack (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,19 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A caught panic in the eager add's cache repack no longer leaves the
+  stored codes ahead of the row count (#388).** The blocked-cache patch is
+  fallible, and `packed_codes` and `scales` were published before it while
+  `n_vectors` was published after — so a caught `PanicException` left both
+  buffers holding the failed batch's rows against the old count, and the
+  next add addressed past the orphans. That is silent slot corruption
+  rather than a detectable inconsistency. Reordering alone is not a fix:
+  both buffers are taken out of the index before encoding, so deferring
+  their publication makes a panic drop them entirely and leave the index
+  with *empty* buffers against a non-zero count. The repack now runs under
+  a guard that truncates both back to their pre-call lengths and
+  republishes them, matching the contract `encode`'s own guard keeps.
+
 - **The v6 codebook check no longer puts a Lloyd-Max solve on the load
   path (#357).** Validating the embedded codebook by recomputing it and
   comparing cost 25–100 ms — two orders of magnitude more than the load

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1302,3 +1302,63 @@ mod settled_append_unwind {
         assert_eq!(idx.search(probe, 5).indices[0], 7);
     }
 }
+
+
+/// #388: the eager `add` path must not publish codes or scales before the
+/// blocked-cache repack, which can panic.
+///
+/// The `perf/op-hillclimb` merge moved `n_vectors` to last so a repack
+/// panic could not leave the count ahead of the cache — but it published
+/// `packed_codes` and `scales` *before* the repack, so a caught panic left
+/// those holding the new rows while `n_vectors` still read the old count.
+/// The next add then addresses past the orphans: silent slot corruption
+/// rather than a detectable inconsistency.
+mod eager_add_unwind {
+    use crate::TurboQuantIndex;
+
+    fn rows(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+        let mut v = vec![0.0f32; n * dim];
+        let mut s = seed | 1;
+        for x in v.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+        }
+        v
+    }
+
+    #[test]
+    fn a_panicking_cache_repack_leaves_the_index_at_its_pre_call_state() {
+        let dim = 64;
+        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+        idx.add_2d(&rows(1200, dim, 1), dim).unwrap();
+        // Materialize the blocked cache so the eager path takes the patch
+        // branch at all.
+        idx.prepare();
+        let before_len = idx.len();
+        let before_bytes = idx.to_bytes();
+
+        TurboQuantIndex::force_repack_panic(true);
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            idx.add_2d(&rows(100, dim, 2), dim)
+        }));
+        assert!(failed.is_err(), "the forced repack panic should have propagated");
+
+        assert_eq!(idx.len(), before_len, "a caught repack panic changed the row count");
+        assert_eq!(
+            idx.to_bytes(),
+            before_bytes,
+            "a caught repack panic left codes or scales holding the failed batch"
+        );
+
+        // And the index is still usable: a retry appends cleanly.
+        idx.add_2d(&rows(100, dim, 2), dim).unwrap();
+        assert_eq!(idx.len(), before_len + 100);
+        let res = idx.search(&rows(1, dim, 3), 10);
+        assert!(
+            res.indices.iter().all(|&i| (i as usize) < idx.len()),
+            "search returned a slot past the end after the retry"
+        );
+    }
+}

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -87,6 +87,13 @@ const FLUSH_EVERY: usize = 256;
 /// magnitude above any realistic embedding value).
 const MAX_INPUT_MAGNITUDE: f32 = 1e16;
 
+// See [`TurboQuantIndex::force_repack_panic`]. Thread-local; see
+// FORCE_ENCODE_PANIC for why these cannot be process-globals (#373).
+#[cfg(test)]
+thread_local! {
+    static FORCE_REPACK_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// See [`TurboQuantIndex::force_encode_panic`].
 ///
 /// Thread-local, not a global: this switch *panics*, so a stray set would
@@ -638,6 +645,15 @@ impl TurboQuantIndex {
     /// Test-only sibling of [`Self::force_encode_panic`] that unwinds
     /// from *inside* `encode`, after the batch has been appended to the
     /// output buffers — the only way to give `encode_and_append`'s
+    // Test-only switch that makes the eager path's blocked-cache repack
+    // panic, so the guard around it can be exercised. Thread-local for the
+    // same reason the other switches are (#373): it panics, so a stray set
+    // would take down whichever test reached the repack next.
+    #[cfg(test)]
+    pub(crate) fn force_repack_panic(on: bool) {
+        FORCE_REPACK_PANIC.with(|f| f.set(on));
+    }
+
     /// unwind guard real truncation work. See
     /// [`encode::force_panic_after_append`].
     #[cfg(test)]
@@ -762,7 +778,10 @@ impl TurboQuantIndex {
             scratch.shrink_to(n * dim);
         }
         self.encode_scratch = scratch;
-        self.scales = scales_buf;
+        // `scales` is published per branch below, at the same commit point
+        // as the codes and the count — publishing it here would leave it
+        // holding `new_n` rows if the eager branch's cache patch panicked
+        // (#388).
 
         // Commit only what `encode` actually produced. It returns a
         // non-empty pair exactly when it fitted one for this batch (i.e.
@@ -800,15 +819,20 @@ impl TurboQuantIndex {
             pack::append_lanes(&mut cache.data, &packed_codes, old_n, n, bit_width, dim);
             let (new_n_blocks, _, _) = pack::blocked_geometry(new_n, bit_width, dim);
             cache.n_blocks = new_n_blocks;
+            self.scales = scales_buf;
             self.n_vectors = new_n;
             return;
         }
         // Eager path: the packed rows are authoritative and already carry
-        // the new vectors. The count is still published last (below), so
-        // that a panic in the cache patch cannot leave `n_vectors` ahead
-        // of a cache that is serialized verbatim — same rule as the lazy
-        // branch. Everything between uses `new_n` explicitly.
-        self.packed_codes = OnceLock::from(packed_codes);
+        // the new vectors. NOTHING is published until every fallible step
+        // below has succeeded — the cache patch can panic (allocation, and
+        // the repack itself), and publishing `packed_codes`/`scales` first
+        // would leave them holding `new_n` rows while `n_vectors` still
+        // reads `old_n`. A caller that catches the panic and keeps using
+        // the index then addresses its next add past the orphans, which is
+        // silent slot corruption rather than a detectable inconsistency
+        // (#388). The patch is therefore built from the local buffer, and
+        // codes, scales, cache and count are committed together at the end.
 
         // Maintain the blocked cache incrementally instead of discarding
         // it: appended rows only affect the (possibly partial) tail block
@@ -824,19 +848,46 @@ impl TurboQuantIndex {
             // Build the patch BEFORE touching the cache: `truncate` then
             // compute would leave a short cache behind if the repack
             // panicked, and the cache is serialized verbatim.
-            let patch = pack::repack_block_range(
-                self.packed_codes.get().expect("packed materialized in add"),
-                new_n,
-                self.bit_width,
-                dim,
-                first_block,
-                new_n_blocks,
-            );
+            //
+            // The repack is the last fallible step, and `packed_codes` /
+            // `scales_buf` are still owned locally here — taken out of
+            // `self` before `encode` and not yet republished. So a panic
+            // would drop them and leave the index with empty buffers
+            // against a non-zero `n_vectors`. Restore the pre-call state
+            // and resume, the same contract `encode`'s guard above keeps
+            // (#388).
+            let bit_width = self.bit_width;
+            let patch = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                #[cfg(test)]
+                if FORCE_REPACK_PANIC.with(|f| f.replace(false)) {
+                    panic!("forced repack panic (test)");
+                }
+                pack::repack_block_range(
+                    &packed_codes,
+                    new_n,
+                    bit_width,
+                    dim,
+                    first_block,
+                    new_n_blocks,
+                )
+            })) {
+                Ok(patch) => patch,
+                Err(panic) => {
+                    packed_codes.truncate(packed_len_before);
+                    scales_buf.truncate(scales_len_before);
+                    self.packed_codes = OnceLock::from(packed_codes);
+                    self.scales = scales_buf;
+                    std::panic::resume_unwind(panic);
+                }
+            };
             let cache = self.blocked.get_mut().expect("blocked present");
             cache.data.truncate(first_block * block_bytes);
             cache.data.extend_from_slice(&patch);
             cache.n_blocks = new_n_blocks;
         }
+        // Commit point: every fallible step above has succeeded.
+        self.packed_codes = OnceLock::from(packed_codes);
+        self.scales = scales_buf;
         self.n_vectors = new_n;
     }
 


### PR DESCRIPTION
Fixes finding 1 of #388 — a defect the `perf/op-hillclimb` merge (`e178a97`) introduced, sitting on `main` now.

## The defect

The merge deliberately moved `self.n_vectors = new_n` to last, with a comment explaining that a panic in the blocked-cache patch must not leave the count ahead of a cache that is serialized verbatim. That reasoning is right — and it only considers one direction. `packed_codes` and `scales` were still published *before* the fallible `pack::repack_block_range`, so a caught panic leaves them holding `new_n` rows while `n_vectors` still reads `old_n`.

A caller that catches the `PanicException` and keeps using the index then gets silent slot corruption on its next add: the orphan rows occupy slots `old_n..new_n`, so new vectors are addressed past `n_vectors` and become invisible.

Note #388 was filed from source reading only (the author could not build). It is correct.

## Reordering alone is not enough — my first attempt was wrong

Worth recording, because the obvious fix makes things worse. Both buffers are `mem::take`n out of `self` before `encode` runs. So simply deferring their publication to the commit point means a repack panic **drops** them, leaving the index with *empty* codes and scales against a non-zero `n_vectors` — a worse inconsistency than the stale-rows one being fixed.

The repack therefore runs under a `catch_unwind` that truncates both buffers back to their pre-call lengths and republishes them before resuming — exactly the contract `encode`'s existing guard already keeps a few lines above.

## Discrimination evidence

New test `a_panicking_cache_repack_leaves_the_index_at_its_pre_call_state`, driven by a new `force_repack_panic` hook (thread-local, per #373 — never a process-global).

Restoring the publish-before-repack ordering fails it on the right assertion:

```
assertion `left == right` failed:
  a caught repack panic left codes or scales holding the failed batch
```

The test asserts three things: the row count is unchanged, `to_bytes()` is byte-identical to before the failed add (so neither buffer kept the failed batch), and a retry afterwards appends cleanly with no slot pointing past the end.

## Not in scope

#388's finding 2 (the `FORCE_SCALAR_FALLBACK` TOCTOU) is untouched — it is a test-only switch and a different shape of problem.

## Verification

22 suites green; lib binary run 3x, 69 passed each time.

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)