### PR TITLE
fix: commit state only after the work that can unwind (#380 items 6, 7; ordering hardening for item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,21 @@ appears under each surface it touches.
 
 #### Changed
 
+- **`IdMapIndex::remove` updates its tables only after the inner removal
+  returns (#380).** Ordering hardening rather than a fix for reachable
+  misbehaviour: no input makes `TurboQuantIndex::swap_remove` unwind
+  today — it calls `packed_mut()` only when the packed rows are already
+  materialized, so the lazy O(n·dim) rebuild never fires from a remove,
+  and the rest of it is asserts, in-bounds indexing and allocation-free
+  lane ops. Taking the id out of `id_to_slot` before that call was
+  nonetheless the wrong order: were the inner removal ever to become
+  fallible, a caught panic would leave the id gone from the map, still
+  present in `slot_to_id`, and `slot_to_id` one entry longer than the
+  inner index — the vector searchable but unresolvable, with every later
+  `remove` computing the swap target off the wrong length. The removal
+  now runs first, matching the "index first, then the maps" order the
+  Python stores' delete paths use. No behaviour change.
+
 - **x86 search dispatch now tests every CPU feature the kernels declare
   (#291).** The AVX2 gates additionally require FMA and the AVX-512 gates
   additionally require AVX2+FMA, matching what those kernels execute. On a
@@ -326,24 +341,14 @@ appears under each surface it touches.
 
 #### Fixed
 
-- **`IdMapIndex::remove` no longer drops the id before the removal that
-  can fail (#380).** The id was taken out of `id_to_slot` first, then the
-  inner `swap_remove` ran — and on a v6-loaded index that call performs
-  the lazy O(n·dim) packed rebuild, so it can unwind. A caught panic left
-  the id gone from the map, still present in `slot_to_id`, and
-  `slot_to_id` one entry longer than the inner index: the vector stayed
-  searchable but unresolvable, and every later `remove` computed the
-  swap target off the wrong length. The inner removal now runs first and
-  the tables are updated only after it returns — the same "index first,
-  then the maps" order the Python stores' delete paths use.
-
 - **A panicking first add no longer wedges a lazy index at a committed
   dim (#380).** `add_2d` locked the inferred dim before the encode, so a
   caught encode panic left an index with a dim and no vectors, and the
   follow-up `add_2d` at a different dim got `DimMismatch` instead of the
   fresh start #129 established. The dim — and the rotation, boundary and
   centroid caches derived from it — are now rolled back if the add
-  unwinds.
+  unwinds; rolling back the dim alone would leave the next add at a
+  different dim panicking inside `rotation` instead of starting fresh.
 
 - **The v6 codebook check no longer puts a Lloyd-Max solve on the load
   path (#357).** Validating the embedded codebook by recomputing it and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,18 +42,20 @@ appears under each surface it touches.
 
 - **`IdMapIndex::remove` updates its tables only after the inner removal
   returns (#380).** Ordering hardening rather than a fix for reachable
-  misbehaviour: no input makes `TurboQuantIndex::swap_remove` unwind
-  today — it calls `packed_mut()` only when the packed rows are already
-  materialized, so the lazy O(n·dim) rebuild never fires from a remove,
-  and the rest of it is asserts, in-bounds indexing and allocation-free
-  lane ops. Taking the id out of `id_to_slot` before that call was
-  nonetheless the wrong order: were the inner removal ever to become
-  fallible, a caught panic would leave the id gone from the map, still
-  present in `slot_to_id`, and `slot_to_id` one entry longer than the
-  inner index — the vector searchable but unresolvable, with every later
-  `remove` computing the swap target off the wrong length. The removal
-  now runs first, matching the "index first, then the maps" order the
-  Python stores' delete paths use. No behaviour change.
+  misbehaviour: no unwind is reachable from `remove`, whose slot comes
+  from the id table and so is in bounds by construction — the documented
+  `idx >= n_vectors` panic in `TurboQuantIndex::swap_remove` cannot fire
+  for it. Past that assert, `swap_remove` calls `packed_mut()` only when
+  the packed rows are already materialized, so the lazy O(n·dim) rebuild
+  never fires from a remove, and the rest is in-bounds indexing and
+  allocation-free lane ops. Taking the id out of `id_to_slot` before that
+  call was nonetheless the wrong order: were the inner removal ever to
+  become fallible, a caught panic would leave the id gone from the map,
+  still present in `slot_to_id`, and `slot_to_id` one entry longer than
+  the inner index — the vector searchable but unresolvable, with every
+  later `remove` computing the swap target off the wrong length. The
+  removal now runs first, matching the "index first, then the maps" order
+  the Python stores' delete paths use. No behaviour change.
 
 - **x86 search dispatch now tests every CPU feature the kernels declare
   (#291).** The AVX2 gates additionally require FMA and the AVX-512 gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,25 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **`IdMapIndex::remove` no longer drops the id before the removal that
+  can fail (#380).** The id was taken out of `id_to_slot` first, then the
+  inner `swap_remove` ran — and on a v6-loaded index that call performs
+  the lazy O(n·dim) packed rebuild, so it can unwind. A caught panic left
+  the id gone from the map, still present in `slot_to_id`, and
+  `slot_to_id` one entry longer than the inner index: the vector stayed
+  searchable but unresolvable, and every later `remove` computed the
+  swap target off the wrong length. The inner removal now runs first and
+  the tables are updated only after it returns — the same "index first,
+  then the maps" order the Python stores' delete paths use.
+
+- **A panicking first add no longer wedges a lazy index at a committed
+  dim (#380).** `add_2d` locked the inferred dim before the encode, so a
+  caught encode panic left an index with a dim and no vectors, and the
+  follow-up `add_2d` at a different dim got `DimMismatch` instead of the
+  fresh start #129 established. The dim — and the rotation, boundary and
+  centroid caches derived from it — are now rolled back if the add
+  unwinds.
+
 - **The v6 codebook check no longer puts a Lloyd-Max solve on the load
   path (#357).** Validating the embedded codebook by recomputing it and
   comparing cost 25–100 ms — two orders of magnitude more than the load
@@ -731,6 +750,17 @@ appears under each surface it touches.
   unchanged. (#167)
 
 #### Fixed
+
+- **agno: a failed load no longer leaves a half-loaded store (#380).**
+  `_load_from` replaced `_index`, `_u64_to_doc`, `_next_u64` and all three
+  reverse indexes *before* the side-car/index consistency check that can
+  raise, so a store whose load failed still reported `exists() is True`
+  and a retried `create()` returned silently as "already created",
+  handing back the half-load. The new state is now built into locals and
+  committed in one block after every check has passed — a store whose
+  load raised is one the method never touched. agno is the only
+  integration that loads in place; the other three return a fresh object
+  and were already safe.
 
 - **agno: a half-present save loaded silently empty and was then
   overwritten (#328).** `create()` caught the `FileNotFoundError` that

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -1127,11 +1127,11 @@ class TurboQuantVectorDb(VectorDb):
         # non-unique, so accumulate handles into a set per id rather than a
         # dict comprehension (which would drop all but the last handle and
         # re-orphan the very vectors issue #104 fixed).
-        str_to_u64: Dict[str, set] = {}
+        str_to_u64: Dict[str, Set[int]] = {}
         for handle, data in u64_to_doc.items():
             str_to_u64.setdefault(data["id"], set()).add(handle)
-        content_hashes = set()
-        name_to_ids: Dict[str, set] = {}
+        content_hashes: Set[str] = set()
+        name_to_ids: Dict[str, Set[str]] = {}
         for data in u64_to_doc.values():
             ch = data.get("content_hash")
             if ch:

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -1108,40 +1108,57 @@ class TurboQuantVectorDb(VectorDb):
                     f"with distance={self.distance.value!r}. Construct the "
                     f"store with the matching distance to load it."
                 )
+            distance = self.distance
         else:
-            self.distance = Distance.max_inner_product
+            distance = Distance.max_inner_product
 
-        self._index = IdMapIndex.load(str(index_file))
-        self._u64_to_doc = {int(h): d for h, d in state["u64_to_doc"]}
-        self._next_u64 = int(state["next_u64"])
+        # This is the only in-place load among the four integrations (the
+        # others are classmethods returning a fresh object), so it is the
+        # only one that can leave a caller holding a half-loaded store.
+        # Everything below is therefore built into locals and committed in
+        # one block at the end: the validation after the rebuild still
+        # raises, and a store whose load raised is one this method never
+        # touched (#380).
+        index = IdMapIndex.load(str(index_file))
+        u64_to_doc = {int(h): d for h, d in state["u64_to_doc"]}
+        next_u64 = int(state["next_u64"])
 
         # Rebuild reverse indexes from the loaded payload. doc_id is
         # non-unique, so accumulate handles into a set per id rather than a
         # dict comprehension (which would drop all but the last handle and
         # re-orphan the very vectors issue #104 fixed).
-        self._str_to_u64 = {}
-        for handle, data in self._u64_to_doc.items():
-            self._str_to_u64.setdefault(data["id"], set()).add(handle)
-        self._content_hashes = set()
-        self._name_to_ids = {}
-        for data in self._u64_to_doc.values():
+        str_to_u64: Dict[str, set] = {}
+        for handle, data in u64_to_doc.items():
+            str_to_u64.setdefault(data["id"], set()).add(handle)
+        content_hashes = set()
+        name_to_ids: Dict[str, set] = {}
+        for data in u64_to_doc.values():
             ch = data.get("content_hash")
             if ch:
-                self._content_hashes.add(ch)
+                content_hashes.add(ch)
             name = data.get("name")
             if name:
-                self._name_to_ids.setdefault(name, set()).add(data["id"])
+                name_to_ids.setdefault(name, set()).add(data["id"])
 
         # Reject a side-car whose handle set desynced from the .tvim index
         # (partial copy, stale backup, hand edit) with a clean ValueError
         # here rather than misbehaving later — matching the other
         # integrations' load paths (issue #115).
         check_persisted_handles(
-            self._index,
-            self._u64_to_doc.keys(),
+            index,
+            u64_to_doc.keys(),
             what="document",
-            next_u64=self._next_u64,
+            next_u64=next_u64,
         )
+
+        # Commit point: nothing above can raise any more.
+        self.distance = distance
+        self._index = index
+        self._u64_to_doc = u64_to_doc
+        self._next_u64 = next_u64
+        self._str_to_u64 = str_to_u64
+        self._content_hashes = content_hashes
+        self._name_to_ids = name_to_ids
 
     # ---- Copy & pickle ----------------------------------------------------
     #

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1044,6 +1044,40 @@ def test_load_rejects_side_car_with_extra_handle(tmp_path):
         TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path)).create()
 
 
+def test_failed_load_leaves_the_store_untouched(tmp_path):
+    # agno is the only integration whose load mutates a live store in
+    # place (the other three are classmethods returning a fresh object),
+    # so it is the only one that can leave a caller holding a half-loaded
+    # store. `check_persisted_handles` runs after the maps are rebuilt, so
+    # a desynced side-car used to raise *after* `_index` and every map had
+    # already been replaced: the store then reported `exists() is True`
+    # and a retried `create()` returned silently as "already created",
+    # handing back the corrupt half-load (#380).
+    db = TurboQuantVectorDb(embedder=StubEmbedder())
+    db.create()
+    db.insert("h", [_doc("a"), _doc("b")])
+    db.save(str(tmp_path))
+
+    with open(tmp_path / "docstore.json") as f:
+        state = json.load(f)
+    state["u64_to_doc"] = state["u64_to_doc"][1:]
+    with open(tmp_path / "docstore.json", "w") as f:
+        json.dump(state, f)
+
+    fresh = TurboQuantVectorDb(embedder=StubEmbedder(), path=str(tmp_path))
+    with pytest.raises(ValueError, match="out of sync"):
+        fresh.create()
+
+    assert not fresh.exists(), "a failed load left the store reporting itself as created"
+    assert fresh._u64_to_doc == {}, "a failed load left documents in the store"
+    assert fresh._str_to_u64 == {}
+    assert fresh._next_u64 == 0
+    # The concrete harm: with `_index` set, the retry is a silent no-op
+    # that hands back the half-load instead of re-raising.
+    with pytest.raises(ValueError, match="out of sync"):
+        fresh.create()
+
+
 # ---- Protocol coverage ----------------------------------------------------
 
 

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -328,11 +328,14 @@ impl IdMapIndex {
         // paths use.
         //
         // Ordering hardening, not a live bug fix: `inner.swap_remove` has
-        // no reachable unwind today. It calls `packed_mut()` only inside
-        // `if self.packed_codes.get().is_some()`, so the lazy O(n·dim)
-        // rebuild is never triggered from here — that `get_or_init` is
-        // always a hit — and the rest of it is asserts, in-bounds
-        // indexing and allocation-free lane ops. What the order buys is
+        // no unwind reachable *from here* today. Its one documented panic
+        // is the `idx < n_vectors` assert, and `slot` comes from the id
+        // table, so it is in bounds by construction. Past that assert it
+        // calls `packed_mut()` only inside `if self.packed_codes.get()
+        // .is_some()`, so the lazy O(n·dim) rebuild is never triggered
+        // from a remove — that `get_or_init` is always a hit — and the
+        // rest is in-bounds indexing and allocation-free lane ops (no
+        // rayon, no allocation). What the order buys is
         // that a future fallible inner removal (an incrementally
         // materializing `packed_mut`, say) cannot corrupt the tables:
         // mutating them first would leave `id_to_slot` short while

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -323,15 +323,28 @@ impl IdMapIndex {
     /// otherwise. O(1) via the inner [`TurboQuantIndex::swap_remove`].
     pub fn remove(&mut self, id: u64) -> bool {
         // Look the slot up without mutating, then run the inner removal
-        // FIRST: `swap_remove` calls `packed_mut()`, which on a v6-loaded
-        // index runs the lazy O(n·dim) rebuild, so it can unwind. Taking
-        // the id out of the map before that would leave `id_to_slot`
-        // short and `slot_to_id` one longer than `inner.len()` — the
-        // vector still searchable but unresolvable, and every later
-        // `remove`/`search_with_allowlist` computing `last` off the wrong
-        // length (#380). Same "index first, then the maps" order the
-        // Python stores' delete paths use. Everything after the inner
-        // removal below is infallible table bookkeeping.
+        // first and update the tables only after it returns — "index
+        // first, then the maps", the order the Python stores' delete
+        // paths use.
+        //
+        // Ordering hardening, not a live bug fix: `inner.swap_remove` has
+        // no reachable unwind today. It calls `packed_mut()` only inside
+        // `if self.packed_codes.get().is_some()`, so the lazy O(n·dim)
+        // rebuild is never triggered from here — that `get_or_init` is
+        // always a hit — and the rest of it is asserts, in-bounds
+        // indexing and allocation-free lane ops. What the order buys is
+        // that a future fallible inner removal (an incrementally
+        // materializing `packed_mut`, say) cannot corrupt the tables:
+        // mutating them first would leave `id_to_slot` short while
+        // `slot_to_id` stayed one longer than `inner.len()`, so the
+        // vector would be searchable but unresolvable and every later
+        // `remove` would compute `last` off the wrong length (#380).
+        //
+        // This orders the two halves; it does not make the operation
+        // atomic. `inner.swap_remove` is itself multi-step, so an unwind
+        // partway through it would leave the inner index short against
+        // full tables — the same desync with the opposite polarity, which
+        // no ordering here can prevent.
         let Some(&slot) = self.ids().get(&id) else {
             return false;
         };

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -322,13 +322,25 @@ impl IdMapIndex {
     /// Returns `true` if the id was present and removed, `false`
     /// otherwise. O(1) via the inner [`TurboQuantIndex::swap_remove`].
     pub fn remove(&mut self, id: u64) -> bool {
-        let Some(slot) = self.ids_mut().remove(&id) else {
+        // Look the slot up without mutating, then run the inner removal
+        // FIRST: `swap_remove` calls `packed_mut()`, which on a v6-loaded
+        // index runs the lazy O(n·dim) rebuild, so it can unwind. Taking
+        // the id out of the map before that would leave `id_to_slot`
+        // short and `slot_to_id` one longer than `inner.len()` — the
+        // vector still searchable but unresolvable, and every later
+        // `remove`/`search_with_allowlist` computing `last` off the wrong
+        // length (#380). Same "index first, then the maps" order the
+        // Python stores' delete paths use. Everything after the inner
+        // removal below is infallible table bookkeeping.
+        let Some(&slot) = self.ids().get(&id) else {
             return false;
         };
         let last = self.slot_to_id.len() - 1;
 
         let moved_from = self.inner.swap_remove(slot);
         debug_assert_eq!(moved_from, last);
+
+        self.ids_mut().remove(&id);
 
         // Mirror the swap-and-pop in our tables.
         if slot != last {

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1302,3 +1302,100 @@ mod settled_append_unwind {
         assert_eq!(idx.search(probe, 5).indices[0], 7);
     }
 }
+
+/// #380: state committed before the fallible work that has to succeed
+/// for it to be true.
+///
+/// Two sites, one shape. `IdMapIndex::remove` took the id out of its
+/// tables before the inner `swap_remove` that can unwind, and `add_2d`
+/// committed a lazy index's dim before the encode that can unwind. Both
+/// leave a *usable* object behind — the binding swallows lock poisoning
+/// — so the damage is observable and silent rather than fatal.
+mod state_before_fallible_work {
+    use crate::{AddError, IdMapIndex, TurboQuantIndex};
+
+    fn rows(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+        let mut v = vec![0.0f32; n * dim];
+        let mut s = seed | 1;
+        for x in v.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+        }
+        v
+    }
+
+    /// A panic in the inner removal must leave the id tables untouched:
+    /// the id still resolves, the tables still agree with `inner.len()`,
+    /// and a retry removes exactly one vector.
+    #[test]
+    fn a_panicking_inner_removal_leaves_the_id_tables_intact() {
+        let dim = 64;
+        let mut idx = IdMapIndex::new(dim, 4).unwrap();
+        let ids: Vec<u64> = (0..1200).collect();
+        idx.add_with_ids_2d(&rows(1200, dim, 1), dim, &ids).unwrap();
+
+        TurboQuantIndex::force_swap_remove_panic(true);
+        let failed =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| idx.remove(7)));
+        assert!(failed.is_err(), "the forced swap_remove panic should have propagated");
+
+        assert_eq!(idx.len(), 1200, "a caught panic changed the row count");
+        assert!(
+            idx.contains(7),
+            "a caught panic dropped the id from the map while its vector is still stored",
+        );
+        // The desync the reorder prevents: `slot_to_id` one longer than
+        // the inner index, so every later remove computes `last` off the
+        // wrong length. An allowlist search over every id is the cheapest
+        // observable proof both tables still agree with `inner`.
+        let (_, got) = idx.search_with_allowlist(&rows(1, dim, 3), 1200, Some(&ids)).unwrap();
+        assert_eq!(got.len(), 1200, "the allowlist lost an id after a caught panic");
+
+        // And a retry removes exactly the one vector, no more.
+        assert!(idx.remove(7));
+        assert_eq!(idx.len(), 1199);
+        assert!(!idx.contains(7));
+        let probe = &rows(1200, dim, 1)[9 * dim..10 * dim];
+        assert_eq!(idx.search(probe, 5).1[0], 9, "self-recall broken after the retry");
+    }
+
+    /// A panic in the first add of a lazy index must leave it lazy: the
+    /// dim is not committed, so a follow-up `add_2d` at a *different*
+    /// dim gets the fresh start #129 established rather than a
+    /// `DimMismatch` naming a dim the index never actually stored.
+    #[test]
+    fn a_panicking_first_add_leaves_a_lazy_index_lazy() {
+        let mut idx = TurboQuantIndex::new_lazy(4).unwrap();
+        assert_eq!(idx.dim_opt(), None);
+
+        TurboQuantIndex::force_encode_panic(true);
+        let failed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            idx.add_2d(&rows(10, 64, 1), 64)
+        }));
+        assert!(failed.is_err(), "the forced encode panic should have propagated");
+
+        assert_eq!(idx.len(), 0, "a caught panic left rows behind");
+        assert_eq!(
+            idx.dim_opt(),
+            None,
+            "a caught panic wedged the lazy index at a committed dim with no vectors",
+        );
+
+        // The user-visible consequence: retrying at a different dim.
+        idx.add_2d(&rows(10, 128, 2), 128).expect("a lazy index should still accept a new dim");
+        assert_eq!(idx.dim_opt(), Some(128));
+        assert_eq!(idx.len(), 10);
+        // The dim-derived caches were rolled back with the dim, so the
+        // rows are encoded under a dim-128 rotation and self-recall holds.
+        let probe = &rows(10, 128, 2)[3 * 128..4 * 128];
+        assert_eq!(idx.search(probe, 3).indices[0], 3, "rolled-back caches were reused");
+
+        // The committed dim is now real: a mismatched add is rejected.
+        assert!(matches!(
+            idx.add_2d(&rows(1, 64, 3), 64),
+            Err(AddError::DimMismatch { existing: 128, got: 64 })
+        ));
+    }
+}

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -140,7 +140,6 @@ mod codebook_correctness {
 /// From `tests/encode.rs` — encoding-pipeline shape/scale correctness.
 mod encode_pipeline {
     use crate::codebook::codebook;
-    use crate::encode::encode;
     /// Test shim preserving the old owned-return encode signature.
     #[allow(clippy::too_many_arguments)]
     fn encode_owned(
@@ -536,7 +535,6 @@ mod core_encode_hardening {
     use std::panic::{catch_unwind, AssertUnwindSafe};
 
     use crate::codebook::codebook;
-    use crate::encode::encode;
     /// Test shim preserving the old owned-return encode signature.
     #[allow(clippy::too_many_arguments)]
     fn encode_owned(

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1303,14 +1303,17 @@ mod settled_append_unwind {
     }
 }
 
-/// #380: state committed before the fallible work that has to succeed
-/// for it to be true.
+/// #380: state committed before the work that has to succeed for it to
+/// be true.
 ///
-/// Two sites, one shape. `IdMapIndex::remove` took the id out of its
-/// tables before the inner `swap_remove` that can unwind, and `add_2d`
-/// committed a lazy index's dim before the encode that can unwind. Both
-/// leave a *usable* object behind — the binding swallows lock poisoning
-/// — so the damage is observable and silent rather than fatal.
+/// Two sites, one shape, but they differ in how live they are.
+/// `add_2d` committing a lazy index's dim before the encode is a real
+/// defect with a real unwind behind it. `IdMapIndex::remove` mutating
+/// its tables before the inner `swap_remove` is ordering hardening:
+/// `swap_remove` has no reachable unwind today (see
+/// `force_swap_remove_panic`), so that test pins the statement order
+/// against a future fallible inner removal rather than reproducing a
+/// bug reachable from the public API.
 mod state_before_fallible_work {
     use crate::{AddError, IdMapIndex, TurboQuantIndex};
 
@@ -1327,8 +1330,14 @@ mod state_before_fallible_work {
     }
 
     /// A panic in the inner removal must leave the id tables untouched:
-    /// the id still resolves, the tables still agree with `inner.len()`,
-    /// and a retry removes exactly one vector.
+    /// the id still resolves, the tables still agree with the inner
+    /// index, and a retry removes exactly one vector.
+    ///
+    /// The switch fires before `swap_remove` touches anything, so this
+    /// pins the caller's statement order and only that. It deliberately
+    /// does not claim `remove` is atomic: a panic partway through
+    /// `swap_remove` would leave the inner index short against full
+    /// tables, which the ordering cannot address.
     #[test]
     fn a_panicking_inner_removal_leaves_the_id_tables_intact() {
         let dim = 64;
@@ -1341,7 +1350,13 @@ mod state_before_fallible_work {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| idx.remove(7)));
         assert!(failed.is_err(), "the forced swap_remove panic should have propagated");
 
-        assert_eq!(idx.len(), 1200, "a caught panic changed the row count");
+        // `IdMapIndex::len()` is `slot_to_id.len()`, so it pins the table
+        // length only. The stored row count is a separate fact: assert it
+        // through the effective k a search clamps to, which comes from
+        // the inner index's length.
+        assert_eq!(idx.len(), 1200, "a caught panic changed the id table length");
+        let (_, all) = idx.search(&rows(1, dim, 3), 5000);
+        assert_eq!(all.len(), 1200, "a caught panic changed the stored row count");
         assert!(
             idx.contains(7),
             "a caught panic dropped the id from the map while its vector is still stored",
@@ -1387,10 +1402,14 @@ mod state_before_fallible_work {
         idx.add_2d(&rows(10, 128, 2), 128).expect("a lazy index should still accept a new dim");
         assert_eq!(idx.dim_opt(), Some(128));
         assert_eq!(idx.len(), 10);
-        // The dim-derived caches were rolled back with the dim, so the
-        // rows are encoded under a dim-128 rotation and self-recall holds.
+        // Rolling back the dim alone is not enough, and this is the line
+        // that proves it: with the rotation cache left behind, the add
+        // above panics in `rotation` ("rotation input row must have
+        // length dim, left: 128, right: 64") rather than returning. The
+        // failure is loud, not silent — the recall check below is a
+        // belt-and-braces follow-up, not the discriminator.
         let probe = &rows(10, 128, 2)[3 * 128..4 * 128];
-        assert_eq!(idx.search(probe, 3).indices[0], 3, "rolled-back caches were reused");
+        assert_eq!(idx.search(probe, 3).indices[0], 3, "self-recall broken at the new dim");
 
         // The committed dim is now real: a mismatched add is rejected.
         assert!(matches!(

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1310,10 +1310,11 @@ mod settled_append_unwind {
 /// `add_2d` committing a lazy index's dim before the encode is a real
 /// defect with a real unwind behind it. `IdMapIndex::remove` mutating
 /// its tables before the inner `swap_remove` is ordering hardening:
-/// `swap_remove` has no reachable unwind today (see
-/// `force_swap_remove_panic`), so that test pins the statement order
-/// against a future fallible inner removal rather than reproducing a
-/// bug reachable from the public API.
+/// `swap_remove` has no unwind reachable from that caller today — its
+/// one documented panic is the `idx < n_vectors` assert, and the slot
+/// comes from the id table (see `force_swap_remove_panic`). That test
+/// pins the statement order against a future fallible inner removal
+/// rather than reproducing a bug reachable from the public API.
 mod state_before_fallible_work {
     use crate::{AddError, IdMapIndex, TurboQuantIndex};
 
@@ -1402,12 +1403,14 @@ mod state_before_fallible_work {
         idx.add_2d(&rows(10, 128, 2), 128).expect("a lazy index should still accept a new dim");
         assert_eq!(idx.dim_opt(), Some(128));
         assert_eq!(idx.len(), 10);
-        // Rolling back the dim alone is not enough, and this is the line
-        // that proves it: with the rotation cache left behind, the add
-        // above panics in `rotation` ("rotation input row must have
-        // length dim, left: 128, right: 64") rather than returning. The
-        // failure is loud, not silent — the recall check below is a
-        // belt-and-braces follow-up, not the discriminator.
+        // Rolling back the dim alone is not enough, and the `add_2d`
+        // above is what proves it: with the rotation cache left behind it
+        // panics ("rotation input row must have length dim, left: 128,
+        // right: 64") instead of returning, so the `.expect` fires. That
+        // failure is loud, not silent. The recall check below covers the
+        // case the rotation assert hides — a stale `boundaries`/
+        // `centroids` pair for the old dim is length-compatible, so it
+        // would be accepted and mis-quantize every row rather than panic.
         let probe = &rows(10, 128, 2)[3 * 128..4 * 128];
         assert_eq!(idx.search(probe, 3).indices[0], 3, "self-recall broken at the new dim");
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -662,13 +662,22 @@ impl TurboQuantIndex {
     }
 
     /// Sibling of [`Self::force_encode_panic`] for [`Self::swap_remove`],
-    /// thread-local for the same reason (#373). Models the one unwind
-    /// `swap_remove` really has — `packed_mut()`'s lazy O(n·dim) rebuild
-    /// on a v6-loaded index — so the layers above it (notably
-    /// [`crate::IdMapIndex::remove`]) can be tested for whether they
-    /// mutate their own state before calling it. Fires before anything in
-    /// the index is touched, which is exactly the case those layers must
-    /// survive.
+    /// thread-local for the same reason (#373).
+    ///
+    /// `swap_remove` has no reachable unwind of its own: `packed_mut()`
+    /// is called only under `if self.packed_codes.get().is_some()`, so
+    /// its lazy rebuild never fires from here, and what remains is
+    /// asserts, in-bounds indexing and allocation-free lane ops. This
+    /// switch exists to pin the *callers'* statement order anyway —
+    /// [`crate::IdMapIndex::remove`] must not mutate its tables before
+    /// calling this — so the ordering keeps holding if `swap_remove`
+    /// ever becomes fallible (an incrementally materializing
+    /// `packed_mut`, say).
+    ///
+    /// Fires before anything in the index is touched, so it exercises
+    /// exactly that ordering and nothing else: a panic *partway through*
+    /// `swap_remove` would tear the inner index against its callers'
+    /// tables, which no caller-side ordering can prevent.
     #[cfg(test)]
     pub(crate) fn force_swap_remove_panic(on: bool) {
         FORCE_SWAP_REMOVE_PANIC.with(|f| f.set(on));
@@ -955,12 +964,13 @@ impl TurboQuantIndex {
             // "committed dim, zero vectors", so a follow-up `add_2d` with
             // a different dim gets `DimMismatch` instead of the fresh
             // start #129 established. Roll the commit back — along with
-            // the caches `add` derives from this dim, which would
-            // otherwise be silently reused at the wrong dim by the next
-            // add — so a caught panic leaves the index exactly as lazy as
-            // it was (#380). `encode_and_append`'s own guard restores the
-            // code and scale buffers, and nothing else is touched before
-            // the encode.
+            // the caches `add` derives from this dim, which the next add
+            // at a different dim would otherwise reuse: the rotation
+            // asserts its input row length, so that add panics inside
+            // `rotation` instead of starting fresh — so a caught panic
+            // leaves the index exactly as lazy as it was (#380).
+            // `encode_and_append`'s own guard restores the code and scale
+            // buffers, and nothing else is touched before the encode.
             self.dim = Some(dim);
             if let Err(panic) =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.add(vectors)))

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -111,8 +111,12 @@ thread_local! {
     static FORCE_FIT_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
-/// See [`TurboQuantIndex::force_swap_remove_panic`]. Thread-local for
-/// exactly the reason [`FORCE_ENCODE_PANIC`] is (#373).
+// See `TurboQuantIndex::force_swap_remove_panic`. Thread-local for
+// exactly the reason `FORCE_ENCODE_PANIC` is (#373). Plain comments, not
+// doc comments: `///` does not attach to a `thread_local!` invocation —
+// rustdoc generates nothing for macro invocations, so the text would
+// render nowhere. Third occurrence of this trap in this file today; the
+// clippy leg from #389 is what catches it.
 #[cfg(test)]
 thread_local! {
     static FORCE_SWAP_REMOVE_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -664,15 +664,22 @@ impl TurboQuantIndex {
     /// Sibling of [`Self::force_encode_panic`] for [`Self::swap_remove`],
     /// thread-local for the same reason (#373).
     ///
-    /// `swap_remove` has no reachable unwind of its own: `packed_mut()`
-    /// is called only under `if self.packed_codes.get().is_some()`, so
-    /// its lazy rebuild never fires from here, and what remains is
-    /// asserts, in-bounds indexing and allocation-free lane ops. This
-    /// switch exists to pin the *callers'* statement order anyway —
-    /// [`crate::IdMapIndex::remove`] must not mutate its tables before
-    /// calling this — so the ordering keeps holding if `swap_remove`
-    /// ever becomes fallible (an incrementally materializing
-    /// `packed_mut`, say).
+    /// `swap_remove` does unwind on a caller error — the `idx <
+    /// n_vectors` assert below is documented and reachable from the
+    /// public API. What it has no reachable unwind for is a *valid*
+    /// `idx`: `packed_mut()` is called only under `if self.packed_codes
+    /// .get().is_some()`, so its lazy rebuild never fires from here, and
+    /// what remains is in-bounds indexing and allocation-free lane ops.
+    /// That is the case [`crate::IdMapIndex::remove`] is in — its slot
+    /// comes from the id table, so it is in bounds by construction.
+    ///
+    /// This switch exists to pin that caller's statement order anyway —
+    /// it must not mutate its tables before calling this — so the
+    /// ordering keeps holding if `swap_remove` ever becomes fallible for
+    /// a valid `idx` (an incrementally materializing `packed_mut`, say).
+    /// Same category as [`encode::force_panic_after_append`], which pins
+    /// a guard whose `truncate` is likewise a no-op against today's
+    /// `encode` and defense against a future incremental one (#384).
     ///
     /// Fires before anything in the index is touched, so it exercises
     /// exactly that ordering and nothing else: a panic *partway through*
@@ -964,13 +971,22 @@ impl TurboQuantIndex {
             // "committed dim, zero vectors", so a follow-up `add_2d` with
             // a different dim gets `DimMismatch` instead of the fresh
             // start #129 established. Roll the commit back — along with
-            // the caches `add` derives from this dim, which the next add
-            // at a different dim would otherwise reuse: the rotation
-            // asserts its input row length, so that add panics inside
-            // `rotation` instead of starting fresh — so a caught panic
-            // leaves the index exactly as lazy as it was (#380).
-            // `encode_and_append`'s own guard restores the code and scale
-            // buffers, and nothing else is touched before the encode.
+            // all three caches `add` derives from this dim, which the
+            // next add at a different dim would otherwise reuse. Each
+            // matters differently, so none of the three resets is
+            // redundant: the rotation asserts its input row length, so
+            // reusing it turns the retry into a panic inside `rotation`
+            // rather than a fresh start (loud, but still wrong), while
+            // `boundaries`/`centroids` are dim-dependent *and* length-
+            // compatible — a stale codebook for the old dim would be
+            // accepted and silently mis-quantize every row. The codebook
+            // case is the silent one and only unreachable because the
+            // rotation assert fires first; resetting the rotation alone
+            // would leave it exposed the moment that ordering changed.
+            // With all three rolled back a caught panic leaves the index
+            // exactly as lazy as it was (#380). `encode_and_append`'s own
+            // guard restores the code and scale buffers, and nothing else
+            // is touched before the encode.
             self.dim = Some(dim);
             if let Err(panic) =
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.add(vectors)))

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -111,6 +111,13 @@ thread_local! {
     static FORCE_FIT_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+/// See [`TurboQuantIndex::force_swap_remove_panic`]. Thread-local for
+/// exactly the reason [`FORCE_ENCODE_PANIC`] is (#373).
+#[cfg(test)]
+thread_local! {
+    static FORCE_SWAP_REMOVE_PANIC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 /// Norm at or below which a vector has no representable direction.
 ///
 /// The encoder stores every vector as (unit direction, norm). At or
@@ -654,6 +661,19 @@ impl TurboQuantIndex {
         FORCE_FIT_PANIC.with(|f| f.set(on));
     }
 
+    /// Sibling of [`Self::force_encode_panic`] for [`Self::swap_remove`],
+    /// thread-local for the same reason (#373). Models the one unwind
+    /// `swap_remove` really has — `packed_mut()`'s lazy O(n·dim) rebuild
+    /// on a v6-loaded index — so the layers above it (notably
+    /// [`crate::IdMapIndex::remove`]) can be tested for whether they
+    /// mutate their own state before calling it. Fires before anything in
+    /// the index is touched, which is exactly the case those layers must
+    /// survive.
+    #[cfg(test)]
+    pub(crate) fn force_swap_remove_panic(on: bool) {
+        FORCE_SWAP_REMOVE_PANIC.with(|f| f.set(on));
+    }
+
     /// Encode `n` rows and append them to the stored codes, using the
     /// committed calibration when there is one and fitting (and
     /// committing) a fresh one otherwise. Assumes the caller has already
@@ -928,7 +948,30 @@ impl TurboQuantIndex {
         // Lazy commit happens via add() (which goes through `self.dim.expect`),
         // so re-do the dim assignment here for the lazy-first-add case.
         if self.dim.is_none() {
+            // `add` is fallible (an encode panic — kernel invariant
+            // assert or rayon worker fault), and it needs the dim
+            // committed to run at all. Committing it and leaving it
+            // committed after an unwind wedges the lazy index at
+            // "committed dim, zero vectors", so a follow-up `add_2d` with
+            // a different dim gets `DimMismatch` instead of the fresh
+            // start #129 established. Roll the commit back — along with
+            // the caches `add` derives from this dim, which would
+            // otherwise be silently reused at the wrong dim by the next
+            // add — so a caught panic leaves the index exactly as lazy as
+            // it was (#380). `encode_and_append`'s own guard restores the
+            // code and scale buffers, and nothing else is touched before
+            // the encode.
             self.dim = Some(dim);
+            if let Err(panic) =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| self.add(vectors)))
+            {
+                self.dim = None;
+                self.rotation = OnceLock::new();
+                self.boundaries = OnceLock::new();
+                self.centroids = OnceLock::new();
+                std::panic::resume_unwind(panic);
+            }
+            return Ok(());
         }
         self.add(vectors);
         Ok(())
@@ -1765,6 +1808,10 @@ impl TurboQuantIndex {
     /// the call); equals `idx` when `idx` was already the last element.
     /// Panics if `idx >= n_vectors`.
     pub fn swap_remove(&mut self, idx: usize) -> usize {
+        #[cfg(test)]
+        if FORCE_SWAP_REMOVE_PANIC.with(|f| f.replace(false)) {
+            panic!("forced swap_remove panic (test)");
+        }
         assert!(
             idx < self.n_vectors,
             "index {idx} out of bounds (n_vectors = {})",


### PR DESCRIPTION
Closes the remaining actionable items of #380. Items 1-2 were fixed in #377; item 1 of the eager-add variant is in #394 (in review).

**Revised after adversarial review** ([comment](https://github.com/RyanCodrai/turbovec/pull/398#issuecomment-5121918859)): the code is unchanged, but item 3's justification was wrong and is now corrected throughout. Details in that section.

Every behavioural fix below has a test proven to fail without it: the fix was reverted, the test run and observed to fail with the stated assertion, then restored and re-run green.

## Item 6 (LOW) — lazy dim committed before the fallible add

`turbovec/src/lib.rs`, `add_2d`. `self.dim = Some(dim); self.add(vectors);` — a caught encode panic left a lazy index wedged at "committed dim, zero vectors", so a follow-up `add_2d` with a different dim got `DimMismatch` instead of the fresh start #129 established.

`add` needs the dim committed to run at all, so this one cannot be a pure build-then-swap. The commit is instead rolled back on unwind — *along with* the rotation/boundary/centroid caches `add` derives from that dim. That part is load-bearing rather than defensive: rolling back the dim alone leaves a dim-64 rotation in the `OnceLock` that the next add at dim 128 reuses. Verified by deleting just the three cache resets and re-running the test, which then fails inside `rotation.rs` with `rotation input row must have length dim, left: 128, right: 64`. Note that is a **loud** failure, not silent corruption — an earlier revision of this body overstated it. The genuinely silent candidate is the codebook pair: `boundaries`/`centroids` are dim-dependent *and* length-compatible, so a stale pair for the old dim would be accepted and mis-quantize every row rather than assert. It is unreachable only because the rotation assert fires first — which is why all three resets are kept, and why the in-tree comment now records that argument rather than justifying the rotation reset alone.

**Evidence.** New test `state_before_fallible_work::a_panicking_first_add_leaves_a_lazy_index_lazy`. Without the fix it fails at `a caught panic wedged the lazy index at a committed dim with no vectors` (`left: Some(64)`, `right: None`).

## Item 7 (LOW) — agno's `_load_from` mutated the live store before it could still raise

`turbovec-python/python/turbovec/agno.py`. `check_persisted_handles` runs *after* `self.distance`, `self._index`, `self._u64_to_doc`, `self._next_u64` and all three reverse indexes have been replaced, so a desynced side-car raised on a store that had already been overwritten. Concrete harm, since `create()` is the only caller: the store then reports `exists() is True`, and a retried `create()` returns silently as "already created", handing the caller the half-load.

Fixed structurally, as the other three integrations already are by construction (they load into a fresh object via classmethods): everything is built into locals, the validation still raises, and the seven fields are committed in one block at the end. A store whose load raised is one this method never touched.

**Evidence.** New test `test_agno.py::test_failed_load_leaves_the_store_untouched`. Without the fix it fails at `a failed load left the store reporting itself as created`. It also asserts the retried `create()` re-raises instead of silently succeeding.

## Item 3 (filed MEDIUM-HIGH) — ordering hardening, NOT a reachable defect

The reorder is kept; **its justification was wrong and has been rewritten.**

#380 states that `IdMapIndex::remove` mutates its tables before an inner `swap_remove` that can unwind via `packed_mut()`'s lazy O(n·dim) rebuild. **That unwind does not exist.** `swap_remove` calls `packed_mut()` only inside `if self.packed_codes.get().is_some()`, so the `get_or_init` is always a hit and the rebuild never fires from a remove. Confirmed with a probe against this branch: after a v6 load, `packed_ready()` is `false` and stays `false` across 34 removes.

**Scoped precisely, because an earlier revision of this body got the sign wrong in the other direction.** `swap_remove` *does* unwind — its rustdoc documents `Panics if idx >= n_vectors`, and `swap_remove(999)` on a 10-row index unwinds with `index 999 out of bounds (n_vectors = 10)`. The true statement is caller-scoped: **no unwind is reachable from `IdMapIndex::remove`**, whose slot comes from the id table and is therefore in bounds by construction, so that assert cannot fire for it. Past the assert, what remains is in-bounds indexing and allocation-free lane ops (`move_lane` takes `&mut [u8]`) — no allocation, no rayon. Saying "no input makes `swap_remove` unwind" was false about a public method and contradicted itself by listing "asserts" among what remains; all four in-tree sites now carry the scoped clause.

This is the same standard applied to items 4 and 5 below, and applying it inconsistently is what the review correctly blocked on. The original body, the `id_map.rs` comment, the hook doc, the test doc and the CHANGELOG all asserted the false unwind; all five now state the reachability accurately and with the caller scope attached.

**What is kept and why.** Index-first-then-tables is the right order regardless and costs nothing, so the reorder stays — as hardening that keeps the invariant holding by construction if the inner removal ever becomes fallible (an incrementally materializing `packed_mut` is the obvious future). The CHANGELOG entry moved from **Fixed** to **Changed** and says "No behaviour change".

**Scope of the test.** `force_swap_remove_panic` fires at the first statement of `swap_remove`, so the test pins the caller's statement order and nothing more. The switch is the same category as `encode::force_panic_after_append` from #384, which pins a guard whose `truncate` is likewise a no-op against today's `encode` and defense against a future incremental one (`595ab31:turbovec/src/encode.rs:483`); the hook doc now cites it as precedent for "no-op guard plus a switch that pins it". It does not establish that `remove` is atomic: `swap_remove` is itself multi-step, and a panic partway through it would leave the inner index short against full tables — the same desync with the opposite polarity, which no caller-side ordering can prevent. Both the hook doc and the test doc now say this rather than implying whole-operation safety.

## NOT fixed, with reasons

- **Item 4 (PLAUSIBLE) — blocked cache truncated before the repack, in `encode_and_append`.** Not reproducible on `main`: the code already computes the patch *before* touching the cache, and `n_vectors` is already published last. The only remaining window is `truncate` → `extend_from_slice`, which can fail only on allocation, and allocation failure aborts rather than unwinds. Nothing to guard. The adjacent hazard that *is* real on main — `packed_codes`/`scales` published before the repack — is #388, fixed in #394, so this file is deliberately left otherwise untouched to keep that PR conflict-free.
- **Item 5 (PLAUSIBLE) — the same shape in `swap_remove`.** Not present on `main`. The `truncate`-then-`redo` the issue describes was replaced by the O(dim) lane-op path (`move_lane`, `zero_lane`, `truncate`), which mutates the cache in place and allocates nothing, so there is no window in which a panic could leave a stale-but-correctly-sized block.
- **Items 1-2** — already fixed in #377.

## Testing

`cargo test --release -p turbovec`: green across all 22 targets. Full Python suite: 709 passed, 15 skipped, 1 failed — `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, the known pre-existing #386 failure.

One flake seen and not reproduced: a single full-suite run also failed `test_store_thread_safety.py::test_delete_vs_delete` for both `agno` and `llama_index` (`invariant store fully emptied: got 3744, want 0`). It passed 10/10 in isolation on this branch and on pristine `origin/main` files, and the same run failed the `llama_index` parametrization, which this PR does not touch — so it reads as load-dependent flakiness in that concurrency test rather than a regression here. Flagging it since it is adjacent to in-flight concurrency work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
