### PR TITLE
fix: deferred-window adds no longer O(n) (#383); the packed_ready() probe gated add, swap_remove and remove off forever (#392)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -762,13 +762,18 @@ appears under each surface it touches.
   more than the operation. `swap_remove` and single-row `add` drop the
   probe entirely; `IdMapIndex.remove` keeps one, but on `slots_ready()`,
   the structure whose first build genuinely is O(n) with the GIL held
-  (#319) and which does flip to true after one remove. Loaded-index cost
-  per op measured against a fresh index of the same contents, 100k × 128,
-  4-bit: `IdMapIndex.remove` 122x → 1.4x, `swap_remove` 278x → 2.2x,
-  single-row `add` 28.0x → 3.5x at default threads; 22.6x → 1.4x,
-  48.0x → 2.2x and 40.9x → 3.6x at `RAYON_NUM_THREADS=1`. Fresh-index
-  cost is unchanged. The residual ratio is real lane work a loaded index
-  does and a fresh one does not, not overhead.
+  (#319) and which does flip to true after one remove. The penalty was a
+  fixed per-call pool handoff, so its size depends on how contended the
+  pool is and is not a stable figure — measured between 20x and 280x the
+  cost of the same operation on a fresh index across ops, thread counts
+  and machine load, and in the worst samples far higher. After the fix a
+  loaded index costs 1.4x a fresh one for `IdMapIndex.remove`, 2.2x for
+  `swap_remove` and ~3x for a single-row `add` (100k × 128, 4-bit), at
+  both default threads and `RAYON_NUM_THREADS=1`; those figures are
+  stable and reproduce. Fresh-index cost is unchanged. The residual is
+  real work a loaded index does and a fresh one does not — blocked-cache
+  lane ops, and in the add case a per-call extract-LUT rebuild — not
+  overhead.
 
 - **agno: a half-present save loaded silently empty and was then
   overwritten (#328).** `create()` caught the `FileNotFoundError` that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,24 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Deferred-window adds no longer cost O(n) when the new ids sort below
+  the retained id table (#383).** After a load, `IdMapIndex` keeps the
+  load-time sorted id table alive so post-load adds can validate new ids
+  by binary search instead of forcing the O(n) `id → slot` map build. The
+  merge that kept it current broke out early only when the new ids all
+  sorted *above* the table's tail, so an id sorting below rewrote all n
+  entries — per add, under the write lock, quadratic over a chatty
+  post-load pattern. Ids added inside the deferred window now go into a
+  side hash set and the load-time table is never rewritten; a presence
+  check is one binary search plus one hash lookup, and an add costs
+  O(rows added) wherever the new ids sort. Measured at dim=32, 4-bit,
+  interleaved A/B, µs per single-row add with ids below the table:
+  52.5/102.2/201.2/405.3 → 3.5/3.1/3.2/3.1 at n = 50k/100k/200k/400k
+  (and 51.8/100.2/198.0/393.9 → 3.5/3.7/3.1/3.0 at
+  `RAYON_NUM_THREADS=1`). Ids sorting above the table were already flat
+  and are unchanged. Note the side set is retained, like the sorted
+  table, until something materializes the map.
+
 - **The v6 codebook check no longer puts a Lloyd-Max solve on the load
   path (#357).** Validating the embedded codebook by recomputing it and
   comparing cost 25–100 ms — two orders of magnitude more than the load
@@ -731,6 +749,26 @@ appears under each surface it touches.
   unchanged. (#167)
 
 #### Fixed
+
+- **Adds and removes on a loaded index are no longer permanently routed
+  through the rayon pool (#392).** The bindings chose between an
+  uncontended fast path and a `py.detach` + pool handoff by probing
+  `packed_ready()`, which was documented as "false only until the first
+  mutation after a load". That stopped being true: no mutation on a
+  v6-loaded index materializes the packed bit-plane rows any more — `add`
+  lazy-appends to the blocked cache and `swap_remove` patches it with
+  O(dim) lane ops — so the probe stayed false for the index's whole
+  lifetime and *every* add and remove paid a pool handoff costing far
+  more than the operation. `swap_remove` and single-row `add` drop the
+  probe entirely; `IdMapIndex.remove` keeps one, but on `slots_ready()`,
+  the structure whose first build genuinely is O(n) with the GIL held
+  (#319) and which does flip to true after one remove. Loaded-index cost
+  per op measured against a fresh index of the same contents, 100k × 128,
+  4-bit: `IdMapIndex.remove` 122x → 1.4x, `swap_remove` 278x → 2.2x,
+  single-row `add` 28.0x → 3.5x at default threads; 22.6x → 1.4x,
+  48.0x → 2.2x and 40.9x → 3.6x at `RAYON_NUM_THREADS=1`. Fresh-index
+  cost is unchanged. The residual ratio is real lane work a loaded index
+  does and a fresh one does not, not overhead.
 
 - **agno: a half-present save loaded silently empty and was then
   overwritten (#328).** `create()` caught the `FileNotFoundError` that

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -420,11 +420,18 @@ impl TurboQuantIndex {
         // stand for "the first mutation after a v6 load rebuilds the
         // packed rows, a payload-sized parallel job regardless of row
         // count", but an add on a loaded index now takes the core's
-        // lazy-append branch: it appends to the blocked cache in
-        // O(rows·dim) serial lane writes and leaves the packed rows
-        // unset. So the probe was permanently false on a loaded index
-        // and sent *every* single-row add through a pool handoff costing
-        // far more than the add (#392).
+        // lazy-append branch, which appends to the blocked cache and
+        // leaves the packed rows unset. So the probe was permanently
+        // false on a loaded index and sent *every* single-row add
+        // through a pool handoff costing far more than the add (#392).
+        //
+        // What matters for this gate is that the lazy-append branch
+        // contains no rayon fan-out, which it does not. It is not free,
+        // though: `pack::extract_codes_flat` rebuilds a 4 KB extract LUT
+        // and allocates a `Vec<Vec<u8>>` on every call, a fixed cost a
+        // one-row add pays in full — most of the ~3x a one-row add on a
+        // loaded index still costs over a fresh one. That is serial work
+        // to be optimized in the core, not a reason to enter the pool.
         // Probing under the write guard makes the check race-free.
         let n_rows = if dim == 0 { 0 } else { slice.len() / dim };
         let validation_splits = turbovec_core::validation_parallelizes(owned.len());

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -647,42 +647,24 @@ impl TurboQuantIndex {
             // Bounds check and removal share one write guard, so a
             // concurrent writer cannot shrink the index in between.
             //
-            // Two paths: with the packed rows materialized (every case
-            // except the first mutation after a v6 load) the removal is
-            // O(1) and skips both the GIL detach and the pool, keeping
-            // the uncontended fast path. Otherwise the mutation lazily
-            // rebuilds the packed rows from the blocked cache — a
-            // parallel O(n·dim) job — so it detaches and runs in the
-            // fork-safe pool (lock on the calling thread, never inside
-            // `with_pool`). The probe can only go false→true, so a race
-            // merely sends a ready index down the slow path harmlessly.
-            //
-            // The probe itself runs detached: `read()` blocks for the
-            // whole duration of a concurrent bulk add, and blocking with
-            // the GIL held stalls every Python thread (issue #289).
-            let ready = py.detach(|| lock_read(&self.inner).packed_ready());
-            let removed = if ready {
+            // Always the uncontended fast path — no GIL detach, no pool
+            // handoff. `swap_remove` maintains whichever code layout is
+            // materialized in O(dim) lane ops and never triggers the lazy
+            // O(n·dim) packed rebuild, so there is no slow case to route
+            // around; a `packed_ready()` probe here would be permanently
+            // false on a loaded index and send every remove through a
+            // pool handoff that costs far more than the removal (#392).
+            let removed = {
                 let mut inner = lock_write_gil_aware(py, &self.inner);
                 let len = inner.len();
                 if i < len {
-                    Ok(Ok(inner.swap_remove(i)))
+                    Ok(inner.swap_remove(i))
                 } else {
                     Err(len)
                 }
-            } else {
-                py.detach(|| {
-                    let mut guard = lock_write(&self.inner);
-                    let inner = &mut *guard;
-                    let len = inner.len();
-                    if i < len {
-                        Ok(with_pool(|| inner.swap_remove(i)))
-                    } else {
-                        Err(len)
-                    }
-                })
             };
             match removed {
-                Ok(moved) => return moved,
+                Ok(moved) => return Ok(moved),
                 Err(len) => {
                     return Err(pyo3::exceptions::PyIndexError::new_err(format!(
                         "index {} out of range for index of length {len}",
@@ -831,29 +813,30 @@ impl IdMapIndex {
     /// never present, so they return `False`.
     fn remove(&self, py: Python<'_>, id: &Bound<'_, PyAny>) -> PyResult<bool> {
         Ok(match extract_membership_id("id", id)? {
-            // Fast path: both lazy structures already materialized —
-            // O(1), no pool. Slow path (the first mutation after a v6
-            // load): the mutation rebuilds the packed rows from the
-            // blocked cache (parallel O(n·dim)) and materializes the
-            // id → slot map (serial O(n) — issue #319), so it detaches
-            // and runs in the fork-safe pool. Both probes only go
+            // Fast path: the id → slot map is already materialized — the
+            // removal is then O(dim) lane ops plus two hash operations,
+            // so it takes the uncontended GIL-aware path with no detach
+            // and no pool handoff. The packed rows are deliberately NOT
+            // probed: `swap_remove` maintains the blocked cache directly
+            // and never triggers the lazy O(n·dim) packed rebuild, so
+            // `packed_ready()` stays false for a loaded index's whole
+            // lifetime and gating on it sent every remove through the
+            // pool forever (#392).
+            //
+            // Slow path, once per loaded index: the first remove builds
+            // the id → slot map (serial O(n) — issue #319), so it
+            // detaches rather than stall every Python thread on the GIL.
+            // No pool: that build is serial. The probe only goes
             // false→true, so a race merely sends a ready index down the
-            // slow path harmlessly; they run detached because `read()`
+            // slow path harmlessly, and it runs detached because `read()`
             // blocks for the duration of a concurrent bulk add and doing
             // that with the GIL held stalls every Python thread (#289).
             Some(v) => {
-                let ready = py.detach(|| {
-                    let guard = lock_read(&self.inner);
-                    guard.packed_ready() && guard.slots_ready()
-                });
+                let ready = py.detach(|| lock_read(&self.inner).slots_ready());
                 if ready {
                     lock_write_gil_aware(py, &self.inner).remove(v)
                 } else {
-                    py.detach(|| {
-                        let mut guard = lock_write(&self.inner);
-                        let inner = &mut *guard;
-                        with_pool(|| inner.remove(v))
-                    })?
+                    py.detach(|| lock_write(&self.inner).remove(v))
                 }
             }
             None => false,

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -404,11 +404,8 @@ impl TurboQuantIndex {
         //
         // Single-row adds take the same inline bypass as nq==1 search —
         // the rayon bridges in a one-row *encode* have length 1 and fold
-        // on the calling thread — but three conditions must hold. The
-        // packed rows must already be materialized: the first mutation
-        // after a v6 load rebuilds them from the blocked cache, a
-        // payload-sized parallel job regardless of row count. And the
-        // input-validation scan must not split — it chunks by float
+        // on the calling thread — but two conditions must hold. The
+        // input-validation scan must not split: it chunks by float
         // count, not by row, so a single wide row can exceed one chunk
         // and inject work into the global sentinel pool (issue #321;
         // #288 is the same hole on the search side). Gating on
@@ -418,16 +415,23 @@ impl TurboQuantIndex {
         // threshold: that fits a calibration and re-encodes the whole
         // buffered prefix, ~1000 rows of splitting work behind a
         // single-row add (`add_parallelizes`, issue #364).
+        //
+        // There is deliberately NO `packed_ready()` term. It used to
+        // stand for "the first mutation after a v6 load rebuilds the
+        // packed rows, a payload-sized parallel job regardless of row
+        // count", but an add on a loaded index now takes the core's
+        // lazy-append branch: it appends to the blocked cache in
+        // O(rows·dim) serial lane writes and leaves the packed rows
+        // unset. So the probe was permanently false on a loaded index
+        // and sent *every* single-row add through a pool handoff costing
+        // far more than the add (#392).
         // Probing under the write guard makes the check race-free.
         let n_rows = if dim == 0 { 0 } else { slice.len() / dim };
         let validation_splits = turbovec_core::validation_parallelizes(owned.len());
         py.detach(|| {
             let mut guard = lock_write(&self.inner);
             let inner = &mut *guard;
-            let pooled = n_rows > 1
-                || validation_splits
-                || !inner.packed_ready()
-                || inner.add_parallelizes(n_rows);
+            let pooled = n_rows > 1 || validation_splits || inner.add_parallelizes(n_rows);
             with_pool_if(pooled, || inner.add_2d(&owned, dim))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
@@ -651,9 +655,12 @@ impl TurboQuantIndex {
             // handoff. `swap_remove` maintains whichever code layout is
             // materialized in O(dim) lane ops and never triggers the lazy
             // O(n·dim) packed rebuild, so there is no slow case to route
-            // around; a `packed_ready()` probe here would be permanently
-            // false on a loaded index and send every remove through a
-            // pool handoff that costs far more than the removal (#392).
+            // around. Nor would a `packed_ready()` probe find one: no
+            // mutation on a v6-loaded index materializes the packed rows
+            // — not `add` (lazy-append branch), not `swap_remove` — so
+            // the probe is permanently false there and would send every
+            // remove through a pool handoff costing far more than the
+            // removal (#392; see `TurboQuantIndex::packed_ready`).
             let removed = {
                 let mut inner = lock_write_gil_aware(py, &self.inner);
                 let len = inner.len();
@@ -817,11 +824,12 @@ impl IdMapIndex {
             // removal is then O(dim) lane ops plus two hash operations,
             // so it takes the uncontended GIL-aware path with no detach
             // and no pool handoff. The packed rows are deliberately NOT
-            // probed: `swap_remove` maintains the blocked cache directly
-            // and never triggers the lazy O(n·dim) packed rebuild, so
-            // `packed_ready()` stays false for a loaded index's whole
-            // lifetime and gating on it sent every remove through the
-            // pool forever (#392).
+            // probed: no mutation on a v6-loaded index materializes them
+            // (`add` lazy-appends to the blocked cache, `swap_remove`
+            // patches it with lane ops), so `packed_ready()` stays false
+            // for such an index's whole lifetime and gating on it sent
+            // every remove through the pool forever (#392; see
+            // `TurboQuantIndex::packed_ready`).
             //
             // Slow path, once per loaded index: the first remove builds
             // the id → slot map (serial O(n) — issue #319), so it

--- a/turbovec-python/tests/test_remove_fast_path.py
+++ b/turbovec-python/tests/test_remove_fast_path.py
@@ -1,19 +1,27 @@
-"""Removes on a *loaded* index must take the binding's fast path (#392).
+"""Mutations on a *loaded* index must take the binding's fast path (#392).
 
-``TurboQuantIndex.swap_remove`` maintains whichever code layout is
-materialized in O(dim) lane ops and never triggers the lazy O(n·dim)
-packed rebuild, so ``packed_ready()`` stays ``False`` for a loaded
-index's entire lifetime. Gating the fast path on it therefore did not
-select "first mutation after a load" — it selected *every* remove on
-every loaded index, and routed each one through a ``py.detach`` plus a
-rayon pool handoff costing far more than the removal itself.
+No mutation on a v6-loaded index materializes the packed bit-plane rows:
+``add`` lazy-appends to the blocked cache, ``swap_remove`` patches it with
+O(dim) lane ops, and neither sets the ``packed_codes`` OnceLock. So
+``packed_ready()`` stays ``False`` for such an index's entire lifetime,
+and a binding fast path gated on it did not select "first mutation after
+a load" — it selected *every* mutation on *every* loaded index, routing
+each through a ``py.detach`` plus a rayon pool handoff costing far more
+than the operation itself.
 
-Asserted as a loaded-vs-fresh ratio on the same process and the same
-index contents, so machine speed cancels; the gate is deliberately far
-above the honest ratio (a loaded index does pay real O(dim) lane work
-where a fresh one memcpys a packed row) and far below the defect, which
-is a fixed per-op overhead of ~3 µs single-threaded and ~18 µs with the
-pool contended, against sub-microsecond removes.
+Asserted as a loaded-vs-fresh ratio in the same process over the same
+index contents, so machine speed cancels. The gates sit well above the
+honest ratio — a loaded index does pay real lane work where a fresh one
+appends to or memcpys a packed row — and well below the defect, which is
+a fixed per-op overhead of ~3-45 µs against sub-microsecond to
+low-microsecond operations.
+
+Measured honest ratios on arm64 after the fix: 1.4x (``remove``), 2.2x
+(``swap_remove``), 3.5x (``add``). The lane writes those paths do go
+through a heavier branch on x86_64 (``pack::write_x86_code_byte`` vs a
+plain byte store), so the honest ratios are expected to be somewhat
+higher there; if a gate proves tight on x86 CI it should be widened, not
+deleted — the defect it discriminates against is 20-280x.
 """
 from __future__ import annotations
 
@@ -29,9 +37,12 @@ DIM = 64
 OPS = 1_000
 REPS = 3
 
-# Honest ratios measured after the fix are 1.4x (IdMapIndex.remove) and
-# 2.2x (swap_remove); the defect is 20-280x depending on pool contention.
-MAX_RATIO = 8.0
+# Per-op gates, each roughly the geometric mean of the honest ratio and
+# the smallest defect ratio measured for that op (the single-threaded
+# case, where the pool handoff is cheapest).
+MAX_RATIO_REMOVE = 8.0  # honest 1.4x, defect >= 20.7x
+MAX_RATIO_SWAP_REMOVE = 12.0  # honest 2.2x, defect >= 48.0x
+MAX_RATIO_ADD = 12.0  # honest 3.5x, defect >= 28.0x
 
 
 @pytest.fixture(scope="module")
@@ -71,7 +82,7 @@ def test_id_map_remove_on_a_loaded_index_is_not_pool_bound(vectors: np.ndarray) 
         return IdMapIndex.from_bytes(fresh().to_bytes())
 
     f, l, ratio = _ratio(fresh, loaded, lambda ix, i: ix.remove(int(ids[i])))
-    assert ratio < MAX_RATIO, (
+    assert ratio < MAX_RATIO_REMOVE, (
         f"remove() on a loaded index costs {l:.2f} us vs {f:.2f} us on a fresh "
         f"one ({ratio:.1f}x) — it is going through the detach + pool slow path"
     )
@@ -87,8 +98,34 @@ def test_swap_remove_on_a_loaded_index_is_not_pool_bound(vectors: np.ndarray) ->
         return TurboQuantIndex.from_bytes(fresh().to_bytes())
 
     f, l, ratio = _ratio(fresh, loaded, lambda ix, _i: ix.swap_remove(0))
-    assert ratio < MAX_RATIO, (
+    assert ratio < MAX_RATIO_SWAP_REMOVE, (
         f"swap_remove() on a loaded index costs {l:.2f} us vs {f:.2f} us on a "
         f"fresh one ({ratio:.1f}x) — it is going through the detach + pool "
         f"slow path"
+    )
+
+
+def test_single_row_add_on_a_loaded_index_is_not_pool_bound(
+    vectors: np.ndarray,
+) -> None:
+    """The sibling of the two above, on the hotter verb.
+
+    The single-row add bypass was gated on the same permanently-false
+    ``packed_ready()`` probe, so every post-load add paid the pool
+    handoff for the index's whole lifetime.
+    """
+    row = vectors[:1].copy()
+
+    def fresh() -> TurboQuantIndex:
+        index = TurboQuantIndex(dim=DIM, bit_width=4)
+        index.add(vectors)
+        return index
+
+    def loaded() -> TurboQuantIndex:
+        return TurboQuantIndex.from_bytes(fresh().to_bytes())
+
+    f, l, ratio = _ratio(fresh, loaded, lambda ix, _i: ix.add(row))
+    assert ratio < MAX_RATIO_ADD, (
+        f"a single-row add() on a loaded index costs {l:.2f} us vs {f:.2f} us "
+        f"on a fresh one ({ratio:.1f}x) — it is going through the pool handoff"
     )

--- a/turbovec-python/tests/test_remove_fast_path.py
+++ b/turbovec-python/tests/test_remove_fast_path.py
@@ -1,0 +1,94 @@
+"""Removes on a *loaded* index must take the binding's fast path (#392).
+
+``TurboQuantIndex.swap_remove`` maintains whichever code layout is
+materialized in O(dim) lane ops and never triggers the lazy O(n·dim)
+packed rebuild, so ``packed_ready()`` stays ``False`` for a loaded
+index's entire lifetime. Gating the fast path on it therefore did not
+select "first mutation after a load" — it selected *every* remove on
+every loaded index, and routed each one through a ``py.detach`` plus a
+rayon pool handoff costing far more than the removal itself.
+
+Asserted as a loaded-vs-fresh ratio on the same process and the same
+index contents, so machine speed cancels; the gate is deliberately far
+above the honest ratio (a loaded index does pay real O(dim) lane work
+where a fresh one memcpys a packed row) and far below the defect, which
+is a fixed per-op overhead of ~3 µs single-threaded and ~18 µs with the
+pool contended, against sub-microsecond removes.
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from turbovec import IdMapIndex, TurboQuantIndex
+
+N = 50_000
+DIM = 64
+OPS = 1_000
+REPS = 3
+
+# Honest ratios measured after the fix are 1.4x (IdMapIndex.remove) and
+# 2.2x (swap_remove); the defect is 20-280x depending on pool contention.
+MAX_RATIO = 8.0
+
+
+@pytest.fixture(scope="module")
+def vectors() -> np.ndarray:
+    rng = np.random.default_rng(0)
+    return rng.standard_normal((N, DIM)).astype(np.float32)
+
+
+def _per_op_us(build, op) -> float:
+    """Microseconds per ``op`` call, best of ``REPS`` fresh indexes."""
+    best = float("inf")
+    for _ in range(REPS):
+        index = build()
+        op(index, 0)  # warm up: materializes any lazy structure
+        t0 = time.perf_counter()
+        for i in range(1, OPS + 1):
+            op(index, i)
+        best = min(best, (time.perf_counter() - t0) / OPS * 1e6)
+    return best
+
+
+def _ratio(fresh_build, loaded_build, op) -> tuple[float, float, float]:
+    fresh = _per_op_us(fresh_build, op)
+    loaded = _per_op_us(loaded_build, op)
+    return fresh, loaded, loaded / fresh
+
+
+def test_id_map_remove_on_a_loaded_index_is_not_pool_bound(vectors: np.ndarray) -> None:
+    ids = np.arange(1, N + 1, dtype=np.uint64)
+
+    def fresh() -> IdMapIndex:
+        index = IdMapIndex(dim=DIM, bit_width=4)
+        index.add_with_ids(vectors, ids)
+        return index
+
+    def loaded() -> IdMapIndex:
+        return IdMapIndex.from_bytes(fresh().to_bytes())
+
+    f, l, ratio = _ratio(fresh, loaded, lambda ix, i: ix.remove(int(ids[i])))
+    assert ratio < MAX_RATIO, (
+        f"remove() on a loaded index costs {l:.2f} us vs {f:.2f} us on a fresh "
+        f"one ({ratio:.1f}x) — it is going through the detach + pool slow path"
+    )
+
+
+def test_swap_remove_on_a_loaded_index_is_not_pool_bound(vectors: np.ndarray) -> None:
+    def fresh() -> TurboQuantIndex:
+        index = TurboQuantIndex(dim=DIM, bit_width=4)
+        index.add(vectors)
+        return index
+
+    def loaded() -> TurboQuantIndex:
+        return TurboQuantIndex.from_bytes(fresh().to_bytes())
+
+    f, l, ratio = _ratio(fresh, loaded, lambda ix, _i: ix.swap_remove(0))
+    assert ratio < MAX_RATIO, (
+        f"swap_remove() on a loaded index costs {l:.2f} us vs {f:.2f} us on a "
+        f"fresh one ({ratio:.1f}x) — it is going through the detach + pool "
+        f"slow path"
+    )

--- a/turbovec-python/tests/test_remove_fast_path.py
+++ b/turbovec-python/tests/test_remove_fast_path.py
@@ -9,19 +9,32 @@ a load" — it selected *every* mutation on *every* loaded index, routing
 each through a ``py.detach`` plus a rayon pool handoff costing far more
 than the operation itself.
 
-Asserted as a loaded-vs-fresh ratio in the same process over the same
-index contents, so machine speed cancels. The gates sit well above the
-honest ratio — a loaded index does pay real lane work where a fresh one
-appends to or memcpys a packed row — and well below the defect, which is
-a fixed per-op overhead of ~3-45 µs against sub-microsecond to
-low-microsecond operations.
+The two remove tests assert a loaded-vs-fresh ratio in the same process
+over the same index contents, so machine speed cancels. Their fresh
+baselines are 0.06-0.38 µs against a ~20 µs handoff, so the defect
+separates from the honest ratio by 10-100x and a ratio gate is safe.
 
-Measured honest ratios on arm64 after the fix: 1.4x (``remove``), 2.2x
-(``swap_remove``), 3.5x (``add``). The lane writes those paths do go
-through a heavier branch on x86_64 (``pack::write_x86_code_byte`` vs a
-plain byte store), so the honest ratios are expected to be somewhat
-higher there; if a gate proves tight on x86 CI it should be widened, not
-deleted — the defect it discriminates against is 20-280x.
+The add test does **not** use that shape, and deliberately. Its fresh
+baseline is ~0.9 µs, so the same fixed handoff shows up as ~25x rather
+than ~50-280x, and under memory pressure the honest and defect
+distributions come within a few percent of each other — a 12.0x gate was
+measured passing with the defect live at 12.64x. Widening such a gate
+makes it unfalsifiable; the fix is to measure something else. So the add
+test compares a one-row add against a **two-row** add on the same loaded
+index: a two-row add is pooled under every version of this code
+(``n_rows > 1``), so both arms pay identical lane-append work and differ
+only by the handoff the one-row bypass is supposed to skip. Contention
+inflates both arms together — measured separation widens from 6.5x idle
+to 12x under load, in the safe direction.
+
+Honest ratios on arm64 after the fix: 1.4x (``remove``), 2.2x
+(``swap_remove``), 0.12 one-row/two-row (``add``). The lane writes these
+paths do go through a heavier branch on x86_64
+(``pack::write_x86_code_byte`` vs a plain byte store), so the two remove
+ratios may sit higher there. If one proves tight, check first that the
+defect range for that op is still an order of magnitude away before
+touching the threshold — for a gate whose honest and defect
+distributions overlap, widening hides the defect instead of catching it.
 """
 from __future__ import annotations
 
@@ -37,12 +50,15 @@ DIM = 64
 OPS = 1_000
 REPS = 3
 
-# Per-op gates, each roughly the geometric mean of the honest ratio and
-# the smallest defect ratio measured for that op (the single-threaded
-# case, where the pool handoff is cheapest).
+# Loaded-vs-fresh gates for the removes, each roughly the geometric mean
+# of the honest ratio and the smallest defect ratio measured for that op
+# (the single-threaded case, where the pool handoff is cheapest).
 MAX_RATIO_REMOVE = 8.0  # honest 1.4x, defect >= 20.7x
 MAX_RATIO_SWAP_REMOVE = 12.0  # honest 2.2x, defect >= 48.0x
-MAX_RATIO_ADD = 12.0  # honest 3.5x, defect >= 28.0x
+
+# One-row / two-row gate for the add: honest 0.08-0.13, defect 0.81-1.29
+# over 12 idle and 6 contended samples. Sits ~3x clear of both.
+MAX_ONE_OVER_TWO_ROW_ADD = 0.4
 
 
 @pytest.fixture(scope="module")
@@ -105,7 +121,7 @@ def test_swap_remove_on_a_loaded_index_is_not_pool_bound(vectors: np.ndarray) ->
     )
 
 
-def test_single_row_add_on_a_loaded_index_is_not_pool_bound(
+def test_single_row_add_on_a_loaded_index_takes_the_inline_bypass(
     vectors: np.ndarray,
 ) -> None:
     """The sibling of the two above, on the hotter verb.
@@ -113,19 +129,27 @@ def test_single_row_add_on_a_loaded_index_is_not_pool_bound(
     The single-row add bypass was gated on the same permanently-false
     ``packed_ready()`` probe, so every post-load add paid the pool
     handoff for the index's whole lifetime.
+
+    Measured against a two-row add on the same loaded index rather than
+    against a fresh one: two rows are pooled under every version of this
+    code, so the two arms differ only by the handoff the bypass skips,
+    and machine load moves both together. See the module docstring for
+    why the loaded-vs-fresh ratio does not work for this op.
     """
-    row = vectors[:1].copy()
 
-    def fresh() -> TurboQuantIndex:
-        index = TurboQuantIndex(dim=DIM, bit_width=4)
-        index.add(vectors)
-        return index
+    def loaded(n_rows: int):
+        def build() -> TurboQuantIndex:
+            index = TurboQuantIndex(dim=DIM, bit_width=4)
+            index.add(vectors)
+            return TurboQuantIndex.from_bytes(index.to_bytes())
 
-    def loaded() -> TurboQuantIndex:
-        return TurboQuantIndex.from_bytes(fresh().to_bytes())
+        batch = vectors[:n_rows].copy()
+        return _per_op_us(build, lambda ix, _i: ix.add(batch))
 
-    f, l, ratio = _ratio(fresh, loaded, lambda ix, _i: ix.add(row))
-    assert ratio < MAX_RATIO_ADD, (
-        f"a single-row add() on a loaded index costs {l:.2f} us vs {f:.2f} us "
-        f"on a fresh one ({ratio:.1f}x) — it is going through the pool handoff"
+    one, two = loaded(1), loaded(2)
+    ratio = one / two
+    assert ratio < MAX_ONE_OVER_TWO_ROW_ADD, (
+        f"a one-row add() on a loaded index costs {one:.2f} us against "
+        f"{two:.2f} us for a two-row add ({ratio:.2f} of it) — the one-row "
+        f"inline bypass is not engaging, so it is paying the pool handoff"
     )

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -141,6 +141,17 @@ pub struct IdMapIndex {
     /// plus one hash lookup and an add costs O(rows added), never O(n).
     /// Freed alongside `sorted_ids` when the map materializes; `Mutex`
     /// for the same reason.
+    ///
+    /// Carries the same not-freed caveat as `sorted_ids`, and more
+    /// sharply: only a map-materializing call (`remove`, `contains`, an
+    /// allowlist search) ends the window, so a load → adds →
+    /// plain-`search` workload never ends it and this set grows by one
+    /// entry (plus hashbrown's load-factor slack) per added id for the
+    /// index's lifetime. It is bounded by the adds actually made, not by
+    /// `n`, and the same ids are already retained in `slot_to_id`, so the
+    /// overhead is a constant factor on the added rows rather than
+    /// unbounded growth against a fixed workload — but a long-lived
+    /// writer that never removes or checks membership does pay it.
     deferred_added: std::sync::Mutex<std::collections::HashSet<u64, IdBuildHasher>>,
 }
 

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -119,6 +119,10 @@ pub struct IdMapIndex {
     /// into the add path. Freed the moment the map materializes (in
     /// [`Self::ids`]), and ignored thereafter.
     ///
+    /// Never mutated after the load — ids added inside the deferred
+    /// window go to `deferred_added` instead, so an add's cost is
+    /// independent of `n` no matter where the new ids sort (#383).
+    ///
     /// Note this is NOT freed by a load+search-only workload: plain
     /// `search` and `search_with_allowlist(None)` never consult the map,
     /// so such an index carries the table (8 bytes/vector) for its
@@ -131,6 +135,13 @@ pub struct IdMapIndex {
     /// `&self`. Mutating callers hold `&mut self` and use `get_mut`, so
     /// they never lock; the one `lock` is the map build itself.
     sorted_ids: std::sync::Mutex<Vec<u64>>,
+    /// Ids added while the deferred window is open, i.e. the ids present
+    /// in the index but not in `sorted_ids`. Together the two cover
+    /// exactly the live id set, so a presence check is one binary search
+    /// plus one hash lookup and an add costs O(rows added), never O(n).
+    /// Freed alongside `sorted_ids` when the map materializes; `Mutex`
+    /// for the same reason.
+    deferred_added: std::sync::Mutex<std::collections::HashSet<u64, IdBuildHasher>>,
 }
 
 impl IdMapIndex {
@@ -143,6 +154,7 @@ impl IdMapIndex {
             slot_to_id: Vec::new(),
             id_to_slot: std::sync::OnceLock::from(HashMap::default()),
             sorted_ids: std::sync::Mutex::new(Vec::new()),
+            deferred_added: std::sync::Mutex::new(Default::default()),
         })
     }
 
@@ -155,6 +167,7 @@ impl IdMapIndex {
             slot_to_id: Vec::new(),
             id_to_slot: std::sync::OnceLock::from(HashMap::default()),
             sorted_ids: std::sync::Mutex::new(Vec::new()),
+            deferred_added: std::sync::Mutex::new(Default::default()),
         })
     }
 
@@ -169,9 +182,13 @@ impl IdMapIndex {
                 .map(|(slot, &id)| (id, slot))
                 .collect();
             // The map is authoritative from here on; release the
-            // load-time sorted copy (8 bytes/vector) rather than carry
-            // it for the index's lifetime.
+            // load-time sorted copy (8 bytes/vector) and the deferred-add
+            // set rather than carry them for the index's lifetime.
             *self.sorted_ids.lock().expect("sorted_ids lock poisoned") = Vec::new();
+            *self
+                .deferred_added
+                .lock()
+                .expect("deferred_added lock poisoned") = Default::default();
             map
         })
     }
@@ -239,21 +256,26 @@ impl IdMapIndex {
         // Validate all ids up-front so a partial failure is impossible.
         // Reject both ids already in the index and duplicates within
         // this call. In the post-load window (map unset) presence checks
-        // run against the load-time sorted table by binary search, so an
-        // add never forces the O(n) map build; the map stays lazy for
+        // run against the retained load-time table, so an add never
+        // forces the O(n) map build; the map stays lazy for
         // remove/contains to build if ever needed.
         let deferred = self.id_to_slot.get().is_none();
         let mut seen_this_call: std::collections::HashSet<u64, IdBuildHasher> =
             std::collections::HashSet::with_capacity_and_hasher(n, IdBuildHasher::default());
         // Split by window: in the deferred (post-load, map-unset) window
-        // presence is a binary search over the retained sorted table, so
-        // an add never forces the O(n) map build. Both windows keep
-        // main's typed distinction between an id already in the index and
-        // a duplicate within this batch.
+        // presence is a binary search over the retained load-time table
+        // plus a hash lookup in the set of ids added since, so an add
+        // never forces the O(n) map build. Both windows keep main's typed
+        // distinction between an id already in the index and a duplicate
+        // within this batch.
         if deferred {
             let sorted = self.sorted_ids.get_mut().expect("sorted_ids lock poisoned");
+            let added = self
+                .deferred_added
+                .get_mut()
+                .expect("deferred_added lock poisoned");
             for &id in ids {
-                if sorted.binary_search(&id).is_ok() {
+                if sorted.binary_search(&id).is_ok() || added.contains(&id) {
                     return Err(AddError::IdAlreadyPresent(id));
                 }
                 if !seen_this_call.insert(id) {
@@ -281,30 +303,19 @@ impl IdMapIndex {
         self.inner.add_2d(vectors, dim)?;
 
         if deferred {
-            // Keep the sorted table current for the next add's binary
-            // searches; the map itself stays unset (a later lazy build
-            // reads the extended slot_to_id and includes these rows).
-            // Two-run backward merge — O(old + new) per add, so a chatty
-            // post-load pattern (many small adds) never pays a full
-            // re-sort of the table.
-            let mut new_sorted = ids.to_vec();
-            new_sorted.sort_unstable();
-            let sorted = self.sorted_ids.get_mut().expect("sorted_ids lock poisoned");
-            let old_len = sorted.len();
-            sorted.resize(old_len + new_sorted.len(), 0);
-            let (mut i, mut j) = (old_len, new_sorted.len());
-            for k in (0..sorted.len()).rev() {
-                if j == 0 {
-                    break; // remaining prefix is already in place
-                }
-                if i > 0 && sorted[i - 1] > new_sorted[j - 1] {
-                    sorted[k] = sorted[i - 1];
-                    i -= 1;
-                } else {
-                    sorted[k] = new_sorted[j - 1];
-                    j -= 1;
-                }
-            }
+            // Record the new ids for the next add's presence check; the
+            // map itself stays unset (a later lazy build reads the
+            // extended slot_to_id and includes these rows). They go in a
+            // side set rather than into `sorted_ids`: merging them into
+            // the sorted table costs O(n) per add whenever a new id sorts
+            // below the table's tail, which is quadratic over a chatty
+            // post-load pattern (#383). Cost here is O(rows added).
+            let added = self
+                .deferred_added
+                .get_mut()
+                .expect("deferred_added lock poisoned");
+            added.reserve(n);
+            added.extend(ids.iter().copied());
         } else {
             self.ids_mut().reserve(n);
             for (i, &id) in ids.iter().enumerate() {
@@ -626,6 +637,7 @@ impl IdMapIndex {
             slot_to_id,
             id_to_slot: std::sync::OnceLock::new(),
             sorted_ids: std::sync::Mutex::new(sorted),
+            deferred_added: std::sync::Mutex::new(Default::default()),
         })
     }
 }
@@ -763,33 +775,45 @@ mod tests {
     /// so a load+search-only index never carries both.
     #[test]
     fn sorted_ids_freed_when_map_materializes() {
-        let ix = loaded_index();
+        let dim = 64usize;
+        let mut ix = loaded_index();
         assert_eq!(sorted_len(&ix), 100, "load should keep the sorted table");
+        let more: Vec<f32> = (0..dim).map(|i| (i % 31) as f32 / 31.0).collect();
+        ix.add_with_ids(&more, &[7]).unwrap();
         assert!(ix.contains(1000), "sanity: id present");
         assert_eq!(
             sorted_len(&ix),
             0,
             "materializing the map must release the sorted table"
         );
+        assert!(
+            ix.deferred_added.lock().expect("lock").is_empty(),
+            "materializing the map must release the deferred-add set"
+        );
+        assert!(ix.contains(7), "sanity: deferred-window id present");
     }
 
-    /// Deferred-window adds keep the sorted table sorted (the merge is
-    /// the only thing later binary searches can rely on).
+    /// Deferred-window adds stay outside the load-time sorted table, and
+    /// a duplicate is caught whichever of the two halves holds it.
     #[test]
-    fn deferred_adds_keep_sorted_ids_sorted_and_reject_duplicates() {
+    fn deferred_adds_reject_duplicates_without_touching_the_loaded_table() {
         let dim = 64usize;
         let mut ix = loaded_index();
         let more: Vec<f32> = (0..10 * dim).map(|i| (i % 31) as f32 / 31.0).collect();
         // Interleaves with the loaded ids (which step by 7 from 1000).
         let new_ids: Vec<u64> = vec![1, 1003, 1500, 999_999, 2, 1004, 1600, 3, 4, 5];
         ix.add_with_ids(&more, &new_ids).unwrap();
-        assert_eq!(sorted_len(&ix), 110);
+        assert_eq!(
+            sorted_len(&ix),
+            100,
+            "the load-time table must not be rewritten by an add"
+        );
         {
             let s = ix.sorted_ids.lock().expect("lock");
-            assert!(s.windows(2).all(|w| w[0] <= w[1]), "merge left it unsorted");
+            assert!(s.windows(2).all(|w| w[0] <= w[1]), "table left unsorted");
         }
-        // A duplicate from the loaded set and one from the merged set are
-        // both caught by the binary search, without building the map.
+        // A duplicate from the loaded set and one from the deferred set
+        // are both caught, without building the map.
         for dup in [1000u64, 1500] {
             let err = ix.add_with_ids(&more[..dim], &[dup]).unwrap_err();
             assert!(matches!(err, AddError::IdAlreadyPresent(d) if d == dup));
@@ -797,6 +821,55 @@ mod tests {
         assert!(
             ix.id_to_slot.get().is_none(),
             "adds must not force the map build"
+        );
+        // The two halves together are exactly the live id set.
+        let mut covered: Vec<u64> = ix.sorted_ids.lock().expect("lock").clone();
+        covered.extend(ix.deferred_added.lock().expect("lock").iter().copied());
+        covered.sort_unstable();
+        let mut live = ix.slot_to_id.clone();
+        live.sort_unstable();
+        assert_eq!(covered, live);
+    }
+
+    /// #383: a deferred-window add whose id sorts BELOW the loaded table
+    /// must not cost O(n). The pre-fix merge rewrote the whole table on
+    /// every such add, so per-add time tracked `n` exactly.
+    ///
+    /// Asserted as a scaling ratio, not an absolute time, and with a
+    /// wide margin: the defect grows the ratio with the size step (8x
+    /// here), so a 3x gate discriminates without being at the mercy of a
+    /// loaded machine.
+    #[test]
+    fn deferred_adds_below_the_table_do_not_scale_with_n() {
+        const DIM: usize = 8;
+        const ADDS: usize = 100;
+        const BASE: u64 = 10_000_000;
+
+        // Per-add wall time for `ADDS` single-row adds with ids that sort
+        // strictly below `BASE`, onto a loaded index of `n` ids.
+        fn per_add_nanos(n: usize) -> f64 {
+            let mut src = IdMapIndex::new(DIM, 4).unwrap();
+            let vectors: Vec<f32> = (0..n * DIM).map(|i| (i % 251) as f32 / 251.0).collect();
+            let ids: Vec<u64> = (0..n as u64).map(|i| BASE + i).collect();
+            src.add_with_ids(&vectors, &ids).unwrap();
+            let mut ix = IdMapIndex::from_bytes(&src.to_bytes()).unwrap();
+            let row = vec![0.25f32; DIM];
+            let t0 = std::time::Instant::now();
+            for i in 0..ADDS as u64 {
+                ix.add_with_ids(&row, &[BASE - 1 - i]).unwrap();
+            }
+            let elapsed = t0.elapsed().as_nanos() as f64;
+            assert!(ix.id_to_slot.get().is_none(), "adds must stay deferred");
+            elapsed / ADDS as f64
+        }
+
+        let small = per_add_nanos(25_000);
+        let large = per_add_nanos(200_000);
+        let ratio = large / small;
+        assert!(
+            ratio < 3.0,
+            "per-add cost scales with n: {small:.0} ns at 25k vs {large:.0} ns at 200k \
+             ({ratio:.1}x for an 8x size step) — a below-the-table add is O(n) again"
         );
     }
 }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -361,11 +361,23 @@ impl TurboQuantIndex {
         })
     }
 
-    /// Whether the packed bit-plane rows are materialized. `false` only
-    /// between a v6 [`Self::load`] and the first mutation or
-    /// serialization that needs them — the window where a mutation
-    /// triggers the (parallel, O(n·dim)) lazy reconstruction. Lets
-    /// bindings pick between an O(1) fast path and a pooled slow path.
+    /// Whether the packed bit-plane rows are materialized.
+    ///
+    /// `false` from a v6 [`Self::load`] until something calls
+    /// [`Self::packed_codes`] — and **nothing else on a loaded index
+    /// does**. The blocked cache the load seeds is authoritative in that
+    /// state, so [`Self::add`] takes the lazy-append branch,
+    /// [`Self::swap_remove`] patches the cache with O(dim) lane ops, and
+    /// serialization copies the cache verbatim; none of them triggers the
+    /// O(n·dim) reconstruction, and none of them sets this flag. A
+    /// load-and-mutate index can therefore report `false` for its entire
+    /// lifetime.
+    ///
+    /// So this is **not** a "first mutation after a load" probe, and
+    /// gating a binding's fast path on it means gating it off forever on
+    /// every loaded index — the defect behind #392. It answers exactly
+    /// one question: which of the two code layouts is currently
+    /// materialized.
     pub fn packed_ready(&self) -> bool {
         self.packed_codes.get().is_some()
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -363,15 +363,22 @@ impl TurboQuantIndex {
 
     /// Whether the packed bit-plane rows are materialized.
     ///
-    /// `false` from a v6 [`Self::load`] until something calls
-    /// [`Self::packed_codes`] — and **nothing else on a loaded index
-    /// does**. The blocked cache the load seeds is authoritative in that
-    /// state, so [`Self::add`] takes the lazy-append branch,
-    /// [`Self::swap_remove`] patches the cache with O(dim) lane ops, and
-    /// serialization copies the cache verbatim; none of them triggers the
-    /// O(n·dim) reconstruction, and none of them sets this flag. A
-    /// load-and-mutate index can therefore report `false` for its entire
-    /// lifetime.
+    /// On a **non-empty** v6 [`Self::load`], `false` until something
+    /// calls [`Self::packed_codes`] — and **nothing else does**. The
+    /// blocked cache the load seeds is authoritative in that state, so
+    /// [`Self::add`] takes the lazy-append branch, [`Self::swap_remove`]
+    /// patches the cache with O(dim) lane ops, and serialization copies
+    /// the cache verbatim; none of them triggers the O(n·dim)
+    /// reconstruction, and none of them sets this flag. Such an index can
+    /// therefore report `false` for its entire lifetime however much it
+    /// is mutated.
+    ///
+    /// The two paths that do set it without `packed_codes` are both out
+    /// of reach there: a v6 load of an **empty** index seeds the lock
+    /// directly, and the TQ+ warm-up crossing replaces it — but a
+    /// non-empty load never enters warm-up, since
+    /// `normalize_calibration` only buffers when the dim is uncommitted
+    /// or the index is empty.
     ///
     /// So this is **not** a "first mutation after a load" probe, and
     /// gating a binding's fast path on it means gating it off forever on


### PR DESCRIPTION
Two live regressions on `main` from the `perf/op-hillclimb` merge (`e178a97`), both in the mutation paths. The second turned out to be a **class**, not an instance: the same permanently-false predicate gated the fast path on `add`, `swap_remove` and `remove`. All three sites are fixed here.

## #383 — deferred-window adds are O(n) when new ids sort below the table

**What.** `IdMapIndex` keeps the load-time sorted id table alive while the `id → slot` map is still lazy, so post-load adds can validate new ids by binary search instead of forcing the O(n) map build. To keep that table current, `826ec51` merged each add's ids into it with a two-run backward merge. The merge breaks out early only when the *new* ids are exhausted, i.e. only when they all sort above the table's tail. An id that sorts below rewrites all n entries, so a chatty post-load add pattern is quadratic — and this runs under the write lock.

**Why it happened.** Same failure shape as #315 one layer down: #315 was the full re-sort, `826ec51` replaced it with the merge and fixed the reported case (ids extending the run), leaving the below-the-table case.

**Fix.** Stop merging. Ids added inside the deferred window go into a side hash set (`deferred_added`); the load-time table is never rewritten. A presence check is one binary search over the loaded table plus one hash lookup in the side set — together they cover exactly the live id set — and an add costs O(rows added) regardless of where the new ids sort. Both halves are freed together when the map materializes, and `deferred_added` documents the same not-freed caveat `sorted_ids` carries (it bites harder on the field that grows per add).

## #392 (items 1–2) — the merge reverted its own H8 delete optimization, and the same predicate was gating `add`

**What.** `c654da9` resolved `turbovec-python/src/lib.rs` by taking main's side wholesale, so `f20df40`'s "always-fast-path removes in bindings (H8)" is absent from main even though it is an ancestor of it. The merge *did* keep the core half: `swap_remove` maintains the blocked cache with O(dim) lane ops and deliberately leaves the packed `OnceLock` empty, and the new `lazy_append` branch in `add` does the same. So `packed_ready()` never becomes true on a loaded index, and the binding probes did not select "first mutation after a load" — they selected **every** mutation on **every** loaded index, routing each through `py.detach` + a rayon pool handoff costing far more than the operation.

**Fix — all three sites.**
- `TurboQuantIndex.swap_remove`: probe and slow path deleted outright.
- `TurboQuantIndex.add`: the `!packed_ready()` term is dropped from the single-row bypass gate. The only payload-sized parallel job on the add path is `self.packed()` (`lib.rs:712`, fanning out at `pack.rs:333` and `pack.rs:554`), which runs only when `!lazy_append`; `!packed_ready()` coexisting with `!lazy_append` requires `n_vectors == 0` or `blocked.is_none()`, and in both `packed()` returns `Vec::new()` before either rayon site. `add_parallelizes` still covers the TQ+ warm-up crossing (#364) and `validation_parallelizes` the wide-row chunking hole (#321).
- `IdMapIndex.remove`: probe kept, but on `slots_ready()` **only**. That is the structure whose first build genuinely is O(n) with the GIL held (#319), and unlike `packed_ready()` it does flip to true after one remove, so it costs one detached remove per loaded index rather than one per call. `with_pool` is dropped from that path — the map build is serial.

**Source of the class.** `TurboQuantIndex::packed_ready`'s own doc comment still asserted the invariant the merge disproved. Both binding comments were derived from it, so fixing only them would have left the trap armed. The comment now states what is true and what the flag is *not* for, scoped to a **non-empty** loaded index — the two paths that set the lock without `packed_codes()` (an empty v6 load at `lib.rs:1374-1378`, the TQ+ crossing at `lib.rs:611`) are both out of reach there, since `normalize_calibration` only buffers when the dim is uncommitted or the index is empty.

Items 3–7 of #392 (missing CHANGELOG coverage of the merge itself, stale published benchmark numbers, `docs/api.md` drift) are documentation work in files other agents are touching and are **not** addressed here, so this PR does not close #392. Note `docs/api.md:113`'s "`remove(id)` is O(1)" is still wrong even after this PR — the first remove on a loaded index remains O(n).

## Discrimination evidence

Each fix was reverted in place (tests untouched), run, and restored. The Python tests were additionally run against `origin/main`'s bindings and against `62c4470` (both remove fixes present, add fix missing).

| test | with fix | fix reverted |
|---|---|---|
| `id_map::tests::deferred_adds_below_the_table_do_not_scale_with_n` | pass | **FAIL** — `27445 ns at 25k vs 194266 ns at 200k (7.1x for an 8x size step)` |
| `id_map::tests::deferred_adds_reject_duplicates_without_touching_the_loaded_table` | pass | **FAIL** — `the load-time table must not be rewritten by an add: left: 110, right: 100` |
| `test_..._id_map_remove_...` | pass | **FAIL** vs `origin/main` — up to `613.8x` |
| `test_..._swap_remove_...` | pass | **FAIL** vs `origin/main` — up to `408.3x` |
| `test_..._single_row_add_...` | pass | **FAIL** at `62c4470` (`4.67`) and vs `origin/main` (`1.16`), gate `0.4` |

## Why the add test is not a loaded-vs-fresh ratio

The first version of the add test used the same loaded-vs-fresh ratio as the removes, gated at 12.0x. **That gate was inside the defect's own distribution** and would have flaked: the add's fresh baseline is ~0.9 µs against 0.06–0.38 µs for the removes, so the same fixed handoff shows as ~25x rather than ~50–280x, and the two distributions overlap under memory pressure. Reproduced here — with the defect live and six probes contending, the loaded-vs-fresh ratio fell to **12.64x against the 12.0x gate**, one step from passing.

Widening the threshold makes it unfalsifiable, so the test now measures something else. A two-row add is pooled under every version of this code (`n_rows > 1`), so **one-row vs two-row on the same loaded index** differs only by the handoff the bypass is supposed to skip, and machine load moves both arms together.

| one-row / two-row | idle | contended |
|---|---|---|
| bypass engaged (fixed) | 0.114–0.124 | 0.078–0.088 |
| defect | 0.808–0.897 | 1.042–1.294 |

Separation widens from 6.5x idle to ~12x under contention — the safe direction. Gate at **0.4**, ~3x clear of both. During the final revert check the box was heavily loaded (a one-row add measured 1201 µs, two-row 257 µs) and the gate still fired unambiguously at 4.67; a fixed-microsecond overhead threshold would not have survived that.

The two remove gates stay as loaded-vs-fresh ratios (8.0x and 12.0x): their fresh baselines are small enough that the defect stays 10–100x clear.

## Perf, A/B interleaved in one run

Binaries built from the same tree with and without each fix, run alternating, min of 3 reps per cell. **Caveat:** shared macOS box with other agents building and testing concurrently; the ratios are the claim, not the absolute microseconds.

### #383 — single-row `add_with_ids` on a loaded index, Rust level, dim=32, 4-bit, 200 adds (µs/add)

Default threads:

| n | above before | above after | below before | below after |
|---|---|---|---|---|
| 50,000 | 3.34 | 3.52 | 52.51 | **3.47** |
| 100,000 | 3.62 | 3.53 | 102.17 | **3.13** |
| 200,000 | 3.63 | 3.60 | 201.22 | **3.16** |
| 400,000 | 3.36 | 3.55 | 405.31 | **3.08** |

`RAYON_NUM_THREADS=1`:

| n | above before | above after | below before | below after |
|---|---|---|---|---|
| 50,000 | 3.18 | 3.49 | 51.80 | **3.49** |
| 100,000 | 3.90 | 3.03 | 100.20 | **3.69** |
| 200,000 | 3.50 | 3.10 | 197.96 | **3.07** |
| 400,000 | 3.47 | 3.47 | 393.87 | **3.02** |

Below-the-table goes from clean linear-in-n to flat at both thread counts; above-the-table, already excellent, is unchanged within noise. No single-threaded regression.

> **This table is Rust-level.** `IdMapIndex.add_with_ids` is unconditionally `with_pool`-wrapped in the Python binding (no single-row bypass), so a Python caller pays a fixed handoff on top of the core add and sees roughly **10x** at n=200k, not the ~60x the table implies. Extending the bypass to `add_with_ids` would be a new optimization rather than a regression fix, so it is deliberately not in this PR.

### #392 — mutations through the bindings, 100k × 128, 4-bit, after warm-up (µs/op)

The "before" penalty is a contended pool handoff, so its magnitude is not a stable quantity — measured anywhere from ~10x to ~600x for the same op within an hour on this box. The direction and the "after" figures are what reproduce.

| op | threads | fresh before | loaded before | fresh after | loaded after |
|---|---|---|---|---|---|
| `IdMapIndex.remove` | default | 0.144 | 17.56 | 0.142 | **0.197** |
| `TurboQuantIndex.swap_remove` | default | 0.064 | 17.77 | 0.045 | **0.097** |
| `TurboQuantIndex.add` (1 row) | default | 1.123 | 31.50 | 1.110 | **3.926** |
| `IdMapIndex.remove` | 1 | 0.139 | 3.13 | 0.135 | **0.191** |
| `TurboQuantIndex.swap_remove` | 1 | 0.062 | 2.98 | 0.043 | **0.094** |
| `TurboQuantIndex.add` (1 row) | 1 | 1.098 | 44.93 | 1.072 | **3.845** |

Win at both thread counts on all three verbs; the fresh-index path is untouched in every row. Post-fix a loaded index costs 1.4x / 2.2x / ~3x a fresh one, stable across runs.

That residual is real work a loaded index does and a fresh one does not: blocked-cache lane ops, and for the add a fixed per-call cost — `pack::extract_codes_flat` rebuilds a 4 KB extract LUT and allocates a `Vec<Vec<u8>>` on **every** call, which a one-row add pays in full. The lazy-append branch is rayon-free, which is what the gate needs, but it is not free; that is serial work to optimize in the core, not a reason to enter the pool, and the binding comment says so.

## Test runs

- `cargo test --release -p turbovec` — 22 binaries, all green.
- `pytest turbovec-python/tests` — 711 passed, 15 skipped, 1 failed: `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, the pre-existing #386 failure on unmodified `main`.
- `cargo clippy --release -p turbovec -p turbovec-python --all-targets` — no new warnings; `cargo fmt --check` shows no new diffs (the three in this file are pre-existing).
- **Flake seen, not caused here:** on heavily loaded runs, `test_store_thread_safety.py::test_delete_vs_delete[haystack|llama_index|agno]` fails with `store fully emptied: got 3632, want 0`. `run_roles` is wall-clock-bounded, so under contention the deleter threads get too few steps to drain the store (13 of ~240 in the failing sample). Reproduces identically against `origin/main`'s bindings and passes on idle runs — pre-existing load sensitivity in that harness, worth a separate issue.

The extension `.so` used for the pytest runs was built and removed before committing; the throwaway bench harnesses are not in the diff.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)
