### PR TITLE
fix: thread-safety harness scored deadlocks as passes; async methods blocked the event loop (#371, #342)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -637,10 +637,11 @@ appears under each surface it touches.
 - **LangChain / LlamaIndex / Agno async methods no longer block the event
   loop, and `asyncio.wait_for` now works on them (#342).** The `a*` /
   `async_*` methods ran their index work inline on the loop thread, so a
-  20k-doc `aadd_texts` blocked the loop for its full ~820 ms and a
-  deadline could never be delivered — `await asyncio.wait_for(...,
-  timeout=0.05)` measured 870 ms with no `TimeoutError` and all documents
-  committed. Each method now runs its sync body on a worker thread via
+  large `aadd_texts` blocked the loop for the operation's full duration
+  and a deadline could never be delivered at all — `await
+  asyncio.wait_for(..., timeout=0.05)` ran to completion with no
+  `TimeoutError` raised and every document committed. Each method now
+  runs its sync body on a worker thread via
   `asyncio.to_thread`, matching `VectorStore`'s own `run_in_executor`
   defaults and the `asyncio.to_thread` shape Agno's in-tree sync-backed
   vector DBs use. One offload per method, never one per chunk, so the
@@ -648,11 +649,15 @@ appears under each surface it touches.
   unchanged. Agno's `async_exists` / `async_name_exists` /
   `async_get_count` still answer inline — O(1) reads where a thread hop
   costs more than it saves. **Cancellation is partial by design:** the
-  awaiting caller is released promptly, but the worker thread runs the
-  already-started call to completion (work inside the Rust core is not
-  interruptible), so a cancelled write may still commit. Treat a timeout
-  as "outcome unknown" and make retries idempotent; the store is never
-  left torn. Documented per integration.
+  awaiting caller is released promptly, but cancelling does not decide
+  what happened to the write. A worker that already started runs the call
+  to completion (work inside the Rust core is not interruptible) and the
+  write commits in full; a call still queued behind a saturated executor
+  is cancelled before it ever runs and nothing is written. A cancelled
+  write is therefore "outcome unknown" — it may have fully committed, or
+  may never have begun — so make retries idempotent. The one guarantee is
+  that the outcome is all-or-nothing: the store is never left torn.
+  Documented per integration.
 
 - **Index file format break (v5): saved indexes from older versions no
   longer load.** The Python package inherits the Rust crate's format v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -634,6 +634,26 @@ appears under each surface it touches.
 
 #### Changed
 
+- **LangChain / LlamaIndex / Agno async methods no longer block the event
+  loop, and `asyncio.wait_for` now works on them (#342).** The `a*` /
+  `async_*` methods ran their index work inline on the loop thread, so a
+  20k-doc `aadd_texts` blocked the loop for its full ~820 ms and a
+  deadline could never be delivered — `await asyncio.wait_for(...,
+  timeout=0.05)` measured 870 ms with no `TimeoutError` and all documents
+  committed. Each method now runs its sync body on a worker thread via
+  `asyncio.to_thread`, matching `VectorStore`'s own `run_in_executor`
+  defaults and the `asyncio.to_thread` shape Agno's in-tree sync-backed
+  vector DBs use. One offload per method, never one per chunk, so the
+  locked bodies stay atomic and the issue-#146 / #89 orderings are
+  unchanged. Agno's `async_exists` / `async_name_exists` /
+  `async_get_count` still answer inline — O(1) reads where a thread hop
+  costs more than it saves. **Cancellation is partial by design:** the
+  awaiting caller is released promptly, but the worker thread runs the
+  already-started call to completion (work inside the Rust core is not
+  interruptible), so a cancelled write may still commit. Treat a timeout
+  as "outcome unknown" and make retries idempotent; the store is never
+  left torn. Documented per integration.
+
 - **Index file format break (v5): saved indexes from older versions no
   longer load.** The Python package inherits the Rust crate's format v5
   rotation break (see the Rust section): any `.tv` / `.tvim` file, pickle,

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -152,6 +152,14 @@ The store also supports `pickle` (e.g. for `multiprocessing` workers, provided t
 
 The lifecycle, write, and read methods have async counterparts: `async_create`, `async_drop`, `async_exists`, `async_name_exists`, `async_get_count`, `async_insert`, `async_upsert`, `async_search`. The remaining methods (the `delete_by_*` family, `update_metadata`, `save`, `id_exists`, `content_hash_exists`, `optimize`) are sync-only. The async paths call the embedder's `async_get_embedding` / `async_get_embeddings_batch_and_usage` for genuine async embedding generation. Agno's `Embedder` base class always defines both, so an embedder that inherits them without implementing them raises `NotImplementedError` on the async paths — use the sync methods with such an embedder.
 
+`async_create`, `async_drop`, `async_insert`, `async_upsert`, and `async_search` run the index work on a worker thread (`asyncio.to_thread`) so the event loop stays responsive while a large insert or search is in flight. That is the shape Agno's own sync-backed vector DBs use (`chromadb`, `pgvector`, `cassandra`, `pineconedb` all wrap their sync bodies in `asyncio.to_thread`). `async_exists`, `async_name_exists`, and `async_get_count` answer inline — they are O(1) reads, and a thread hop would cost more than it saves.
+
+Cancellation is only partial, and the distinction matters:
+
+- `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
+- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled `async_insert` may still commit. Treat a timeout as "outcome unknown", not "the insert did not happen"; retry through `async_upsert` on the same `content_hash` if you need the retry to be idempotent.
+- The store is never left in a torn state either way.
+
 ## Thread safety
 
 The store is safe for concurrent multi-threaded use:

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -157,8 +157,9 @@ The lifecycle, write, and read methods have async counterparts: `async_create`, 
 Cancellation is only partial, and the distinction matters:
 
 - `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
-- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled `async_insert` may still commit. Treat a timeout as "outcome unknown", not "the insert did not happen"; retry through `async_upsert` on the same `content_hash` if you need the retry to be idempotent.
-- The store is never left in a torn state either way.
+- It does **not** decide what happened to the insert. If the worker thread had already started, it runs the call to completion — work inside the Rust core is not interruptible at all — and the insert commits in full. If the executor was saturated, the call is cancelled before it ever starts and nothing is inserted. **A cancelled `async_insert` is "outcome unknown": it may have fully committed, or may never have begun.** Retry through `async_upsert` on the same `content_hash` if you need the retry to be idempotent.
+- What *is* guaranteed: the outcome is all-or-nothing. The store is never left in a torn state.
+- Timing out does not make the work go away: the loop's shutdown (`asyncio.run` on the way out, or `loop.shutdown_default_executor()`) waits for the worker thread, so a process that exits right after a short timeout can still block for the rest of the in-flight call.
 
 ## Thread safety
 

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -160,6 +160,18 @@ Document metadata must be JSON-serializable — the same constraint `InMemoryVec
 
 The store also supports `pickle` (e.g. for `multiprocessing` workers, provided the embedder is picklable) and `copy.copy` / `copy.deepcopy` — both copies return a fully independent store (there is no shallow copy that shares the underlying index).
 
+## Async
+
+Every read and write method has an `a*` counterpart: `aadd_texts`, `aadd_documents`, `asimilarity_search*`, `aget_by_ids`, `adelete`, `afrom_texts`.
+
+They run the index work on a worker thread (`asyncio.to_thread`), so the event loop stays responsive while a large add or search is in flight — the same contract as `VectorStore`'s own default async implementations, which offload via `run_in_executor`. The embedding step still awaits the embedder's own `aembed_*` coroutine.
+
+Cancellation is only partial, and the distinction matters:
+
+- `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
+- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled write may still commit. Treat a timeout as "outcome unknown", not "the write did not happen", and make retries idempotent by passing explicit `ids`.
+- The store is never left in a torn state either way.
+
 ## Thread safety
 
 The store is safe for concurrent multi-threaded use:

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -169,8 +169,9 @@ They run the index work on a worker thread (`asyncio.to_thread`), so the event l
 Cancellation is only partial, and the distinction matters:
 
 - `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
-- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled write may still commit. Treat a timeout as "outcome unknown", not "the write did not happen", and make retries idempotent by passing explicit `ids`.
-- The store is never left in a torn state either way.
+- It does **not** decide what happened to the write. If the worker thread had already started, it runs the call to completion — work inside the Rust core is not interruptible at all — and the write commits in full. If the executor was saturated, the call is cancelled before it ever starts and nothing is written. **A cancelled write is "outcome unknown": it may have fully committed, or may never have begun.** Neither "it happened" nor "it did not happen" is safe to assume; make retries idempotent by passing explicit `ids`, or read back to find out.
+- What *is* guaranteed: the outcome is all-or-nothing. The store is never left in a torn state.
+- Timing out does not make the work go away: the loop's shutdown (`asyncio.run` on the way out, or `loop.shutdown_default_executor()`) waits for the worker thread, so a process that exits right after a short timeout can still block for the rest of the in-flight call.
 
 ## Thread safety
 

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -185,6 +185,14 @@ await vector_store.adelete_nodes(node_ids=[...])
 await vector_store.aclear()
 ```
 
+They run the index work on a worker thread (`asyncio.to_thread`), so the event loop stays responsive while a large add or query is in flight. `BasePydanticVectorStore`'s defaults call straight into the sync body, which would block the loop for the operation's full duration — a 20k-node add measured 1.75 s of loop lag.
+
+Cancellation is only partial, and the distinction matters:
+
+- `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
+- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled `async_add` may still commit. Treat a timeout as "outcome unknown", not "the add did not happen"; re-adding the same `node_id` is an overwrite, so retries are idempotent.
+- The store is never left in a torn state either way.
+
 ## Persist / load
 
 ### Direct (file-stem) interface

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -185,13 +185,14 @@ await vector_store.adelete_nodes(node_ids=[...])
 await vector_store.aclear()
 ```
 
-They run the index work on a worker thread (`asyncio.to_thread`), so the event loop stays responsive while a large add or query is in flight. `BasePydanticVectorStore`'s defaults call straight into the sync body, which would block the loop for the operation's full duration — a 20k-node add measured 1.75 s of loop lag.
+They run the index work on a worker thread (`asyncio.to_thread`), so the event loop stays responsive while a large add or query is in flight. `BasePydanticVectorStore`'s defaults call straight into the sync body, which would block the loop for the operation's full duration.
 
 Cancellation is only partial, and the distinction matters:
 
 - `asyncio.wait_for`, `task.cancel()`, or a client disconnect returns control to the awaiting caller promptly — that part now works, where previously the coroutine ran to completion and the timeout never fired.
-- It does **not** abort the operation. The worker thread runs the already-started call to completion; work inside the Rust core is not interruptible at all. So a cancelled `async_add` may still commit. Treat a timeout as "outcome unknown", not "the add did not happen"; re-adding the same `node_id` is an overwrite, so retries are idempotent.
-- The store is never left in a torn state either way.
+- It does **not** decide what happened to the add. If the worker thread had already started, it runs the call to completion — work inside the Rust core is not interruptible at all — and the add commits in full. If the executor was saturated, the call is cancelled before it ever starts and nothing is added. **A cancelled `async_add` is "outcome unknown": it may have fully committed, or may never have begun.** Re-adding the same `node_id` is an overwrite, so retrying is safe either way.
+- What *is* guaranteed: the outcome is all-or-nothing. The store is never left in a torn state.
+- Timing out does not make the work go away: the loop's shutdown (`asyncio.run` on the way out, or `loop.shutdown_default_executor()`) waits for the worker thread, so a process that exits right after a short timeout can still block for the rest of the in-flight call.
 
 ## Persist / load
 

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -5,10 +5,21 @@ Install with: ``pip install turbovec[agno]``.
 Implements Agno's ``VectorDb`` interface and matches the public surface
 of ``agno.vectordb.lancedb.LanceDb`` (the closest in-tree single-machine
 backend) so this can be swapped in wherever ``LanceDb`` is used.
+
+The ``async_*`` methods run the index work on a worker thread
+(``asyncio.to_thread``) so the event loop stays responsive while a large
+insert or search is in flight (issue #342). That is the same shape
+Agno's own sync-backed vector DBs use (``chromadb``, ``pgvector``,
+``cassandra``, ``pineconedb`` all wrap their sync bodies in
+``asyncio.to_thread``). Cancelling the awaiting task returns control to
+the caller immediately, but it does **not** abort the index operation:
+the worker thread runs the already-started call to completion, so a
+cancelled insert may still commit. The store is never left torn.
 """
 
 from __future__ import annotations
 
+import asyncio
 import copy as _copy
 import json
 import threading
@@ -243,7 +254,9 @@ class TurboQuantVectorDb(VectorDb):
             self._index = IdMapIndex(self.dimensions, self.bit_width)
 
     async def async_create(self) -> None:
-        self.create()
+        # create() can load a persisted index off disk — real I/O plus a
+        # full deserialize, so it does not belong on the loop thread.
+        await asyncio.to_thread(self.create)
 
     def drop(self) -> None:
         """Drop the underlying index. After this call ``exists()`` returns
@@ -266,7 +279,8 @@ class TurboQuantVectorDb(VectorDb):
             self._name_to_ids.clear()
 
     async def async_drop(self) -> None:
-        self.drop()
+        # drop() unlinks the persisted artifacts: filesystem work.
+        await asyncio.to_thread(self.drop)
 
     def exists(self) -> bool:
         """True iff the underlying index has been created via ``create()``
@@ -276,6 +290,8 @@ class TurboQuantVectorDb(VectorDb):
         return self._index is not None
 
     async def async_exists(self) -> bool:
+        # O(1) attribute read — offloading it would cost more than it
+        # saves, and it cannot block the loop measurably.
         return self.exists()
 
     def delete(self) -> bool:
@@ -297,6 +313,7 @@ class TurboQuantVectorDb(VectorDb):
         return len(self._index)
 
     async def async_get_count(self) -> int:
+        # O(1) len() — see async_exists.
         return self.get_count()
 
     # ---- VectorDb protocol: existence checks ------------------------------
@@ -309,6 +326,7 @@ class TurboQuantVectorDb(VectorDb):
     async def async_name_exists(self, name: str) -> bool:
         # LanceDb raises NotImplementedError here; we have a trivial sync
         # backing call, so we return the real answer. Intentional deviation.
+        # A single dict lookup — see async_exists; not worth a thread hop.
         return self.name_exists(name)
 
     def id_exists(self, id: str) -> bool:
@@ -562,8 +580,11 @@ class TurboQuantVectorDb(VectorDb):
         if not documents:
             return
         await self._embed_missing_async(documents)
-        # Now every doc should have an embedding; insert delegates to sync.
-        self.insert(content_hash, documents, filters)
+        # Now every doc should have an embedding; insert delegates to
+        # sync — on a worker thread, so the loop is free for the whole
+        # write (#342). One call for the entire locked body: an await
+        # inside it would break insert's atomicity.
+        await asyncio.to_thread(self.insert, content_hash, documents, filters)
 
     def upsert_available(self) -> bool:
         return True
@@ -611,8 +632,11 @@ class TurboQuantVectorDb(VectorDb):
         # generations accumulated (issue #146). Delegating preserves the
         # insert-before-delete ordering (issue #89) and makes concurrent
         # async upserts last-writer-wins — identical to sync semantics.
+        # The delegation runs on a worker thread (#342); that adds no
+        # suspension point *inside* the locked body, so the issue-#146
+        # reasoning above is unaffected.
         await self._embed_missing_async(documents)
-        self.upsert(content_hash, documents, filters)
+        await asyncio.to_thread(self.upsert, content_hash, documents, filters)
 
     def _handles_for_content_hash(self, content_hash: str) -> List[int]:
         """Internal handles of every document currently stored under this
@@ -869,12 +893,7 @@ class TurboQuantVectorDb(VectorDb):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
-        results = self._retrieve(qvec, limit, filters)
-        if self.reranker is not None and results:
-            results = self.reranker.rerank(query=query, documents=results)
-        # Dedup by content as the final step, after rerank — matching
-        # LanceDb.search's ordering exactly (issue #136).
-        return self._dedup_by_content(results)
+        return self._search_and_rank(query, qvec, limit, filters)
 
     async def async_search(
         self,
@@ -899,11 +918,24 @@ class TurboQuantVectorDb(VectorDb):
         if not qvec.flags["C_CONTIGUOUS"]:
             qvec = np.ascontiguousarray(qvec)
 
+        # Retrieve + rerank + dedup on a worker thread so the loop stays
+        # free (#342). Kept as one call so the retrieve/rerank/dedup
+        # ordering that matches LanceDb.search (issue #136) is preserved.
+        return await asyncio.to_thread(self._search_and_rank, query, qvec, limit, filters)
+
+    def _search_and_rank(
+        self,
+        query: str,
+        qvec: np.ndarray,
+        limit: int,
+        filters: Optional[Union[Dict[str, Any], List[Any]]],
+    ) -> List[Document]:
+        """Shared tail of ``search`` / ``async_search``: retrieve, then
+        rerank, then dedup by content — that exact order matches
+        LanceDb.search (issue #136)."""
         results = self._retrieve(qvec, limit, filters)
         if self.reranker is not None and results:
             results = self.reranker.rerank(query=query, documents=results)
-        # Dedup by content as the final step, after rerank — matching
-        # LanceDb.search's ordering exactly (issue #136).
         return self._dedup_by_content(results)
 
     def get_supported_search_types(self) -> List[SearchType]:

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -12,9 +12,13 @@ insert or search is in flight (issue #342). That is the same shape
 Agno's own sync-backed vector DBs use (``chromadb``, ``pgvector``,
 ``cassandra``, ``pineconedb`` all wrap their sync bodies in
 ``asyncio.to_thread``). Cancelling the awaiting task returns control to
-the caller immediately, but it does **not** abort the index operation:
-the worker thread runs the already-started call to completion, so a
-cancelled insert may still commit. The store is never left torn.
+the caller immediately, but it does **not** decide the insert's fate: a
+worker that already started runs to completion (work inside the Rust core
+is not interruptible), while a call still queued behind a saturated
+executor is cancelled before it ever runs. A cancelled insert is
+therefore "outcome unknown" — it may have fully committed, or may never
+have begun. The one guarantee is that it is all-or-nothing: the store is
+never left torn.
 """
 
 from __future__ import annotations

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -10,9 +10,12 @@ matching the ``run_in_executor`` contract of ``VectorStore``'s own default
 async implementations, so the event loop stays responsive while a large
 add or search is in flight (issue #342). Cancelling the awaiting task —
 ``asyncio.wait_for``, a client disconnect — returns control to the caller
-immediately, but it does **not** abort the index operation: the worker
-thread runs the already-started call to completion, so a cancelled write
-may still commit. The store is never left in a torn state either way.
+immediately, but it does **not** decide the write's fate: a worker that
+already started runs to completion (work inside the Rust core is not
+interruptible), while a call still queued behind a saturated executor is
+cancelled before it ever runs. A cancelled write is therefore "outcome
+unknown" — it may have fully committed, or may never have begun. The one
+guarantee is that it is all-or-nothing: the store is never left torn.
 """
 
 from __future__ import annotations

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -4,10 +4,20 @@ Install with: ``pip install turbovec[langchain]``.
 
 The public surface mirrors langchain_core's in-tree ``InMemoryVectorStore``
 so this store can be swapped in wherever the in-memory store is used.
+
+Async methods run the index work on a worker thread (``asyncio.to_thread``),
+matching the ``run_in_executor`` contract of ``VectorStore``'s own default
+async implementations, so the event loop stays responsive while a large
+add or search is in flight (issue #342). Cancelling the awaiting task —
+``asyncio.wait_for``, a client disconnect — returns control to the caller
+immediately, but it does **not** abort the index operation: the worker
+thread runs the already-started call to completion, so a cancelled write
+may still commit. The store is never left in a torn state either way.
 """
 
 from __future__ import annotations
 
+import asyncio
 import copy as _copy
 import json
 import threading
@@ -295,7 +305,13 @@ class TurboQuantVectorStore(VectorStore):
             await self._embedding.aembed_documents(texts_list), dtype=np.float32
         )
         self._check_embedded_batch(vectors, len(texts_list))
-        return self._store_texts_and_vectors(texts_list, vectors, metadatas, ids)
+        # Offload the index write: a 20k-doc add blocks for its full
+        # duration, and inline it blocks the loop for all of it (#342).
+        # One to_thread call, not one per chunk — the sync body must stay
+        # atomic (no await may split validation from the locked write).
+        return await asyncio.to_thread(
+            self._store_texts_and_vectors, texts_list, vectors, metadatas, ids
+        )
 
     def add_documents(
         self,
@@ -486,7 +502,7 @@ class TurboQuantVectorStore(VectorStore):
         qvec = self._validate_query_embedding(
             await self._embedding.aembed_query(query)
         )
-        return self._search_vector(qvec, k, filter=filter)
+        return await asyncio.to_thread(self._search_vector, qvec, k, filter)
 
     def similarity_search_by_vector(
         self,
@@ -505,8 +521,11 @@ class TurboQuantVectorStore(VectorStore):
         filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[Document]:
-        # The search itself is sync (no embedding step). Delegate.
-        return self.similarity_search_by_vector(embedding, k=k, filter=filter)
+        # No embedding step, so there is nothing to await — offload the
+        # search itself to keep the loop free (#342).
+        return await asyncio.to_thread(
+            self.similarity_search_by_vector, embedding, k, filter
+        )
 
     def similarity_search_with_score_by_vector(
         self,
@@ -529,8 +548,10 @@ class TurboQuantVectorStore(VectorStore):
         filter: dict[str, Any] | Callable[[Document], bool] | None = None,
         **_: Any,
     ) -> list[tuple[Document, float]]:
-        # The search itself is sync (no embedding step). Delegate.
-        return self.similarity_search_with_score_by_vector(embedding, k=k, filter=filter)
+        # See asimilarity_search_by_vector: nothing to await, so offload.
+        return await asyncio.to_thread(
+            self.similarity_search_with_score_by_vector, embedding, k, filter
+        )
 
     def _search_vector(
         self,
@@ -707,7 +728,9 @@ class TurboQuantVectorStore(VectorStore):
         return out
 
     async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
-        return self.get_by_ids(ids)
+        # Cost is proportional to len(ids); the base class offloads this
+        # too (VectorStore.aget_by_ids -> run_in_executor).
+        return await asyncio.to_thread(self.get_by_ids, ids)
 
     def delete(self, ids: list[str] | None = None, **_: Any) -> None:
         """Remove documents by id. Missing ids are silently skipped — matches
@@ -734,7 +757,9 @@ class TurboQuantVectorStore(VectorStore):
                 self._docs.pop(sid, None)
 
     async def adelete(self, ids: list[str] | None = None, **_: Any) -> None:
-        self.delete(ids)
+        # One to_thread call for the whole locked body: the write lock
+        # must not be split across a suspension point.
+        await asyncio.to_thread(self.delete, ids)
 
     # ---- Construction helpers -----------------------------------------
 

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -308,8 +308,8 @@ class TurboQuantVectorStore(VectorStore):
             await self._embedding.aembed_documents(texts_list), dtype=np.float32
         )
         self._check_embedded_batch(vectors, len(texts_list))
-        # Offload the index write: a 20k-doc add blocks for its full
-        # duration, and inline it blocks the loop for all of it (#342).
+        # Offload the index write: run inline it would block the loop for
+        # the operation's whole duration (#342).
         # One to_thread call, not one per chunk — the sync body must stay
         # atomic (no await may split validation from the locked write).
         return await asyncio.to_thread(

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -1,10 +1,20 @@
 """LlamaIndex VectorStore backed by turbovec's quantized index.
 
 Install with: ``pip install turbovec[llama-index]``.
+
+Async methods run the index work on a worker thread
+(``asyncio.to_thread``) so the event loop stays responsive while a large
+add or query is in flight (issue #342) — ``BasePydanticVectorStore``'s
+defaults call straight into the sync body, which blocked the loop for the
+operation's full duration. Cancelling the awaiting task returns control
+to the caller immediately, but it does **not** abort the index operation:
+the worker thread runs the already-started call to completion, so a
+cancelled write may still commit. The store is never left in a torn state.
 """
 
 from __future__ import annotations
 
+import asyncio
 import copy as _copy
 import json
 import os
@@ -841,17 +851,25 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     # ---- Async overrides --------------------------------------------------
     #
     # The base class provides default async impls that delegate to sync via
-    # `return self.<sync>(...)`. We override them explicitly so the signature
-    # is visible on the class and an autodoc tool / IDE doesn't make
-    # callers chase the abstract base class for the documentation.
+    # `return self.<sync>(...)` — inline on the loop thread, which blocks
+    # it for the whole operation (a 20k-node add measured 1.75 s of loop
+    # lag, issue #342). We override them to run the sync body on a worker
+    # thread instead. One `to_thread` call per method, never one per
+    # chunk: the sync bodies take the write lock, and a suspension point
+    # inside one would break the atomicity the sync path guarantees.
+    #
+    # `asyncio.to_thread` propagates the caller's context vars, and the
+    # index releases the GIL for the heavy work, so the loop really does
+    # keep running. Cancellation frees the *caller*, not the worker — see
+    # the module docstring.
 
     async def async_add(
         self, nodes: Sequence[BaseNode], **kwargs: Any
     ) -> List[str]:
-        return self.add(list(nodes), **kwargs)
+        return await asyncio.to_thread(self.add, list(nodes), **kwargs)
 
     async def adelete(self, ref_doc_id: str, **kwargs: Any) -> None:
-        self.delete(ref_doc_id, **kwargs)
+        await asyncio.to_thread(self.delete, ref_doc_id, **kwargs)
 
     async def adelete_nodes(
         self,
@@ -859,22 +877,26 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         filters: Optional[MetadataFilters] = None,
         **kwargs: Any,
     ) -> None:
-        self.delete_nodes(node_ids=node_ids, filters=filters, **kwargs)
+        await asyncio.to_thread(
+            self.delete_nodes, node_ids=node_ids, filters=filters, **kwargs
+        )
 
     async def aclear(self) -> None:
-        self.clear()
+        await asyncio.to_thread(self.clear)
 
     async def aquery(
         self, query: VectorStoreQuery, **kwargs: Any
     ) -> VectorStoreQueryResult:
-        return self.query(query, **kwargs)
+        return await asyncio.to_thread(self.query, query, **kwargs)
 
     async def aget_nodes(
         self,
         node_ids: Optional[List[str]] = None,
         filters: Optional[MetadataFilters] = None,
     ) -> List[BaseNode]:
-        return self.get_nodes(node_ids=node_ids, filters=filters)
+        return await asyncio.to_thread(
+            self.get_nodes, node_ids=node_ids, filters=filters
+        )
 
     # ---- Config serialization ---------------------------------------------
 

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -7,9 +7,12 @@ Async methods run the index work on a worker thread
 add or query is in flight (issue #342) — ``BasePydanticVectorStore``'s
 defaults call straight into the sync body, which blocked the loop for the
 operation's full duration. Cancelling the awaiting task returns control
-to the caller immediately, but it does **not** abort the index operation:
-the worker thread runs the already-started call to completion, so a
-cancelled write may still commit. The store is never left in a torn state.
+to the caller immediately, but it does **not** decide the write's fate: a
+worker that already started runs to completion (work inside the Rust core
+is not interruptible), while a call still queued behind a saturated
+executor is cancelled before it ever runs. A cancelled write is therefore
+"outcome unknown" — it may have fully committed, or may never have begun.
+The one guarantee is that it is all-or-nothing: the store is never torn.
 """
 
 from __future__ import annotations
@@ -852,8 +855,8 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
     #
     # The base class provides default async impls that delegate to sync via
     # `return self.<sync>(...)` — inline on the loop thread, which blocks
-    # it for the whole operation (a 20k-node add measured 1.75 s of loop
-    # lag, issue #342). We override them to run the sync body on a worker
+    # it for the operation's whole duration (issue #342). We override
+    # them to run the sync body on a worker
     # thread instead. One `to_thread` call per method, never one per
     # chunk: the sync bodies take the write lock, and a suspension point
     # inside one would break the atomicity the sync path guarantees.

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1200,6 +1200,8 @@ def test_insert_filters_kwarg_merges_into_doc_metadata():
         _doc("b", doc_id="d2", meta_data={"existing": 2}),
     ]
     db.insert("h", docs, filters={"tenant": "acme", "tier": "pro"})
+    # Length first: this loop passes vacuously if insert stores nothing.
+    assert len(db._u64_to_doc) == 2
     for data in db._u64_to_doc.values():
         # Original meta_data preserved...
         assert "existing" in data["meta_data"]

--- a/turbovec-python/tests/test_async_offload.py
+++ b/turbovec-python/tests/test_async_offload.py
@@ -113,6 +113,19 @@ def _langchain_store():
         def embed_query(self, text):
             return _unit(text)
 
+        # Native async overrides, deliberately. `Embeddings` inherits
+        # `aembed_*` implementations that hop through
+        # `run_in_executor(None, ...)`, i.e. the loop's default executor —
+        # so a cell that saturates that executor would strand the
+        # coroutine at the *embedding* step and never reach the index
+        # offload under test. These keep the embedding step on the loop
+        # so the only thread hop is the one being measured.
+        async def aembed_documents(self, texts):
+            return self.embed_documents(texts)
+
+        async def aembed_query(self, text):
+            return self.embed_query(text)
+
     return TurboQuantVectorStore(embedding=StubEmbeddings()), TurboQuantVectorStore
 
 
@@ -204,6 +217,19 @@ def test_langchain_cancelled_before_start_writes_nothing():
     store, _cls = _langchain_store()
     release = threading.Event()
 
+    # Trace the embedding step. Without this the cell could pass for the
+    # wrong reason — a coroutine stranded at an earlier `run_in_executor`
+    # also writes nothing — and would then pass against a build that has
+    # no offload at all.
+    embedded: list[int] = []
+    inner = store._embedding.aembed_documents
+
+    async def traced(texts):
+        embedded.append(len(texts))
+        return await inner(texts)
+
+    store._embedding.aembed_documents = traced
+
     async def main():
         executor = ThreadPoolExecutor(max_workers=1)
         asyncio.get_running_loop().set_default_executor(executor)
@@ -220,6 +246,10 @@ def test_langchain_cancelled_before_start_writes_nothing():
             executor.shutdown(wait=True)
 
     asyncio.run(main())
+    assert embedded == [2], (
+        "the coroutine never reached the offload — it was cancelled at an "
+        "earlier suspension point, so this cell proves nothing about the write"
+    )
     assert len(store._docs) == 0, "the add ran despite never being scheduled"
 
 

--- a/turbovec-python/tests/test_async_offload.py
+++ b/turbovec-python/tests/test_async_offload.py
@@ -1,0 +1,318 @@
+"""Event-loop behaviour of the async integration surfaces (issue #342).
+
+The langchain / llama_index / agno ``async``/``a*`` methods used to call
+their sync bodies inline on the loop thread, so a large add blocked the
+loop for its whole duration and ``asyncio.wait_for`` could not fire. They
+now run the sync body on a worker thread.
+
+Three properties are pinned here, all structural rather than timing-tight:
+
+1. **Offload** — the sync body observably runs on a thread other than the
+   one running the loop. Deterministic: no timing at all.
+2. **Responsiveness** — a heartbeat task ticks while an async op is in
+   flight. The op is made slow by an injected ``time.sleep`` (which
+   releases the GIL exactly like the index's own hot loops do), and the
+   threshold is a small fraction of the ticks a healthy loop produces.
+3. **Cancellation** — ``asyncio.wait_for`` raises on a slow op instead of
+   running it to completion, *and* the underlying write still commits.
+   That second half is the deliberate limitation: cancelling frees the
+   awaiting caller, it cannot abort work already running in the Rust
+   core. Pinned so the docs and the behaviour can't drift apart.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+
+import numpy as np
+import pytest
+
+DIM = 32
+# Injected op duration for the responsiveness / cancellation cells. Long
+# enough that a loaded machine only ever makes the margins wider.
+SLOW = 1.0
+
+
+def _unit(text: str, dim: int = DIM) -> list[float]:
+    rng = np.random.default_rng(abs(hash(text)) % (2**32))
+    v = rng.standard_normal(dim).astype(np.float32)
+    v /= np.linalg.norm(v) + 1e-9
+    return v.tolist()
+
+
+def _record_thread(monkeypatch, owner, name):
+    """Patch ``owner.name`` to record the thread it runs on. Returns the
+    (growing) list of thread idents."""
+    seen: list[int] = []
+    orig = getattr(owner, name)
+
+    def wrapper(self, *args, **kwargs):
+        seen.append(threading.get_ident())
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(owner, name, wrapper)
+    return seen
+
+
+def _make_slow(monkeypatch, owner, name, delay=SLOW):
+    """Patch ``owner.name`` to take ``delay`` seconds before doing its
+    real work. ``time.sleep`` releases the GIL, which is the same thing
+    the index does around its heavy kernels."""
+    orig = getattr(owner, name)
+
+    def wrapper(self, *args, **kwargs):
+        time.sleep(delay)
+        return orig(self, *args, **kwargs)
+
+    monkeypatch.setattr(owner, name, wrapper)
+
+
+def _assert_offloaded(seen, loop_thread):
+    assert seen, "the sync body never ran — the test proved nothing"
+    assert loop_thread not in seen, (
+        "the sync body ran on the event-loop thread; the async method is "
+        "blocking the loop for its full duration"
+    )
+
+
+def _run_capturing_loop_thread(coro_factory):
+    """Run ``coro_factory(...)`` under asyncio.run and return the ident of
+    the thread the loop ran on."""
+    holder: list[int] = []
+
+    async def main():
+        holder.append(threading.get_ident())
+        await coro_factory()
+
+    asyncio.run(main())
+    return holder[0]
+
+
+# ---------------------------------------------------------------------------
+# langchain
+# ---------------------------------------------------------------------------
+
+
+def _langchain_store():
+    pytest.importorskip("langchain_core")
+    from langchain_core.embeddings import Embeddings
+
+    from turbovec.langchain import TurboQuantVectorStore
+
+    class StubEmbeddings(Embeddings):
+        def embed_documents(self, texts):
+            return [_unit(t) for t in texts]
+
+        def embed_query(self, text):
+            return _unit(text)
+
+    return TurboQuantVectorStore(embedding=StubEmbeddings()), TurboQuantVectorStore
+
+
+LANGCHAIN_CASES = {
+    # async method -> (sync body it must offload, coroutine factory)
+    "aadd_texts": (
+        "_store_texts_and_vectors",
+        lambda s: s.aadd_texts(["alpha", "beta"]),
+    ),
+    "asimilarity_search_with_score": (
+        "_search_vector",
+        lambda s: s.asimilarity_search_with_score("alpha", k=1),
+    ),
+    "asimilarity_search_by_vector": (
+        "similarity_search_by_vector",
+        lambda s: s.asimilarity_search_by_vector(_unit("alpha"), k=1),
+    ),
+    "asimilarity_search_with_score_by_vector": (
+        "similarity_search_with_score_by_vector",
+        lambda s: s.asimilarity_search_with_score_by_vector(_unit("alpha"), k=1),
+    ),
+    "aget_by_ids": ("get_by_ids", lambda s: s.aget_by_ids(["id-0"])),
+    "adelete": ("delete", lambda s: s.adelete(["id-0"])),
+}
+
+
+@pytest.mark.parametrize("method", sorted(LANGCHAIN_CASES))
+def test_langchain_async_runs_off_the_event_loop(method, monkeypatch):
+    store, cls = _langchain_store()
+    store.add_texts(["alpha", "beta"], ids=["id-0", "id-1"])
+    sync_name, factory = LANGCHAIN_CASES[method]
+    seen = _record_thread(monkeypatch, cls, sync_name)
+    loop_thread = _run_capturing_loop_thread(lambda: factory(store))
+    _assert_offloaded(seen, loop_thread)
+
+
+def test_langchain_aadd_texts_leaves_the_loop_responsive(monkeypatch):
+    store, cls = _langchain_store()
+    _make_slow(monkeypatch, cls, "_store_texts_and_vectors")
+
+    async def main():
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        beat = asyncio.create_task(heartbeat())
+        await store.aadd_texts(["alpha", "beta"])
+        beat.cancel()
+        return ticks
+
+    ticks = asyncio.run(main())
+    # A healthy loop ticks ~100x over SLOW=1s. Require 5 — enough to prove
+    # the loop ran (it ticked zero times when the add was inline), loose
+    # enough to survive a badly loaded machine.
+    assert ticks >= 5, f"loop ticked only {ticks} times during a {SLOW}s add"
+
+
+def test_langchain_aadd_texts_is_cancellable_but_still_commits(monkeypatch):
+    """`wait_for` must now fire — and the write it interrupted still lands.
+    Cancelling frees the caller; it cannot abort the worker thread."""
+    store, cls = _langchain_store()
+    _make_slow(monkeypatch, cls, "_store_texts_and_vectors")
+
+    async def main():
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                store.aadd_texts(["alpha", "beta"], ids=["id-0", "id-1"]),
+                timeout=SLOW / 20,
+            )
+
+    # asyncio.run shuts the default executor down on the way out, so the
+    # worker has finished by the time this returns.
+    asyncio.run(main())
+    assert len(store._docs) == 2, "the cancelled write should still have committed"
+
+
+# ---------------------------------------------------------------------------
+# llama_index
+# ---------------------------------------------------------------------------
+
+
+def _llama_store():
+    pytest.importorskip("llama_index.core")
+    from turbovec.llama_index import TurboQuantVectorStore
+
+    return TurboQuantVectorStore(), TurboQuantVectorStore
+
+
+def _llama_nodes(n=2):
+    from llama_index.core.schema import TextNode
+
+    return [
+        TextNode(id_=f"n{i}", text=f"t{i}", embedding=_unit(f"t{i}"))
+        for i in range(n)
+    ]
+
+
+def _llama_query(k=1):
+    from llama_index.core.vector_stores.types import VectorStoreQuery
+
+    return VectorStoreQuery(query_embedding=_unit("t0"), similarity_top_k=k)
+
+
+LLAMA_CASES = {
+    "async_add": ("add", lambda s: s.async_add(_llama_nodes())),
+    "aquery": ("query", lambda s: s.aquery(_llama_query())),
+    "aget_nodes": ("get_nodes", lambda s: s.aget_nodes(node_ids=["n0"])),
+    "adelete": ("delete", lambda s: s.adelete("ref-0")),
+    "adelete_nodes": ("delete_nodes", lambda s: s.adelete_nodes(node_ids=["n0"])),
+    "aclear": ("clear", lambda s: s.aclear()),
+}
+
+
+@pytest.mark.parametrize("method", sorted(LLAMA_CASES))
+def test_llama_index_async_runs_off_the_event_loop(method, monkeypatch):
+    store, cls = _llama_store()
+    store.add(_llama_nodes())
+    sync_name, factory = LLAMA_CASES[method]
+    seen = _record_thread(monkeypatch, cls, sync_name)
+    loop_thread = _run_capturing_loop_thread(lambda: factory(store))
+    _assert_offloaded(seen, loop_thread)
+
+
+def test_llama_index_async_add_is_cancellable_but_still_commits(monkeypatch):
+    store, cls = _llama_store()
+    _make_slow(monkeypatch, cls, "add")
+
+    async def main():
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                store.async_add(_llama_nodes()), timeout=SLOW / 20
+            )
+
+    asyncio.run(main())
+    assert len(store._nodes) == 2, "the cancelled add should still have committed"
+
+
+# ---------------------------------------------------------------------------
+# agno
+# ---------------------------------------------------------------------------
+
+
+def _agno_db():
+    pytest.importorskip("agno")
+    from turbovec.agno import TurboQuantVectorDb
+
+    class StubEmbedder:
+        enable_batch = False
+
+        def __init__(self) -> None:
+            self.dimensions = DIM
+
+        def get_embedding(self, text: str):
+            return _unit(text)
+
+        async def async_get_embedding(self, text: str):
+            return _unit(text)
+
+    return TurboQuantVectorDb(embedder=StubEmbedder()), TurboQuantVectorDb
+
+
+def _agno_docs(n=2):
+    from agno.knowledge.document import Document
+
+    return [
+        Document(id=f"d{i}", content=f"c{i}", meta_data={}, embedding=_unit(f"c{i}"))
+        for i in range(n)
+    ]
+
+
+AGNO_CASES = {
+    "async_create": ("create", lambda db: db.async_create()),
+    "async_drop": ("drop", lambda db: db.async_drop()),
+    "async_insert": ("insert", lambda db: db.async_insert("h2", _agno_docs())),
+    "async_upsert": ("upsert", lambda db: db.async_upsert("h", _agno_docs())),
+    # `_retrieve` rather than the `_search_and_rank` wrapper: it predates
+    # this change, so the cell discriminates on behaviour, not on a name.
+    "async_search": ("_retrieve", lambda db: db.async_search("c0", limit=1)),
+}
+
+
+@pytest.mark.parametrize("method", sorted(AGNO_CASES))
+def test_agno_async_runs_off_the_event_loop(method, monkeypatch):
+    db, cls = _agno_db()
+    db.create()
+    db.insert("h", _agno_docs())
+    sync_name, factory = AGNO_CASES[method]
+    seen = _record_thread(monkeypatch, cls, sync_name)
+    loop_thread = _run_capturing_loop_thread(lambda: factory(db))
+    _assert_offloaded(seen, loop_thread)
+
+
+def test_agno_async_insert_is_cancellable_but_still_commits(monkeypatch):
+    db, cls = _agno_db()
+    db.create()
+    _make_slow(monkeypatch, cls, "insert")
+
+    async def main():
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                db.async_insert("h", _agno_docs()), timeout=SLOW / 20
+            )
+
+    asyncio.run(main())
+    assert db.get_count() == 2, "the cancelled insert should still have committed"

--- a/turbovec-python/tests/test_async_offload.py
+++ b/turbovec-python/tests/test_async_offload.py
@@ -14,16 +14,22 @@ Three properties are pinned here, all structural rather than timing-tight:
    releases the GIL exactly like the index's own hot loops do), and the
    threshold is a small fraction of the ticks a healthy loop produces.
 3. **Cancellation** — ``asyncio.wait_for`` raises on a slow op instead of
-   running it to completion, *and* the underlying write still commits.
-   That second half is the deliberate limitation: cancelling frees the
-   awaiting caller, it cannot abort work already running in the Rust
-   core. Pinned so the docs and the behaviour can't drift apart.
+   running it to completion, and the write it interrupted lands
+   *all-or-nothing*. Both branches are real and neither is guaranteed:
+   if the worker had already started, cancelling frees the awaiting
+   caller but cannot abort work inside the Rust core, so the write
+   commits in full; if the executor was saturated the call is cancelled
+   before it ever starts and nothing is written. The contract a caller
+   can rely on is "outcome unknown, never torn" — pinned here in that
+   form, with a dedicated cell for the never-started branch, so the docs
+   and the behaviour can't drift apart.
 """
 from __future__ import annotations
 
 import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pytest
@@ -168,9 +174,11 @@ def test_langchain_aadd_texts_leaves_the_loop_responsive(monkeypatch):
     assert ticks >= 5, f"loop ticked only {ticks} times during a {SLOW}s add"
 
 
-def test_langchain_aadd_texts_is_cancellable_but_still_commits(monkeypatch):
-    """`wait_for` must now fire — and the write it interrupted still lands.
-    Cancelling frees the caller; it cannot abort the worker thread."""
+def test_langchain_aadd_texts_is_cancellable_and_lands_all_or_nothing(monkeypatch):
+    """`wait_for` must now fire, and the interrupted write must be
+    all-or-nothing. Which of the two it is depends on whether the worker
+    had started, so neither branch may be asserted on its own — only that
+    the store is coherent afterwards."""
     store, cls = _langchain_store()
     _make_slow(monkeypatch, cls, "_store_texts_and_vectors")
 
@@ -181,10 +189,38 @@ def test_langchain_aadd_texts_is_cancellable_but_still_commits(monkeypatch):
                 timeout=SLOW / 20,
             )
 
-    # asyncio.run shuts the default executor down on the way out, so the
-    # worker has finished by the time this returns.
+    # asyncio.run shuts the default executor down on the way out, so any
+    # worker that did start has finished by the time this returns.
     asyncio.run(main())
-    assert len(store._docs) == 2, "the cancelled write should still have committed"
+    assert len(store._docs) in (0, 2), "the cancelled write landed torn"
+    assert len(store._docs) == len(store._str_to_u64) == len(store._index)
+
+
+def test_langchain_cancelled_before_start_writes_nothing():
+    """The other branch of the same contract: with the executor already
+    saturated the offloaded call is cancelled before it ever runs, so the
+    write never happens. This is why the docs say "outcome unknown"
+    rather than "the write still commits"."""
+    store, _cls = _langchain_store()
+    release = threading.Event()
+
+    async def main():
+        executor = ThreadPoolExecutor(max_workers=1)
+        asyncio.get_running_loop().set_default_executor(executor)
+        # Occupy the only worker for the whole test.
+        executor.submit(release.wait)
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    store.aadd_texts(["alpha", "beta"], ids=["id-0", "id-1"]),
+                    timeout=SLOW / 20,
+                )
+        finally:
+            release.set()
+            executor.shutdown(wait=True)
+
+    asyncio.run(main())
+    assert len(store._docs) == 0, "the add ran despite never being scheduled"
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +270,7 @@ def test_llama_index_async_runs_off_the_event_loop(method, monkeypatch):
     _assert_offloaded(seen, loop_thread)
 
 
-def test_llama_index_async_add_is_cancellable_but_still_commits(monkeypatch):
+def test_llama_index_async_add_is_cancellable_and_lands_all_or_nothing(monkeypatch):
     store, cls = _llama_store()
     _make_slow(monkeypatch, cls, "add")
 
@@ -245,7 +281,10 @@ def test_llama_index_async_add_is_cancellable_but_still_commits(monkeypatch):
             )
 
     asyncio.run(main())
-    assert len(store._nodes) == 2, "the cancelled add should still have committed"
+    # See the langchain cell: whether the worker started is not
+    # guaranteed, so only all-or-nothing may be asserted.
+    assert len(store._nodes) in (0, 2), "the cancelled add landed torn"
+    assert len(store._nodes) == len(store._index)
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +342,7 @@ def test_agno_async_runs_off_the_event_loop(method, monkeypatch):
     _assert_offloaded(seen, loop_thread)
 
 
-def test_agno_async_insert_is_cancellable_but_still_commits(monkeypatch):
+def test_agno_async_insert_is_cancellable_and_lands_all_or_nothing(monkeypatch):
     db, cls = _agno_db()
     db.create()
     _make_slow(monkeypatch, cls, "insert")
@@ -315,4 +354,7 @@ def test_agno_async_insert_is_cancellable_but_still_commits(monkeypatch):
             )
 
     asyncio.run(main())
-    assert db.get_count() == 2, "the cancelled insert should still have committed"
+    # See the langchain cell: whether the worker started is not
+    # guaranteed, so only all-or-nothing may be asserted.
+    assert db.get_count() in (0, 2), "the cancelled insert landed torn"
+    assert db.get_count() == len(db._u64_to_doc)

--- a/turbovec-python/tests/test_async_offload.py
+++ b/turbovec-python/tests/test_async_offload.py
@@ -225,8 +225,15 @@ def test_langchain_cancelled_before_start_writes_nothing():
     inner = store._embedding.aembed_documents
 
     async def traced(texts):
+        # Record AFTER the await, not before. Appending on entry only
+        # proves the embedding step was reached, so the guard below stays
+        # green even when the coroutine is cancelled mid-embedding and
+        # never gets near the offload — which is exactly the defect this
+        # cell was rewritten to close. Recording on completion makes the
+        # guard fail in that case.
+        result = await inner(texts)
         embedded.append(len(texts))
-        return await inner(texts)
+        return result
 
     store._embedding.aembed_documents = traced
 

--- a/turbovec-python/tests/test_haystack.py
+++ b/turbovec-python/tests/test_haystack.py
@@ -356,6 +356,9 @@ def test_async_concurrent_embedding_retrievals_are_consistent():
         return [[d.id for d in r] for r in results]
 
     all_ids = asyncio.run(run())
+    # Length first: a loop over an empty (or short) list asserts nothing.
+    assert len(sync_ids) == 3
+    assert len(all_ids) == 10
     for ids in all_ids:
         assert ids == sync_ids
 
@@ -1033,6 +1036,8 @@ def test_scale_score_cosine_formula():
     results = store.embedding_retrieval(
         query_embedding=make_docs(3)[0].embedding, top_k=3, scale_score=True
     )
+    # Length first: a loop over an empty result list asserts nothing.
+    assert len(results) == 3
     # Cosine scores live in [-1, 1]; after (s+1)/2 they're in [0, 1].
     for doc in results:
         assert 0.0 <= doc.score <= 1.0
@@ -1046,6 +1051,8 @@ def test_scale_score_dot_product_formula():
     results = store.embedding_retrieval(
         query_embedding=make_docs(3)[0].embedding, top_k=3, scale_score=True
     )
+    # Length first: a loop over an empty result list asserts nothing.
+    assert len(results) == 3
     # expit(s/100) sigmoid is monotonically increasing on (-inf, inf) → (0, 1).
     for doc in results:
         assert 0.0 < doc.score < 1.0
@@ -1299,7 +1306,10 @@ def test_filter_documents_returns_documents_with_score_none():
     # embedding_retrieval — pin this so the invariant doesn't drift.
     store = TurboQuantDocumentStore(dim=DIM, bit_width=4)
     store.write_documents(make_docs(3))
-    for doc in store.filter_documents():
+    fetched = store.filter_documents()
+    # Length first: a loop over an empty result list asserts nothing.
+    assert len(fetched) == 3
+    for doc in fetched:
         assert doc.score is None
 
 

--- a/turbovec-python/tests/test_similarity_modes.py
+++ b/turbovec-python/tests/test_similarity_modes.py
@@ -327,6 +327,9 @@ def test_llama_dot_product_mode_passes_raw_inner_products():
     store = TurboQuantVectorStore(similarity="dot_product")
     store.add(_li_nodes(docs))
     res = store.query(_li_query(query, 3))
+    # Length first: zip() truncates to the shortest input, so a short
+    # (or empty) `similarities` would check nothing.
+    assert len(res.similarities) == 3
     raw = [c * m for c, m in zip(POS_COS, POS_MAGS)]  # 380 / 50 / 4
     # Quantization noise on the raw inner product scales with the
     # document magnitude (~2% of ||v|| at 4 bits), so tolerate that.

--- a/turbovec-python/tests/test_store_thread_safety.py
+++ b/turbovec-python/tests/test_store_thread_safety.py
@@ -11,7 +11,10 @@ Two halves:
    exceptions in every role plus the final-state invariants
    ``len(index) == len(each side-car map)`` — and, for add-vs-add, an
    exact ``_next_u64`` (which is what catches lost increments /
-   duplicate handles, the LlamaIndex data-loss race).
+   duplicate handles, the LlamaIndex data-loss race). ``run_roles`` also
+   fails the cell if any worker is still alive after the join — a hang is
+   the primary failure these cells exist to catch, and it used to score
+   green (issue #371).
 
 2. **Deterministic units**: mutation ordering (maps populated before the
    index add; index removal precedes map pops) observed via a spy index;
@@ -59,6 +62,7 @@ class ScenarioResult:
     ops: Counter = field(default_factory=Counter)      # role -> completed ops
     errors: Counter = field(default_factory=Counter)   # (role, exc, msg) -> n
     first_tb: dict = field(default_factory=dict)
+    hung: list = field(default_factory=list)           # roles still alive after join
 
 
 def _msg_head(exc: BaseException) -> str:
@@ -66,10 +70,24 @@ def _msg_head(exc: BaseException) -> str:
     return re.sub(r"\d+", "#", s)[:90]
 
 
-def run_roles(roles, duration=DUR):
+def _stack_of(thread: threading.Thread) -> str:
+    """Best-effort current stack of a live thread, for hang diagnosis."""
+    frame = sys._current_frames().get(thread.ident)
+    if frame is None:
+        return "    <no frame available>\n"
+    return "".join(traceback.format_stack(frame))
+
+
+def run_roles(roles, duration=DUR, join_timeout=30):
     """roles: list of (role_name, fn); each fn is called in a loop on its
     own thread until the duration elapses (or it returns StopIteration).
-    Every exception is recorded, never raised."""
+    Every exception is recorded, never raised.
+
+    A worker that does not return within ``join_timeout`` of the stop
+    signal is a hang — which is exactly what these cells exist to catch
+    (issue #161 is about lock ordering) — so it fails the calling test
+    with the stuck thread's stack. Without this, a deadlocked worker just
+    times out of ``join`` and the cell scores green (issue #371)."""
     old_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-7)
     res = ScenarioResult()
@@ -95,15 +113,29 @@ def run_roles(roles, duration=DUR):
         return runner
 
     threads = [threading.Thread(target=wrap(r, f), daemon=True) for r, f in roles]
+    names = [r for r, _ in roles]
     try:
         for t in threads:
             t.start()
         time.sleep(duration)
     finally:
         stop.set()
+        # One shared deadline rather than a per-thread timeout: a wedged
+        # cell must not cost join_timeout x len(roles).
+        deadline = time.monotonic() + join_timeout
         for t in threads:
-            t.join(timeout=30)
+            t.join(timeout=max(0.0, deadline - time.monotonic()))
+        stacks = []
+        for role, t in zip(names, threads):
+            if t.is_alive():
+                res.hung.append(role)
+                stacks.append(f"  {role} is still running:\n{_stack_of(t)}")
         sys.setswitchinterval(old_interval)
+    if res.hung:
+        pytest.fail(
+            f"worker(s) {res.hung} did not finish {join_timeout}s after the stop "
+            "signal — the scenario deadlocked or livelocked:\n" + "\n".join(stacks)
+        )
     return res
 
 
@@ -572,6 +604,68 @@ def test_get_vs_churn(adapter):
     res = run_roles(roles)
     assert res.ops["churn"] > 0 and res.ops["get0"] > 0
     assert_clean(res, adapter.counts(s))
+
+
+# ---------------------------------------------------------------------------
+# Harness self-check
+# ---------------------------------------------------------------------------
+
+
+def test_harness_reports_a_healthy_scenario():
+    """Control for the deadlock case below: an ordinary role that returns
+    is joined and reported, with no hang."""
+    res = run_roles([("work", lambda: None)], duration=0.05, join_timeout=5)
+    assert res.ops["work"] > 0
+    assert res.hung == []
+
+
+def test_harness_fails_on_a_deadlocked_worker():
+    """The harness must fail — not silently return — when a worker never
+    comes back (issue #371). Before the liveness check, `join(timeout=...)`
+    simply expired and `assert_clean` passed on the empty error counter,
+    so every hang in the 28 stress cells scored green.
+
+    The wedge is a non-reentrant lock held by this thread across the
+    worker's call into it — the canonical deadlock shape these cells
+    exist to catch. It is released at the end so no thread is left stuck.
+    """
+    wedge = threading.Lock()
+    entered = threading.Event()
+
+    def deadlock():
+        entered.set()
+        with wedge:  # held by the test thread: blocks until released
+            pass
+
+    wedge.acquire()
+    try:
+        with pytest.raises(pytest.fail.Exception, match="did not finish"):
+            run_roles([("wedged", deadlock)], duration=0.05, join_timeout=1)
+        assert entered.is_set(), "the wedged role never ran; the test proved nothing"
+    finally:
+        wedge.release()
+
+
+def test_harness_names_the_hung_role_only():
+    """A healthy role alongside a wedged one must not be reported as hung,
+    and the failure message must identify the wedged one."""
+    wedge = threading.Lock()
+
+    def deadlock():
+        with wedge:
+            pass
+
+    wedge.acquire()
+    try:
+        with pytest.raises(pytest.fail.Exception) as excinfo:
+            run_roles(
+                [("healthy", lambda: None), ("wedged", deadlock)],
+                duration=0.05,
+                join_timeout=1,
+            )
+        assert "['wedged']" in str(excinfo.value)
+    finally:
+        wedge.release()
 
 
 # ---------------------------------------------------------------------------

--- a/turbovec-python/tests/test_store_thread_safety.py
+++ b/turbovec-python/tests/test_store_thread_safety.py
@@ -78,7 +78,8 @@ def _stack_of(thread: threading.Thread) -> str:
     return "".join(traceback.format_stack(frame))
 
 
-def run_roles(roles, duration=DUR, join_timeout=30):
+def run_roles(roles, duration=DUR, join_timeout=30, run_to_completion=False,
+              completion_timeout=60):
     """roles: list of (role_name, fn); each fn is called in a loop on its
     own thread until the duration elapses (or it returns StopIteration).
     Every exception is recorded, never raised.
@@ -87,7 +88,16 @@ def run_roles(roles, duration=DUR, join_timeout=30):
     signal is a hang — which is exactly what these cells exist to catch
     (issue #161 is about lock ordering) — so it fails the calling test
     with the stuck thread's stack. Without this, a deadlocked worker just
-    times out of ``join`` and the cell scores green (issue #371)."""
+    times out of ``join`` and the cell scores green (issue #371).
+
+    ``run_to_completion=True`` waits for every role to finish its own
+    workload (return ``StopIteration``) instead of stopping them after
+    ``duration``. Use it for cells whose final-state invariant is
+    absolute — "the store is empty" only holds if the deleters got all
+    the way through their id list, so a wall-clock budget would make the
+    assertion a measure of machine speed rather than of thread safety.
+    ``completion_timeout`` still bounds it, so a genuine hang is still
+    reported as one."""
     old_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-7)
     res = ScenarioResult()
@@ -117,7 +127,12 @@ def run_roles(roles, duration=DUR, join_timeout=30):
     try:
         for t in threads:
             t.start()
-        time.sleep(duration)
+        if run_to_completion:
+            done_by = time.monotonic() + completion_timeout
+            for t in threads:
+                t.join(timeout=max(0.0, done_by - time.monotonic()))
+        else:
+            time.sleep(duration)
     finally:
         stop.set()
         # One shared deadline rather than a per-thread timeout: a wedged
@@ -125,6 +140,14 @@ def run_roles(roles, duration=DUR, join_timeout=30):
         deadline = time.monotonic() + join_timeout
         for t in threads:
             t.join(timeout=max(0.0, deadline - time.monotonic()))
+        # Grace pass: the shared deadline can be consumed entirely by the
+        # first thread, leaving later ones joined with timeout 0 and
+        # misreported as hung. Anything genuinely wedged is still wedged
+        # after this; anything merely unlucky in the ordering is not.
+        grace = min(1.0, join_timeout)
+        for t in threads:
+            if t.is_alive():
+                t.join(timeout=grace)
         stacks = []
         for role, t in zip(names, threads):
             if t.is_alive():
@@ -543,7 +566,14 @@ def test_delete_vs_delete(adapter):
             pos[slot] = p + 16
         return step
 
-    res = run_roles([("del0", deleter(0)), ("del1", deleter(1))])
+    # Run to completion rather than for DUR seconds: the invariant below
+    # is "the store is empty", which only holds once both deleters have
+    # walked their whole id list. Under a wall-clock budget this cell
+    # failed with e.g. `got 816, want 0` on a loaded machine — a report
+    # about machine speed, not about thread safety (issue #371).
+    res = run_roles(
+        [("del0", deleter(0)), ("del1", deleter(1))], run_to_completion=True
+    )
     counts = adapter.counts(s)
     assert_clean(res, counts, extra={"store fully emptied": (len(s._index), 0)})
 
@@ -644,6 +674,31 @@ def test_harness_fails_on_a_deadlocked_worker():
         assert entered.is_set(), "the wedged role never ran; the test proved nothing"
     finally:
         wedge.release()
+
+
+def test_harness_run_to_completion_waits_for_the_whole_workload():
+    """`run_to_completion` must ignore `duration` and let the role finish.
+    Cells with an absolute final-state invariant ("the store is empty")
+    depend on it: cut the role off early and the assertion reports how
+    fast the machine is, not whether the store is thread-safe (#371)."""
+    done = []
+    steps = iter(range(5))
+
+    def step():
+        time.sleep(0.05)  # 5 steps > the 0.01s wall-clock budget below
+        try:
+            done.append(next(steps))
+        except StopIteration:
+            return StopIteration
+
+    res = run_roles(
+        [("work", step)],
+        duration=0.01,
+        run_to_completion=True,
+        completion_timeout=30,
+    )
+    assert done == [0, 1, 2, 3, 4]
+    assert res.hung == []
 
 
 def test_harness_names_the_hung_role_only():

--- a/turbovec-python/tests/test_store_thread_safety.py
+++ b/turbovec-python/tests/test_store_thread_safety.py
@@ -46,6 +46,10 @@ VECPOOL /= np.linalg.norm(VECPOOL, axis=1, keepdims=True) + 1e-9
 BATCH = 64
 N_READERS = 3
 DUR = 1.5  # seconds per stress cell; every issue-#161 race reproduced <1 s
+# `run_to_completion` gives up once this many exceptions have piled up:
+# the cell is already doomed, and a role that raises on every step would
+# otherwise spin for the whole completion_timeout.
+ERROR_BAILOUT = 100
 
 
 def vec_for(n: int) -> np.ndarray:
@@ -97,7 +101,8 @@ def run_roles(roles, duration=DUR, join_timeout=30, run_to_completion=False,
     the way through their id list, so a wall-clock budget would make the
     assertion a measure of machine speed rather than of thread safety.
     ``completion_timeout`` still bounds it, so a genuine hang is still
-    reported as one."""
+    reported as one, and a role failing in a tight loop bails out after
+    ``ERROR_BAILOUT`` exceptions rather than spinning out the timeout."""
     old_interval = sys.getswitchinterval()
     sys.setswitchinterval(1e-7)
     res = ScenarioResult()
@@ -129,8 +134,18 @@ def run_roles(roles, duration=DUR, join_timeout=30, run_to_completion=False,
             t.start()
         if run_to_completion:
             done_by = time.monotonic() + completion_timeout
-            for t in threads:
-                t.join(timeout=max(0.0, done_by - time.monotonic()))
+            while time.monotonic() < done_by:
+                if not any(t.is_alive() for t in threads):
+                    break
+                # Bail out early once a role is failing in a tight loop:
+                # a step that always raises never returns StopIteration,
+                # so waiting out completion_timeout only delays a failure
+                # `assert_clean` is already certain to report.
+                with lock:
+                    failures = sum(res.errors.values())
+                if failures > ERROR_BAILOUT:
+                    break
+                time.sleep(0.005)
         else:
             time.sleep(duration)
     finally:
@@ -699,6 +714,30 @@ def test_harness_run_to_completion_waits_for_the_whole_workload():
     )
     assert done == [0, 1, 2, 3, 4]
     assert res.hung == []
+
+
+def test_harness_run_to_completion_bails_out_on_a_role_that_always_raises():
+    """A step that always raises never returns StopIteration, so without a
+    bail-out `run_to_completion` would spin for the whole
+    completion_timeout before reporting a failure that is already
+    certain. Bound the wait, not just the timeout."""
+
+    def always_raises():
+        raise RuntimeError("boom")
+
+    started = time.monotonic()
+    res = run_roles(
+        [("bad", always_raises)],
+        run_to_completion=True,
+        completion_timeout=30,
+    )
+    elapsed = time.monotonic() - started
+    assert sum(res.errors.values()) > 0
+    assert res.hung == []
+    # Generous: the bail-out fires after ERROR_BAILOUT exceptions, which
+    # a tight loop reaches in milliseconds. Anything well under the 30s
+    # timeout proves we did not wait it out.
+    assert elapsed < 10, f"took {elapsed:.1f}s; the bail-out did not fire"
 
 
 def test_harness_names_the_hung_role_only():


### PR DESCRIPTION
Two Python-side concurrency defects: a test harness that scored deadlocks as passes, and async methods that blocked the event loop.

## #371 — the thread-safety harness scored deadlocks as passes

**What.** `run_roles` (`test_store_thread_safety.py`) joined its workers with `t.join(timeout=30)` and never checked `t.is_alive()`; `assert_clean` only inspected recorded exceptions and final counts. A deadlocked worker simply timed out of the join and the cell scored green — so all 28 issue-#161 stress cells, whose entire purpose is catching lock-ordering hangs, were structurally unable to report one.

**Why this shape.** `run_roles` now joins against one shared deadline (a wedged cell no longer costs `join_timeout × len(roles)`), records every still-alive role in `ScenarioResult.hung`, and fails the calling test with the stuck thread's stack via `sys._current_frames()`. The failure is raised inside `run_roles` itself rather than in `assert_clean`, so no future call site can opt out of it.

**Discrimination evidence.** Three self-check tests were added. The deadlock is real: the test thread holds a non-reentrant lock across the worker's call into it (released in a `finally`, so no thread is left stuck).

| harness | `test_harness_fails_on_a_deadlocked_worker` | `test_harness_names_the_hung_role_only` |
|---|---|---|
| liveness check disabled (previous behaviour) | **FAILED** — `Failed: DID NOT RAISE` | **FAILED** — `DID NOT RAISE` |
| liveness check enabled | passed | passed |

So `run_roles` returned normally, with `errors={}`, from a scenario whose worker never came back — exactly the claim in the issue.

**Do the now-real tests pass? Yes, but with one qualification.** All 28 stress cells (4 stores × 7 scenarios) pass with the liveness assertion live. **The harness fix surfaced no concurrency bug** — no cell reported a hang, a lost handle, or a desynced side-car map. No assertion was weakened.

What it did surface is **#400**: `test_delete_vs_delete` decided its "store fully emptied" invariant on a 1.5 s wall-clock budget, so on a loaded machine it failed with `invariant store fully emptied: got 816, want 0` — a report about machine speed, not about thread safety. That is pre-existing (matched main-vs-PR pairs fail at the same rate) and is **not** a concurrency bug, but it is exactly the class of defect #371 is about, sitting in the file this PR audits. So: no thread-safety bug found; one cell was load-sensitive for an unrelated reason, and this PR fixes it — see below. Close #400 with this PR if you agree with the shape.

### #371 item 2 — four tests passing vacuously on empty results

Six loops/`zip`s now assert a length first: the two haystack `scale_score` formula tests, haystack's `filter_documents` score-is-`None` test, haystack's concurrent-async-retrieval consistency test (a `for` over an empty gather result), agno's insert-filters-merge test (which passed with `insert` a no-op), and the llama_index `dot_product` similarity test (whose `zip` truncated to the shortest input).

**Discrimination evidence.** With the code under test monkeypatched to return `[]` / no-op (`embedding_retrieval`, `filter_documents`, `TurboQuantVectorDb.insert`, `TurboQuantVectorStore.query`):

| | result |
|---|---|
| tests as they were on main | **6 passed** |
| tests with the length assertions | **6 failed** (`assert 0 == 3`, …) |

## #342 — async methods blocked the event loop and ignored cancellation

**What.** The `a*` / `async_*` methods on the langchain, llama_index, and agno stores ran their index work inline on the loop thread. Nothing suspended during the CPU work, so the loop stalled for the operation's full duration (the issue measured 815 ms of loop lag on a 20k-doc `aadd_texts`) and a deadline could not be delivered at all — `asyncio.wait_for(aadd_texts(30k), timeout=0.05)` ran 870 ms to completion with no `TimeoutError` and all 30,000 docs committed. A FastAPI / LangServe request deadline on any of these was silently non-functional.

**Why this shape — matched, not invented.** I checked each framework's reference before choosing:

- **langchain**: `VectorStore`'s own default async implementations (`aadd_texts`, `aadd_documents`, `adelete`, `asimilarity_search`, `aget_by_ids`) all offload via `run_in_executor`. `InMemoryVectorStore` overrides them to run inline — because its work is GIL-bound Python where a thread hop buys nothing. turbovec's is GIL-releasing Rust, so the base contract is the right one to follow here.
- **agno**: `VectorDb` is abstract, but every in-tree sync-backed DB — chromadb, pgvector, cassandra, pineconedb — wraps its sync body in `asyncio.to_thread`. Same shape adopted.
- **llama_index**: `BasePydanticVectorStore`'s defaults call the sync body inline ("if not implemented, it will just call synchronously"). Offloading is the improvement the base explicitly leaves to implementations.

`asyncio.to_thread` (stdlib, ≥3.9, matches the package's floor) propagates the caller's context vars, so it is `run_in_executor` plus context.

**Exactly one offload per method, never one per chunk.** The sync bodies take the write lock; a suspension point inside one would break atomicity. agno's `async_upsert` keeps the issue-#146 capture/insert/remove sequence unsplit, and every store keeps the issue-#89 insert-before-delete ordering. agno's `async_exists` / `async_name_exists` / `async_get_count` still answer inline — O(1) reads where a thread hop costs more than it saves. agno's search tail was extracted to `_search_and_rank` so sync and async share one retrieve→rerank→dedup ordering (issue #136).

**What cancellation does and does not mean.** Documented per integration and pinned by tests rather than implied:

- `wait_for` / `task.cancel()` / a client disconnect now releases the awaiting caller promptly. That part genuinely works where it previously did not.
- It does **not** decide what happened to the write. Both branches are real: a worker that already started runs the call to completion (work inside the Rust core is not interruptible) and commits in full; a call still queued behind a saturated executor is cancelled before it ever runs and writes nothing. **A cancelled write is "outcome unknown" — it may have fully committed, or may never have begun.** Neither assumption is safe; make retries idempotent.
- The one real guarantee is that the outcome is **all-or-nothing**. The store is never left torn.
- Timing out does not make the work go away: the loop's shutdown waits for the worker thread, so a process exiting right after a short timeout can still block for the rest of the in-flight call. Also documented.

`test_*_is_cancellable_and_lands_all_or_nothing` asserts that guarantee rather than one branch, and `test_langchain_cancelled_before_start_writes_nothing` pins the never-started branch by saturating the loop's default executor. The first revision of this PR asserted `== 2` in those three cells and documented only "may still commit" — that was half the contract, and the review was right to block on it.

The never-started cell needed a second correction, also from review: the langchain stub defined only a sync `embed_documents`, so `aadd_texts` hit `Embeddings`' inherited `aembed_documents`, which hops through `run_in_executor(None, ...)` — the executor the test had just saturated. The coroutine died at the *embedding* step and never reached the offload; the tell was that the cell **passed** against `origin/main`, which has no offload at all. The stub now defines native `async def aembed_documents` / `aembed_query`, and the cell traces the embedding step and asserts it ran, so it cannot pass for that reason again. Against `origin/main` it now fails with `DID NOT RAISE <class 'TimeoutError'>`.

**Discrimination evidence.** New file `turbovec-python/tests/test_async_offload.py`, 22 cells:

| | result |
|---|---|
| three modules reverted to `origin/main` | **22 failed** |
| with the fix | **22 passed** |

The offload cells are fully deterministic — no timing at all. They patch the store's own sync method to record `threading.get_ident()` and assert it is not the loop thread's, so the failure mode before the fix is `assert <loop ident> not in [<loop ident>]`, not a timeout. The one agno case that would otherwise have discriminated on a *name* (the new `_search_and_rank`) records on the pre-existing `_retrieve` instead, so it discriminates on behaviour.

The two timing-shaped cells are deliberately loose, per the #367 guidance:

- **responsiveness**: a 10 ms heartbeat task must tick ≥ 5 times during an op made to take 1 s (a healthy loop ticks ~100; it ticked **0** before the fix). Machine load can only reduce the op's speed, which widens the margin.
- **cancellation**: `wait_for(..., timeout=0.05)` against a 1 s op — a 20× margin, and load pushes it further open.

## Test runs

- **Full Python suite**: `735 passed, 15 skipped, 1 failed`. The single failure is `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, which fails identically on unmodified main (#386 — the declared llama-index floor is genuinely unsupported). Pre-existing, untouched by this PR.
- **`cargo test --release -p turbovec`**: 317 passed, 0 failed, across all 22 test binaries plus doc-tests.
- **Flakiness, unloaded**: `test_async_offload.py` + `test_store_thread_safety.py` (74 tests, including all 28 now-real stress cells) run **10 consecutive times: all passed**, ~50 s per run, on a machine concurrently running `cargo test --release` and two other agents.
- **Flakiness, under load**: the review showed the unloaded number was not enough. Re-run **6 times under 10 CPU burners: 75 passed every time**, 49–54 s per run. The same condition on `origin/main`'s `test_delete_vs_delete` fails **2 of 6** here (`invariant store fully emptied: got 816, want 0`) and **5 of 6** in the reviewer's harsher matched-pair run; with this PR's `run_to_completion` fix that cell passes **6 of 6** in both. It also runs ~1.4–2.4× faster (mean ~1.7×), since it stops when the deleters finish instead of always sleeping out the wall-clock budget.
- No new test of the `test_gil_release.py` starvation-measuring shape was added.

## Found but not fixed

**Also fixed after review**: `run_to_completion` now bails out after 100 recorded exceptions. A step that always raises never returns `StopIteration`, so an already-doomed cell would otherwise spin out the full `completion_timeout` before reporting what `assert_clean` was already certain to report — measured **30.2 s** without the bail-out, **0.1 s** with it, and covered by its own discriminating self-check.

**Fixed here after review**: #400 (`test_delete_vs_delete`'s wall-clock-bounded invariant — the review confirms this resolves #400 outright, which asks verbatim for "run the deleters to completion instead of asserting emptiness after a fixed wall-clock window"), the misattribution risk in the shared join deadline (a per-thread grace pass — only reachable with a short `join_timeout`, never at the 30 s default), and the one-sided cancellation contract.

**Consciously left**, all reported by the review:

- **Two liveness blind spots** that still score `hung == []`: a leaked *wedged daemon child process* (process liveness is `test_fork_safety.py`'s domain, not this harness's thread join), and a role that leaks the store lock and then exits cleanly (the thread is genuinely done — catching that needs a lock-ownership detector, which is a different mechanism and a bigger change than #371 asks for).
- **`RLock` is now non-reentrant across the async boundary.** A caller holding a store's internal write lock and awaiting an async method on the same store would now block instead of re-entering. No public path reaches this — the embedder, reranker, and langchain filter callables are all invoked outside the lock — so it is a latent shape change rather than a live defect, but it is a real consequence of the offload and worth stating.

From **#371**, deliberately left for separate issues (they are distinct defects, not part of these fixes):

- **Item 3** — `test_fork_safety.py`'s unavailable-start-method path emits `RESULT: PASS`, so a skipped scenario is indistinguishable from a real pass and invisible to pytest's skip report.
- **Item 4** — the `test_gil_release.py` regression tests self-disable on fast machines (one skipped on 2 of 3 isolated runs), and one of them fails via a trailing `assert False` that reads as a skip. Overlaps #367; fixing it well means changing the measurement, not adding an assertion.
- **Item 6** — no signal when a CI job is missing a framework and silently drops ~100 `importorskip`-gated tests.
- The ranked missing-test list (fork while a thread holds the store lock, the persist/reload matrix with a golden on-disk fixture, magnitude edge cases) is untouched.

From **#342**, out of the scope named for this PR:

- **Item 1** — haystack's `max_workers=1` executor serializes all async reads behind any in-flight async write (2915× measured slowdown). It faithfully mirrors `InMemoryDocumentStore`, but that store's reads are GIL-bound Python, so mirroring costs it little and costs turbovec its headline concurrency property. Worth its own decision about diverging from the reference.
- **Item 3** — `_interruptible` chunking is inert under `asyncio.run`; Ctrl-C is deaf for the whole operation because `asyncio.runners` installs its own SIGINT handler. The docstring's "notebooks and servers" claim is unqualified. Docs-plus-design change, not a mechanical one.
- **Item 5** — `TurboQuantDocumentStore.__del__` raises `RuntimeError: cannot join current thread` when a worker thread holds the store's last reference.
- **Item 6** — cancelled haystack async writes keep mutating in the background. Same semantic this PR now documents for the other three stores; haystack's docs do not yet state it.
- **Item 4** — the event-loop lag table from the issue is not published. The docs describe the *contract* (offloaded, partially cancellable) without quoting numbers: per #312, published figures in this repo come from official benchmark runs, and these are issue-body measurements. An official loop-lag sweep would be its own piece of work.

## Caveats

- Whether a cancelled write commits depends on executor scheduling, so the tests assert all-or-nothing rather than a specific outcome. A caller that needs to know must read back.
- The responsiveness test injects a `time.sleep` into the sync body to make the op reliably slow. `time.sleep` releases the GIL, as the index's own kernels do, so the test demonstrates the offload mechanism rather than the index's specific GIL behaviour (which `test_gil_release.py` already covers).
- `aget_by_ids` and llama_index's `aget_nodes` are now offloaded even though they can be cheap; that follows the base-class contract and their cost scales with the number of ids, but a single-id lookup does pay a thread-hop it did not before.
- `asyncio.run` shuts down the default executor on exit, which is what makes the all-or-nothing assertion observable at the end of the test. That same shutdown is why a process exiting right after a short timeout still blocks for the rest of the in-flight call — now documented per integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
