### PR TITLE
test: raise the discrimination floor on the GIL-rebuild test

### DIFF
--- a/turbovec-python/tests/test_gil_release.py
+++ b/turbovec-python/tests/test_gil_release.py
@@ -293,10 +293,25 @@ def test_first_removal_after_load_does_not_hold_gil(tmp_path, vectors):
     finally:
         sys.setswitchinterval(old_interval)
 
-    if block < 0.01:
+    # The ratio below only means something when `block` is large relative to
+    # the ticker's own scheduling granularity. The ticker sleeps ~1 ms and the
+    # switch interval is 0.5 ms, so a healthy run still shows gaps of several
+    # ms from ordinary descheduling — at block = 11 ms that noise alone is
+    # ~0.5 * block and the assertion fires on a correct build. Observed
+    # exactly that on macOS CI: block 11 ms, gap 7 ms, twice, on unrelated
+    # PRs (#367 catalogues this shape).
+    #
+    # The floor is therefore set by what the measurement can resolve, not by
+    # "is there anything to measure": below 50 ms the ratio is noise, so skip
+    # rather than assert on it. The rebuild this test targets is ~5.8 ms at
+    # 1M vectors and shrinking as the remove path gets cheaper, so on a fast
+    # machine this will increasingly skip — that is honest, where a coin-flip
+    # assertion is not.
+    if block < 0.05:
         pytest.skip(
-            f"first remove after load took only {block * 1e3:.1f} ms; "
-            "nothing to measure on this machine"
+            f"first remove after load took only {block * 1e3:.1f} ms; below "
+            "50 ms the ticker's own scheduling noise is the same order as "
+            "the signal, so the ratio cannot discriminate on this machine"
         )
     assert gap < 0.5 * block, (
         f"the first remove after a load took {block * 1e3:.0f} ms and froze "


### PR DESCRIPTION
A scheduler-dependent assertion that is currently failing **two unrelated PRs** on macOS CI.

## Evidence

`test_first_removal_after_load_does_not_hold_gil` failed on `Python (macos-14)` for both #398 and #399, with near-identical numbers:

```
#398: assert 0.00742 < (0.5 * 0.01057)   # block 11 ms, gap 7 ms
#399: assert 0.00652 < (0.5 * 0.01138)   # block 11 ms, gap 7 ms
```

Neither PR touches the removal path. Both were green on every other leg.

## Why it fires on correct code

The test asserts `gap < 0.5 * block`, and skips only when `block < 10 ms`. But the ticker thread sleeps ~1 ms against a 0.5 ms switch interval, so a *healthy* run still records gaps of several ms purely from ordinary descheduling. At `block = 11 ms` that noise alone is ~0.5 × block — the assertion is a coin flip, decided by how the OS scheduled a 1 ms ticker, not by whether the GIL was held.

The old floor asked "is there anything to measure?". The right question is "can this measurement resolve the thing it claims to?" — and below ~50 ms it cannot.

## The change

One constant, 10 ms → 50 ms, with the reasoning recorded inline so the next person does not lower it back.

Consequence stated plainly in the comment: the rebuild this targets is ~5.8 ms at 1M vectors and **shrinking** as the remove path gets cheaper (#392/#397 make loaded removes ~100x faster), so on a fast machine this test will increasingly skip. That is honest. A test that silently becomes a coin flip as the code improves is worse than one that says it cannot measure.

Related: #398's reviewer separately observed that this test measures the very rebuild #397 retires, and now always takes its own skip guard.

## Verified

Locally it skips deterministically, 3 runs of 3, rather than passing or failing by scheduling.

## Same class as

- **#367** — catalogues `test_removal_blocked_on_add_does_not_hold_gil[remove]` as unreliable for this exact reason.
- **#400** — `test_delete_vs_delete`, an assertion decided by wall-clock budget rather than by the property under test.

Three instances now. The general lesson for this file: a timing-ratio assertion needs its floor set by the measurement's resolution, not by the presence of a signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)