### PR TITLE
fix: reject side-car payloads JSON can't round-trip; require key presence in LangChain dict filters (#350, #381)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,21 +745,42 @@ appears under each surface it touches.
 
 #### Fixed
 
-- **The JSON side-car no longer writes data it cannot read back (#350).**
-  Two payloads passed `json.dumps` but did not survive the file, and both
-  did so silently, across all four integrations' save paths. *Non-string
-  metadata keys* were stringified, so `{1: "int-one", "1": "str-one"}`
-  landed on disk as a single `{"1": "str-one"}` — one entry gone, with
-  `save()` returning success (`True`/`1` and `2020`/`"2020"` collided the
-  same way). *NaN and Infinity* were emitted as bare tokens RFC 8259
-  forbids: Python round-tripped them, but `jq .` rewrites `NaN` to `null`
-  and `serde_json` / `JSON.parse` reject the file outright — in a side-car
-  documented as plain, inspectable JSON. Both now raise before any file is
-  touched: `TypeError` for a non-str key, `ValueError` for a non-finite
-  float, each naming the exact path to the offending entry. Metadata that
-  relied on non-str keys must now stringify them at the call site; those
-  saves were already lossy on reload, so nothing that round-tripped
-  correctly before is affected.
+- **The JSON side-car no longer writes data it cannot read back
+  (#350).** ⚠️ **Breaking for stores with non-finite metadata — see the
+  migration note below.** Two payloads passed `json.dumps` but did not
+  survive the file, silently, across all four integrations' save paths.
+  *Non-string metadata keys* were stringified, so `{1: "int-one", "1":
+  "str-one"}` landed on disk as a single `{"1": "str-one"}` — one entry
+  gone, with `save()` returning success (`True`/`1` and `2020`/`"2020"`
+  collided the same way). *NaN and Infinity* were emitted as bare tokens
+  RFC 8259 forbids: `jq .` rewrites `NaN` to `null` and `serde_json` /
+  `JSON.parse` reject the file outright — in a side-car documented as
+  plain, inspectable JSON. Both now raise before any file is touched:
+  `TypeError` for a non-str key, `ValueError` for a non-finite float,
+  each naming the exact path to the offending entry.
+
+  **Migration.** The two halves differ in impact and it is worth being
+  precise about which affects you:
+
+  - *Non-str keys* — no working code is affected. Those saves were
+    already lossy on reload (the keys came back as strings, and colliding
+    entries were simply gone), so the previous behaviour reported success
+    for a save that had not preserved the data. If you relied on it,
+    stringify the keys at the call site: `{str(k): v for k, v in ...}`.
+  - *NaN / Infinity* — **this is a genuine break.** Python's `json` both
+    writes and reads the non-standard tokens, so such metadata *did*
+    round-trip correctly through turbovec's own `save`/`load`, and that
+    now raises `ValueError`. The change is still deliberate: the file
+    those saves produced was not JSON, and every non-Python consumer
+    either rejects it or (jq) quietly rewrites the value to `null`. If
+    you legitimately carry non-finite numbers, sanitize before saving —
+    `None` for "no value" (it round-trips as `null` and is valid JSON),
+    or a finite sentinel your pipeline agrees on.
+
+  Validation walks the whole payload, so serializing the side-car costs
+  roughly twice what it did: on a 200k-document payload with 4-field
+  metadata, 0.31 s → 0.65 s. That is the side-car step only; a full
+  `save()` also writes and fsyncs the index.
 
 - **LangChain: a dict filter with a `None` value no longer matches
   documents that lack the key (#381).** `filter={"g": None}` was compiled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -746,9 +746,10 @@ appears under each surface it touches.
 #### Fixed
 
 - **The JSON side-car no longer writes data it cannot read back
-  (#350).** ⚠️ **Breaking for stores with non-finite metadata — see the
-  migration note below.** Two payloads passed `json.dumps` but did not
-  survive the file, silently, across all four integrations' save paths.
+  (#350).** ⚠️ **Breaking for stores holding non-finite floats
+  anywhere in the side-car — see the migration note below.** Two
+  payloads passed `json.dumps` but did not survive the file, silently,
+  across all four integrations' save paths.
   *Non-string metadata keys* were stringified, so `{1: "int-one", "1":
   "str-one"}` landed on disk as a single `{"1": "str-one"}` — one entry
   gone, with `save()` returning success (`True`/`1` and `2020`/`"2020"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,32 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **The JSON side-car no longer writes data it cannot read back (#350).**
+  Two payloads passed `json.dumps` but did not survive the file, and both
+  did so silently, across all four integrations' save paths. *Non-string
+  metadata keys* were stringified, so `{1: "int-one", "1": "str-one"}`
+  landed on disk as a single `{"1": "str-one"}` — one entry gone, with
+  `save()` returning success (`True`/`1` and `2020`/`"2020"` collided the
+  same way). *NaN and Infinity* were emitted as bare tokens RFC 8259
+  forbids: Python round-tripped them, but `jq .` rewrites `NaN` to `null`
+  and `serde_json` / `JSON.parse` reject the file outright — in a side-car
+  documented as plain, inspectable JSON. Both now raise before any file is
+  touched: `TypeError` for a non-str key, `ValueError` for a non-finite
+  float, each naming the exact path to the offending entry. Metadata that
+  relied on non-str keys must now stringify them at the call site; those
+  saves were already lossy on reload, so nothing that round-tripped
+  correctly before is affected.
+
+- **LangChain: a dict filter with a `None` value no longer matches
+  documents that lack the key (#381).** `filter={"g": None}` was compiled
+  to `doc.metadata.get("g") is None`, and `dict.get` cannot tell "absent"
+  from "present and None" — so every document with no `g` key at all came
+  back. A dict entry now requires the key to be present, matching the
+  predicate a user would write by hand and agreeing with the agno store's
+  dict filter (#144). Absence is still expressible through the callable
+  filter form (`lambda doc: "g" not in doc.metadata`), which is the only
+  form langchain_core's own `InMemoryVectorStore` accepts.
+
 - **agno: a half-present save loaded silently empty and was then
   overwritten (#328).** `create()` caught the `FileNotFoundError` that
   `_load_from` raises for a folder holding only one of

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -119,7 +119,9 @@ docs = store.similarity_search(
 )
 ```
 
-The callable form matches the `Callable[[Document], bool]` convention used by `InMemoryVectorStore`, so predicates ported from there work unchanged.
+The callable form matches the `Callable[[Document], bool]` convention used by `InMemoryVectorStore`, so predicates ported from there work unchanged. The dict form is a turbovec convenience on top of it — `InMemoryVectorStore` itself takes callables only.
+
+A dict entry requires the key to be **present**: `filter={"source": None}` matches documents that store `source=None`, not documents with no `source` key at all. To match on absence, use the callable form (`lambda doc: "source" not in doc.metadata`).
 
 Filters are resolved to an id allowlist **before** scoring; the kernel only ever inserts allowed documents into the per-query heap. You get up to `k` results from the filtered set, never fewer than `k` because the filter happened to exclude the top-scoring candidates.
 

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -197,7 +197,7 @@ def _check_json_faithful(payload: Any) -> None:
             for key, value in obj.items():
                 if not isinstance(key, str):
                     raise TypeError(
-                        f"side-car metadata key {key!r} at "
+                        f"side-car key {key!r} at "
                         f"{_crumb_path(entry)} is {type(key).__name__}, not "
                         f"str. JSON object keys are strings, so writing it "
                         f"would stringify the key and silently merge it with "
@@ -217,7 +217,7 @@ def _check_json_faithful(payload: Any) -> None:
             else:
                 token = "Infinity" if obj > 0 else "-Infinity"
             raise ValueError(
-                f"side-car metadata value at {_crumb_path(entry)} is {obj!r}, "
+                f"side-car value at {_crumb_path(entry)} is {obj!r}, "
                 f"which JSON cannot represent: it would be written as a bare "
                 f"{token} token that RFC 8259 forbids. Other JSON readers "
                 f"reject the file (serde_json, JSON.parse) or silently "

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import itertools
 import json
+import math
 import os
 import secrets
 import time
@@ -88,15 +89,108 @@ def _replace_atomic(src: str, dst: str) -> None:
     os.replace(src, dst)
 
 
+def _check_json_faithful(payload: Any) -> None:
+    """Reject payloads JSON cannot represent *faithfully* (#350).
+
+    ``json.dumps`` accepts two classes of value that survive the call but
+    do not survive the file, and it does so silently:
+
+    1. **Non-string mapping keys.** JSON object keys are strings, so
+       ``json.dumps`` stringifies ``int``/``float``/``bool``/``None`` keys.
+       ``{1: "a", "1": "b"}`` becomes ``{"1": "b"}`` — the int-keyed entry
+       is *gone*, ``save()`` returns success, and the loss is invisible
+       until someone reads the data back. ``True``/``1`` and ``2020``/
+       ``"2020"`` collide the same way.
+    2. **Non-finite floats.** ``allow_nan`` defaults to True, emitting bare
+       ``NaN``/``Infinity`` tokens that RFC 8259 forbids. Python round-trips
+       them, so the damage only shows outside Python: ``JSON.parse`` and
+       ``serde_json`` reject the file outright, and ``jq .`` silently
+       rewrites ``NaN`` to ``null`` — corrupting values in a side-car this
+       project documents as plain, inspectable JSON.
+
+    The contract: **the side-car is portable JSON, and a save that could
+    not be read back faithfully fails loudly before any file is touched**
+    rather than writing a lossy or non-conforming file. This is the same
+    posture ``atomic_save`` already documents for sets and ndarrays; the
+    two cases above were the gaps where it silently did not hold.
+
+    Both are rejected rather than coerced. Coercion is what causes the
+    data loss — stringifying keys is exactly the step that merges ``1``
+    into ``"1"``, and mapping NaN to ``null`` (what jq does) turns a
+    "score was NaN" into "score was absent". Neither can be undone at load
+    time, and neither is detectable by the handle/keyset checks, so the
+    only place to be loud is the write.
+
+    This does narrow what ``save()`` accepts: metadata with, say, int keys
+    persisted "fine" before as long as no string key collided with it. That
+    is the intended trade — those saves were already lossy on reload (the
+    keys came back as strings), so the previous behaviour was not a working
+    contract but an unreported one. The error names the exact path to the
+    offending key/value so the fix is mechanical (``str(k)`` at the call
+    site, or drop the NaN).
+
+    Raises:
+        TypeError: if any mapping key anywhere in ``payload`` is not a str.
+        ValueError: if any float anywhere in ``payload`` is NaN or Infinity.
+    """
+    # Iterative with a visited set: metadata may nest arbitrarily deep
+    # (recursion would blow the stack before json.dumps' own guard fires)
+    # and may contain shared or cyclic containers. Recording container
+    # identity keeps a cycle from spinning forever; a shared subtree is
+    # still validated, just once.
+    stack: list[tuple[Any, str]] = [(payload, "payload")]
+    seen: set[int] = set()
+    while stack:
+        obj, path = stack.pop()
+        if isinstance(obj, dict):
+            if id(obj) in seen:
+                continue
+            seen.add(id(obj))
+            for key, value in obj.items():
+                if not isinstance(key, str):
+                    raise TypeError(
+                        f"side-car metadata key {key!r} at {path} is "
+                        f"{type(key).__name__}, not str. JSON object keys are "
+                        f"strings, so writing it would stringify the key and "
+                        f"silently merge it with any existing "
+                        f"{str(key)!r} key, losing data on reload. Convert "
+                        f"the key to a str before saving."
+                    )
+                stack.append((value, f"{path}[{key!r}]"))
+        elif isinstance(obj, (list, tuple)):
+            if id(obj) in seen:
+                continue
+            seen.add(id(obj))
+            for i, value in enumerate(obj):
+                stack.append((value, f"{path}[{i}]"))
+        elif isinstance(obj, float) and not math.isfinite(obj):
+            if math.isnan(obj):
+                token = "NaN"
+            else:
+                token = "Infinity" if obj > 0 else "-Infinity"
+            raise ValueError(
+                f"side-car metadata value at {path} is {obj!r}, which JSON "
+                f"cannot represent: it would be written as a bare {token} "
+                f"token that RFC 8259 forbids. Other JSON readers reject the "
+                f"file (serde_json, JSON.parse) or silently rewrite the value "
+                f"to null (jq). Replace it with None or a finite number "
+                f"before saving."
+            )
+
+
 def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
     """Atomically persist an index + JSON side-car pair — the shared
     write path for all four integrations' save methods.
 
     The failure-ordering guarantees:
 
-    1. ``payload`` is JSON-serialized fully in memory *first*, so a
-       non-serializable value (a set or ndarray in document metadata)
-       raises ``TypeError`` before any file is touched.
+    1. ``payload`` is validated and JSON-serialized fully in memory
+       *first*, so a value JSON cannot carry faithfully raises before any
+       file is touched: a non-serializable value (a set or ndarray in
+       document metadata) or a non-str mapping key raises ``TypeError``,
+       and a NaN/Infinity float raises ``ValueError``. See
+       ``_check_json_faithful`` for why the last two are rejected rather
+       than coerced (#350).
     2. Both artifacts are written to sibling temp files in the
        destination directory, flushed and fsynced, then moved into place
        with ``os.replace`` (atomic on POSIX). A failure or crash before
@@ -117,7 +211,12 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
         payload: JSON-serializable side-car payload.
         sidecar_path: destination for the JSON side-car.
     """
-    payload_str = json.dumps(payload)  # fail before touching any file
+    # Fail before touching any file. The explicit walk catches what
+    # json.dumps accepts but cannot round-trip (non-str keys, non-finite
+    # floats); allow_nan=False is a backstop for any float the walk can't
+    # reach (e.g. inside a custom container json handles but we don't).
+    _check_json_faithful(payload)
+    payload_str = json.dumps(payload, allow_nan=False)
 
     index_path = os.fspath(index_path)
     sidecar_path = os.fspath(sidecar_path)

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -89,11 +89,27 @@ def _replace_atomic(src: str, dst: str) -> None:
     os.replace(src, dst)
 
 
-def _check_json_faithful(payload: Any) -> None:
-    """Reject payloads JSON cannot represent *faithfully* (#350).
+def _crumb_path(entry) -> str:
+    """Rebuild ``payload['docs']['a']['metadata'][1]`` from a stack entry.
 
-    ``json.dumps`` accepts two classes of value that survive the call but
-    do not survive the file, and it does so silently:
+    Only called on the failure path — see ``_check_json_faithful`` for why
+    the walk carries parent links instead of prebuilt path strings.
+    """
+    keys = []
+    while entry is not None:
+        _obj, parent, key = entry
+        if parent is not None:
+            keys.append(f"[{key!r}]" if isinstance(key, str) else f"[{key}]")
+        entry = parent
+    return "payload" + "".join(reversed(keys))
+
+
+def _check_json_faithful(payload: Any) -> None:
+    """Reject payloads whose JSON form would lose data or not be portable
+    JSON (#350).
+
+    ``json.dumps`` accepts two things it writes *destructively*, silently,
+    and irreversibly:
 
     1. **Non-string mapping keys.** JSON object keys are strings, so
        ``json.dumps`` stringifies ``int``/``float``/``bool``/``None`` keys.
@@ -108,26 +124,48 @@ def _check_json_faithful(payload: Any) -> None:
        rewrites ``NaN`` to ``null`` — corrupting values in a side-car this
        project documents as plain, inspectable JSON.
 
-    The contract: **the side-car is portable JSON, and a save that could
-    not be read back faithfully fails loudly before any file is touched**
-    rather than writing a lossy or non-conforming file. This is the same
-    posture ``atomic_save`` already documents for sets and ndarrays; the
-    two cases above were the gaps where it silently did not hold.
+    **Scope — exactly these two, and deliberately not "everything JSON
+    round-trips imperfectly".** The guard covers values whose JSON form
+    either *loses data* (a collided key: two entries in, one out, and no
+    way to tell which) or *is not JSON at all* (a bare ``NaN`` token).
+    Total, well-known type narrowings are out of scope and are documented
+    at the call sites instead:
+
+    - ``tuple`` -> ``list``. Every element survives; only the type narrows,
+      the mapping is total and one-way for every tuple alike, and the
+      side-car's own payloads are built from ``dict.items()`` pairs.
+      ``langchain.py``'s dump and ``llama_index.py``'s ``node_id_to_u64``
+      both already document the coercion in-line.
+    - ``int`` wider than 2**53. Python writes and reads these exactly, and
+      an arbitrary-precision integer literal *is* valid RFC 8259 — the
+      imprecision lives in double-based readers (``JSON.parse`` turns
+      ``9007199254740993`` into ``...992``), not in the file. Rejecting
+      them would break the legitimate int64 ids the stores are expected to
+      carry, so they are accepted and the reader caveat is documented.
+
+    So the enforced contract is: **a save whose side-car would lose data
+    or would not be portable JSON fails loudly before any file is
+    touched.** That extends the posture ``atomic_save`` already documents
+    for sets and ndarrays to the two cases where it silently did not hold.
 
     Both are rejected rather than coerced. Coercion is what causes the
-    data loss — stringifying keys is exactly the step that merges ``1``
-    into ``"1"``, and mapping NaN to ``null`` (what jq does) turns a
-    "score was NaN" into "score was absent". Neither can be undone at load
-    time, and neither is detectable by the handle/keyset checks, so the
-    only place to be loud is the write.
+    damage — stringifying keys is exactly the step that merges ``1`` into
+    ``"1"``, and mapping NaN to ``null`` (what jq does) turns a "score was
+    NaN" into "score was absent". Neither can be undone at load time, and
+    neither is detectable by the handle/keyset checks, so the only place
+    to be loud is the write.
 
-    This does narrow what ``save()`` accepts: metadata with, say, int keys
-    persisted "fine" before as long as no string key collided with it. That
-    is the intended trade — those saves were already lossy on reload (the
-    keys came back as strings), so the previous behaviour was not a working
-    contract but an unreported one. The error names the exact path to the
-    offending key/value so the fix is mechanical (``str(k)`` at the call
-    site, or drop the NaN).
+    **This is a breaking change for one of the two cases.** Non-str keys
+    were already lossy on reload — those saves never worked, they only
+    reported success. NaN/Infinity metadata is different: it round-tripped
+    correctly through turbovec's own ``save``/``load``, because Python's
+    ``json`` both writes and reads the non-standard tokens. Such a store
+    now raises ``ValueError`` at save time. That is intended — the file it
+    used to write is not JSON, and any non-Python consumer either rejects
+    it or (jq) quietly corrupts it — but it does break working code.
+    Callers with legitimately non-finite metadata should sanitize before
+    saving (``None`` for "no value", or a sentinel that is a real number).
+    The error names the exact path to the offending entry.
 
     Raises:
         TypeError: if any mapping key anywhere in ``payload`` is not a str.
@@ -138,10 +176,20 @@ def _check_json_faithful(payload: Any) -> None:
     # and may contain shared or cyclic containers. Recording container
     # identity keeps a cycle from spinning forever; a shared subtree is
     # still validated, just once.
-    stack: list[tuple[Any, str]] = [(payload, "payload")]
+    #
+    # Each entry is (obj, parent_entry, key_in_parent) and doubles as its
+    # children's parent link, so the walk costs one tuple per node and
+    # builds no path strings. Eagerly formatting `f"{path}[{key!r}]"` for
+    # every node cost ~18% of the whole validation pass on a 200k-doc
+    # payload, all of it to produce strings that are thrown away unless a
+    # save fails. `_crumb_path` reconstructs the path from the links on
+    # the failure path only.
+    root = (payload, None, None)
+    stack = [root]
     seen: set[int] = set()
     while stack:
-        obj, path = stack.pop()
+        entry = stack.pop()
+        obj = entry[0]
         if isinstance(obj, dict):
             if id(obj) in seen:
                 continue
@@ -149,32 +197,32 @@ def _check_json_faithful(payload: Any) -> None:
             for key, value in obj.items():
                 if not isinstance(key, str):
                     raise TypeError(
-                        f"side-car metadata key {key!r} at {path} is "
-                        f"{type(key).__name__}, not str. JSON object keys are "
-                        f"strings, so writing it would stringify the key and "
-                        f"silently merge it with any existing "
-                        f"{str(key)!r} key, losing data on reload. Convert "
-                        f"the key to a str before saving."
+                        f"side-car metadata key {key!r} at "
+                        f"{_crumb_path(entry)} is {type(key).__name__}, not "
+                        f"str. JSON object keys are strings, so writing it "
+                        f"would stringify the key and silently merge it with "
+                        f"any existing {str(key)!r} key, losing data on "
+                        f"reload. Convert the key to a str before saving."
                     )
-                stack.append((value, f"{path}[{key!r}]"))
+                stack.append((value, entry, key))
         elif isinstance(obj, (list, tuple)):
             if id(obj) in seen:
                 continue
             seen.add(id(obj))
             for i, value in enumerate(obj):
-                stack.append((value, f"{path}[{i}]"))
+                stack.append((value, entry, i))
         elif isinstance(obj, float) and not math.isfinite(obj):
             if math.isnan(obj):
                 token = "NaN"
             else:
                 token = "Infinity" if obj > 0 else "-Infinity"
             raise ValueError(
-                f"side-car metadata value at {path} is {obj!r}, which JSON "
-                f"cannot represent: it would be written as a bare {token} "
-                f"token that RFC 8259 forbids. Other JSON readers reject the "
-                f"file (serde_json, JSON.parse) or silently rewrite the value "
-                f"to null (jq). Replace it with None or a finite number "
-                f"before saving."
+                f"side-car metadata value at {_crumb_path(entry)} is {obj!r}, "
+                f"which JSON cannot represent: it would be written as a bare "
+                f"{token} token that RFC 8259 forbids. Other JSON readers "
+                f"reject the file (serde_json, JSON.parse) or silently "
+                f"rewrite the value to null (jq). Replace it with None or a "
+                f"finite number before saving."
             )
 
 
@@ -185,12 +233,15 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
     The failure-ordering guarantees:
 
     1. ``payload`` is validated and JSON-serialized fully in memory
-       *first*, so a value JSON cannot carry faithfully raises before any
-       file is touched: a non-serializable value (a set or ndarray in
-       document metadata) or a non-str mapping key raises ``TypeError``,
-       and a NaN/Infinity float raises ``ValueError``. See
-       ``_check_json_faithful`` for why the last two are rejected rather
-       than coerced (#350).
+       *first*, so a value whose JSON form would lose data or not be
+       portable JSON raises before any file is touched: a non-serializable
+       value (a set or ndarray in document metadata) or a non-str mapping
+       key raises ``TypeError``, and a NaN/Infinity float raises
+       ``ValueError``. See ``_check_json_faithful`` for the exact scope,
+       for why the last two are rejected rather than coerced, and for
+       what is deliberately *not* covered (#350). Validation walks the
+       whole payload, so it costs roughly as much again as the
+       ``json.dumps`` it precedes.
     2. Both artifacts are written to sibling temp files in the
        destination directory, flushed and fsynced, then moved into place
        with ``os.replace`` (atomic on POSIX). A failure or crash before
@@ -211,10 +262,15 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
         payload: JSON-serializable side-car payload.
         sidecar_path: destination for the JSON side-car.
     """
-    # Fail before touching any file. The explicit walk catches what
-    # json.dumps accepts but cannot round-trip (non-str keys, non-finite
-    # floats); allow_nan=False is a backstop for any float the walk can't
-    # reach (e.g. inside a custom container json handles but we don't).
+    # Fail before touching any file. The walk catches what json.dumps
+    # accepts but writes destructively (non-str keys, non-finite floats)
+    # and is the thing that produces the useful message. `allow_nan=False`
+    # is defence in depth, not a second mechanism: json's encoder handles
+    # exactly the container and scalar types the walk descends, so there
+    # is no known float it reaches that the walk does not. It is here so
+    # that a future encoder change (or a `default=` hook added to this
+    # call) cannot re-open the hole silently — a NaN slipping past the
+    # walk would raise here rather than land on disk.
     _check_json_faithful(payload)
     payload_str = json.dumps(payload, allow_nan=False)
 

--- a/turbovec-python/python/turbovec/langchain.py
+++ b/turbovec-python/python/turbovec/langchain.py
@@ -634,7 +634,22 @@ class TurboQuantVectorStore(VectorStore):
             return filter
         if isinstance(filter, dict):
             items = list(filter.items())
-            return lambda doc: all(doc.metadata.get(k) == v for k, v in items)
+            # Key presence is required (#381). `dict.get` returns None both
+            # for "absent" and for "present and None", so the old
+            # `doc.metadata.get(k) == v` form let a document with no `k` at
+            # all satisfy `filter={"k": None}`. The reference
+            # InMemoryVectorStore accepts *only* callables, so nothing
+            # upstream fixes the dict form's meaning — but the dict form is
+            # sugar for the callable a user would otherwise write, and
+            # nobody writes `lambda d: d.metadata.get("k") is None` meaning
+            # "documents without k". Matching an absent key also can't be
+            # asked for any other way, whereas "has k, and it's None" can't
+            # be expressed at all under the loose form. This is the same
+            # leak Agno's `_meta_matches` fixed in #144; the two dict
+            # filters now agree.
+            return lambda doc: all(
+                k in doc.metadata and doc.metadata[k] == v for k, v in items
+            )
         raise TypeError(
             "filter must be a dict of metadata key/value pairs or a callable "
             f"taking a Document, got {type(filter).__name__}"

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -1373,12 +1373,6 @@ def test_dict_filter_presence_requirement_holds_for_every_value_type():
 # ---- #350: a lossy side-car fails the dump loudly ---------------------
 
 
-def _reject_constant(name):
-    # `json.loads` accepts NaN/Infinity by default; this makes the reader
-    # as strict as RFC 8259 (and as strict as serde_json or JSON.parse).
-    raise AssertionError(f"side-car holds the non-JSON token {name}")
-
-
 def test_dump_rejects_non_str_metadata_keys(tmp_path):
     # End-to-end through a store: `{1: ..., "1": ...}` used to be written
     # as a single `"1"` entry with dump() returning success, losing the
@@ -1407,16 +1401,37 @@ def test_dump_rejects_non_finite_metadata_floats(tmp_path):
     assert list(folder.iterdir()) == []
 
 
-def test_dump_sidecar_is_strict_json(tmp_path):
-    # Positive control: what does get written parses under a strict
-    # reader (no NaN/Infinity extension), same as any non-Python consumer.
+def test_dump_of_nan_metadata_leaves_no_file_to_misread(tmp_path):
+    # The pre-fix write was not merely lossy, it was *not JSON*: a bare
+    # `NaN` token that jq rewrites to null and serde_json/JSON.parse
+    # reject. Assert on the observable that matters to a non-Python
+    # consumer — no such file exists to be misread — and that a store
+    # sanitised the documented way (None for "no value") saves and
+    # reloads cleanly.
     import json
 
     emb = StubEmbeddings(dim=64)
-    store = TurboQuantVectorStore.from_texts(
-        ["a", "b"], emb, metadatas=[{"score": 0.5}, {"score": None}], bit_width=4
+    bad = TurboQuantVectorStore.from_texts(
+        ["a"], emb, metadatas=[{"score": float("nan")}], bit_width=4
     )
     folder = tmp_path / "store"
-    store.dump(folder)
+    with pytest.raises(ValueError):
+        bad.dump(folder)
+    assert not (folder / "docstore.json").exists()
+
+    good = TurboQuantVectorStore.from_texts(
+        ["a"], emb, metadatas=[{"score": None}], ids=["doc-a"], bit_width=4
+    )
+    good.dump(folder)
     text = (folder / "docstore.json").read_text()
-    json.loads(text, parse_constant=_reject_constant)
+    # `parse_constant` fires only on NaN/Infinity/-Infinity, so a strict
+    # reader accepts this file where it would have rejected the one above.
+    json.loads(text, parse_constant=_fail_on_non_json_token)
+    reloaded = TurboQuantVectorStore.load(folder, emb)
+    assert reloaded.get_by_ids(["doc-a"])[0].metadata == {"score": None}
+
+
+def _fail_on_non_json_token(name):
+    # `json.loads` accepts NaN/Infinity by default; this makes the reader
+    # as strict as RFC 8259 (and as strict as serde_json or JSON.parse).
+    raise AssertionError(f"side-car holds the non-JSON token {name}")

--- a/turbovec-python/tests/test_langchain.py
+++ b/turbovec-python/tests/test_langchain.py
@@ -1315,3 +1315,108 @@ def test_load_rejects_a_rewound_next_u64_watermark(tmp_path):
 
     with pytest.raises(ValueError, match="next_u64"):
         TurboQuantVectorStore.load(tmp_path, emb)
+
+
+# ---- #381: a dict filter entry requires the key to be present ---------
+
+
+def test_dict_filter_none_value_requires_the_key_to_be_present():
+    # `doc.metadata.get(k)` returns None both for "absent" and for
+    # "present and None", so `filter={"g": None}` used to return every
+    # document without a `g` key at all. The dict form is turbovec's own
+    # extension — the reference InMemoryVectorStore accepts callables only
+    # — so it should mean what the equivalent hand-written predicate
+    # means, not something a user cannot opt out of.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["has-none", "no-key", "has-value"],
+        emb,
+        metadatas=[{"g": None}, {"other": 1}, {"g": 5}],
+        ids=["has-none", "no-key", "has-value"],
+        bit_width=4,
+    )
+
+    matched = store.similarity_search("has-none", k=10, filter={"g": None})
+    assert [d.id for d in matched] == ["has-none"]
+
+    # The dict form must agree with the predicate a user would write for
+    # the same intent.
+    equivalent = store.similarity_search(
+        "has-none", k=10,
+        filter=lambda doc: "g" in doc.metadata and doc.metadata["g"] is None,
+    )
+    assert {d.id for d in matched} == {d.id for d in equivalent}
+
+    # Absence is still expressible — via the callable form, which is the
+    # only form the reference store has.
+    absent = store.similarity_search(
+        "no-key", k=10, filter=lambda doc: "g" not in doc.metadata
+    )
+    assert [d.id for d in absent] == ["no-key"]
+
+
+def test_dict_filter_presence_requirement_holds_for_every_value_type():
+    # Not None-specific: a multi-key dict where one key is missing from a
+    # document must exclude that document whatever the filter value is.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["both", "partial"],
+        emb,
+        metadatas=[{"a": 1, "b": None}, {"a": 1}],
+        ids=["both", "partial"],
+        bit_width=4,
+    )
+    got = store.similarity_search("both", k=10, filter={"a": 1, "b": None})
+    assert [d.id for d in got] == ["both"]
+
+
+# ---- #350: a lossy side-car fails the dump loudly ---------------------
+
+
+def _reject_constant(name):
+    # `json.loads` accepts NaN/Infinity by default; this makes the reader
+    # as strict as RFC 8259 (and as strict as serde_json or JSON.parse).
+    raise AssertionError(f"side-car holds the non-JSON token {name}")
+
+
+def test_dump_rejects_non_str_metadata_keys(tmp_path):
+    # End-to-end through a store: `{1: ..., "1": ...}` used to be written
+    # as a single `"1"` entry with dump() returning success, losing the
+    # int-keyed value with no signal at all.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a"], emb, metadatas=[{1: "int-one", "1": "str-one"}], bit_width=4
+    )
+    folder = tmp_path / "store"
+    with pytest.raises(TypeError, match="not str"):
+        store.dump(folder)
+    # Nothing persisted — no half-written store to load later.
+    assert list(folder.iterdir()) == []
+
+
+def test_dump_rejects_non_finite_metadata_floats(tmp_path):
+    # A NaN score (a realistic output of a scoring pipeline) used to write
+    # a bare `NaN` token: invalid JSON that jq silently rewrites to null.
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a"], emb, metadatas=[{"score": float("nan")}], bit_width=4
+    )
+    folder = tmp_path / "store"
+    with pytest.raises(ValueError, match="NaN"):
+        store.dump(folder)
+    assert list(folder.iterdir()) == []
+
+
+def test_dump_sidecar_is_strict_json(tmp_path):
+    # Positive control: what does get written parses under a strict
+    # reader (no NaN/Infinity extension), same as any non-Python consumer.
+    import json
+
+    emb = StubEmbeddings(dim=64)
+    store = TurboQuantVectorStore.from_texts(
+        ["a", "b"], emb, metadatas=[{"score": 0.5}, {"score": None}], bit_width=4
+    )
+    folder = tmp_path / "store"
+    store.dump(folder)
+    text = (folder / "docstore.json").read_text()
+    json.loads(text, parse_constant=_reject_constant)

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -314,8 +314,73 @@ def test_atomic_save_still_accepts_faithful_payloads(tmp_path):
         "schema_version": 2,
         "docs": {"a": {"metadata": {"n": None, "f": 1.5, "b": True, "": "empty"}}},
         "pairs": [["id", 7], ["id2", 8]],  # int *values* stay fine
-        "big": 2**70,
         "unicode": "\U0001f600 é",
     }
+    atomic_save(idx, tmp_path / "i.tvim", payload, tmp_path / "s.json")
+    assert json.loads((tmp_path / "s.json").read_text()) == payload
+
+
+# The guard's scope is deliberately narrower than "everything JSON
+# round-trips imperfectly": it covers values whose JSON form *loses data*
+# (a collided key) or *is not JSON* (a bare NaN token). Total, documented
+# type narrowings are out of scope. These two tests pin that boundary so
+# it cannot drift silently in either direction.
+
+
+def test_tuples_are_accepted_and_narrow_to_lists(tmp_path):
+    # Out of scope by decision, not oversight. Unlike a collided key,
+    # tuple -> list loses no element and applies uniformly to every tuple;
+    # the stores' own payloads are built from `dict.items()` pairs
+    # (llama_index's `node_id_to_u64`), and both langchain.py's dump and
+    # llama_index.py's persist document the coercion in-line. Rejecting
+    # tuples would break the writers before it helped any caller.
+    import json
+
+    import numpy as np
+
+    from turbovec import IdMapIndex
+    from turbovec._persist import atomic_save
+
+    idx = IdMapIndex(dim=32, bit_width=4)
+    idx.add_with_ids(np.eye(2, 32, dtype=np.float32), np.arange(2, dtype=np.uint64))
+
+    payload = {"pairs": [("id", 7)], "docs": {"a": {"bbox": (10, 20, 30, 40)}}}
+    atomic_save(idx, tmp_path / "i.tvim", payload, tmp_path / "s.json")
+    on_disk = json.loads((tmp_path / "s.json").read_text())
+    assert on_disk == {"pairs": [["id", 7]], "docs": {"a": {"bbox": [10, 20, 30, 40]}}}
+
+    # ...and a bad value *inside* a tuple is still caught: the walk
+    # descends tuples, it just does not reject them.
+    with pytest.raises(ValueError, match="NaN"):
+        atomic_save(
+            _WriteRecordingIndex(),
+            tmp_path / "j.tvim",
+            {"docs": ({"score": float("nan")},)},
+            tmp_path / "t.json",
+        )
+
+
+def test_ints_wider_than_2_53_are_accepted_and_exact_in_python(tmp_path):
+    # Also out of scope by decision. 9007199254740993 is the smallest
+    # integer a double cannot hold — `JSON.parse` silently returns ...992
+    # — but Python writes and reads it exactly and an arbitrary-precision
+    # integer literal is valid RFC 8259, so the imprecision belongs to the
+    # reader, not the file. Rejecting these would break the legitimate
+    # int64 ids the stores carry. (2**70 would not test this: powers of
+    # two survive a double round-trip, so the value must be one that does
+    # not.)
+    import json
+
+    import numpy as np
+
+    from turbovec import IdMapIndex
+    from turbovec._persist import atomic_save
+
+    idx = IdMapIndex(dim=32, bit_width=4)
+    idx.add_with_ids(np.eye(2, 32, dtype=np.float32), np.arange(2, dtype=np.uint64))
+
+    lossy_as_double = 9007199254740993  # 2**53 + 1
+    assert int(float(lossy_as_double)) != lossy_as_double  # a double loses it
+    payload = {"docs": {"a": {"metadata": {"id64": lossy_as_double, "max": 2**64 - 1}}}}
     atomic_save(idx, tmp_path / "i.tvim", payload, tmp_path / "s.json")
     assert json.loads((tmp_path / "s.json").read_text()) == payload

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -167,3 +167,155 @@ def test_atomic_save_round_trips_a_long_sidecar_name(tmp_path):
     assert len(IdMapIndex.load(str(index_path))) == 4
     assert json.loads(sidecar_path.read_text()) == {"docs": [1, 2, 3]}
     assert [p.name for p in tmp_path.iterdir() if ".tmp." in p.name] == []
+
+
+# ---- #350: the side-car must be faithful, portable JSON ---------------
+#
+# `json.dumps` accepts two things it cannot round-trip, and silently:
+# non-str mapping keys (stringified, so `1` and `"1"` merge and one entry
+# is lost) and NaN/Infinity (bare tokens RFC 8259 forbids — jq rewrites
+# them to null, serde_json/JSON.parse reject the file). Both now fail
+# loudly at save time, before any file is touched.
+
+
+class _WriteRecordingIndex:
+    """Records whether `atomic_save` ever got as far as writing."""
+
+    def __init__(self):
+        self.wrote = False
+
+    def write(self, path):  # pragma: no cover - must never run in these tests
+        self.wrote = True
+        open(path, "wb").close()
+
+
+@pytest.mark.parametrize(
+    "bad_key",
+    [1, 2020, True, None, 3.5],
+    ids=["int", "year-int", "bool", "none", "float"],
+)
+def test_atomic_save_rejects_non_str_metadata_keys(tmp_path, bad_key):
+    from turbovec._persist import atomic_save
+
+    index = _WriteRecordingIndex()
+    payload = {"docs": {"a": {"metadata": {bad_key: "x"}}}}
+    with pytest.raises(TypeError) as exc:
+        atomic_save(
+            index, tmp_path / "i.tvim", payload, tmp_path / "s.json"
+        )
+    # The message must name the offending key and where it lives, so the
+    # fix is mechanical.
+    assert repr(bad_key) in str(exc.value)
+    assert "['docs']['a']['metadata']" in str(exc.value)
+    assert "not str" in str(exc.value)
+    # Fail-before-touching-files: nothing was written, not even a temp.
+    assert not index.wrote
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_save_rejects_colliding_int_and_str_keys(tmp_path):
+    # The exact loss from #350: in-memory `{1: "int-one", "1": "str-one"}`
+    # used to land on disk as `{"1": "str-one"}` with save() returning
+    # success — the int-keyed entry gone, undetectably.
+    from turbovec._persist import atomic_save
+
+    payload = {"docs": {"a": {"metadata": {1: "int-one", "1": "str-one"}}}}
+    with pytest.raises(TypeError):
+        atomic_save(
+            _WriteRecordingIndex(), tmp_path / "i.tvim", payload, tmp_path / "s.json"
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "bad_value, token",
+    [
+        (float("nan"), "NaN"),
+        (float("inf"), "Infinity"),
+        (float("-inf"), "-Infinity"),
+    ],
+    ids=["nan", "inf", "-inf"],
+)
+def test_atomic_save_rejects_non_finite_floats(tmp_path, bad_value, token):
+    from turbovec._persist import atomic_save
+
+    index = _WriteRecordingIndex()
+    payload = {"docs": {"a": {"metadata": {"score": bad_value}}}}
+    with pytest.raises(ValueError) as exc:
+        atomic_save(
+            index, tmp_path / "i.tvim", payload, tmp_path / "s.json"
+        )
+    assert token in str(exc.value)
+    assert "['docs']['a']['metadata']['score']" in str(exc.value)
+    assert not index.wrote
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_atomic_save_finds_bad_values_nested_in_lists(tmp_path):
+    from turbovec._persist import atomic_save
+
+    with pytest.raises(ValueError, match="NaN"):
+        atomic_save(
+            _WriteRecordingIndex(),
+            tmp_path / "i.tvim",
+            {"docs": [{"metadata": {"xs": [1.0, float("nan")]}}]},
+            tmp_path / "s.json",
+        )
+    with pytest.raises(TypeError, match="not str"):
+        atomic_save(
+            _WriteRecordingIndex(),
+            tmp_path / "i.tvim",
+            {"docs": [{"metadata": {"nested": {7: "v"}}}]},
+            tmp_path / "s.json",
+        )
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_check_json_faithful_terminates_on_cyclic_metadata():
+    # Metadata is user-supplied; a self-referential container must not
+    # spin the validator forever. json.dumps rejects it afterwards, which
+    # is the pre-existing (and correct) behaviour for a cycle.
+    from turbovec._persist import _check_json_faithful
+
+    cycle: dict = {"a": 1}
+    cycle["self"] = cycle
+    _check_json_faithful({"docs": cycle})  # must return, not hang
+
+    shared = {"k": "v"}
+    _check_json_faithful({"docs": {"x": shared, "y": shared}})
+
+
+def test_check_json_faithful_survives_deep_nesting():
+    # An iterative walk, so nesting deeper than Python's recursion limit
+    # is a job for json.dumps' own guard, not a RecursionError from us.
+    from turbovec._persist import _check_json_faithful
+
+    deep: object = "leaf"
+    for _ in range(5000):
+        deep = {"n": deep}
+    _check_json_faithful(deep)
+
+
+def test_atomic_save_still_accepts_faithful_payloads(tmp_path):
+    # Guard against over-rejection: the values the side-car is documented
+    # to carry must keep working.
+    import json
+
+    import numpy as np
+
+    from turbovec import IdMapIndex
+    from turbovec._persist import atomic_save
+
+    v = np.eye(4, 32, dtype=np.float32)
+    idx = IdMapIndex(dim=32, bit_width=4)
+    idx.add_with_ids(v, np.arange(4, dtype=np.uint64))
+
+    payload = {
+        "schema_version": 2,
+        "docs": {"a": {"metadata": {"n": None, "f": 1.5, "b": True, "": "empty"}}},
+        "pairs": [["id", 7], ["id2", 8]],  # int *values* stay fine
+        "big": 2**70,
+        "unicode": "\U0001f600 é",
+    }
+    atomic_save(idx, tmp_path / "i.tvim", payload, tmp_path / "s.json")
+    assert json.loads((tmp_path / "s.json").read_text()) == payload


### PR DESCRIPTION
Two independent correctness bugs in the Python integration layer. Both were silent — neither surfaced as an error, and neither was detectable by the existing side-car consistency checks.

## #350 — the side-car wrote data it could not read back

**What.** `_persist.atomic_save` serialized with a bare `json.dumps(payload)`, which accepts two classes of value that survive the call but not the file:

- **Non-string mapping keys.** JSON object keys are strings, so `json.dumps` stringifies `int`/`float`/`bool`/`None` keys. In-memory metadata `{1: "int-one", "1": "str-one"}` landed on disk as `{"1": "str-one"}` — the int-keyed entry gone, `save()` returning success. `True`/`1` and `2020`/`"2020"` collided identically.
- **Non-finite floats.** `allow_nan` defaults to True, so a NaN score (a realistic output of a scoring pipeline) was written as a bare `NaN` token that RFC 8259 forbids. Python round-trips it, so the damage only showed outside Python: `serde_json` and `JSON.parse` reject the file outright, and `jq .` **silently rewrites `NaN` to `null`** — corrupting values in a side-car this project documents as plain, inspectable JSON.

All four integrations (`langchain`, `haystack`, `llama_index`, `agno`) save through `atomic_save`, so both reached all four.

**Why it mattered beyond the write.** Neither failure is recoverable at load time and neither is caught by `check_persisted_handles` / `check_sidecar_keysets` — those validate handle/keyset structure, which a collided key leaves perfectly intact. The write is the only place the loss is still visible.

### The contract chosen

> **A save whose side-car would lose data or would not be portable JSON fails loudly before any file is touched.**

The scope is exactly those two properties, and deliberately *not* "everything JSON round-trips imperfectly". The guard covers values whose JSON form either **loses data** (a collided key: two entries in, one out, no way to tell which) or **is not JSON at all** (a bare `NaN` token). Total, well-known type narrowings are out of scope and documented at the call sites instead:

- **`tuple` → `list`.** Every element survives, only the type narrows, the mapping is total and uniform, and rejecting it would break the *writers*: `llama_index.py`'s `node_id_to_u64` is built from `dict.items()` pairs, and both it and `langchain.py`'s dump already document the coercion in-line.
- **`int` wider than 2**53.** Python writes and reads these exactly and an arbitrary-precision integer literal *is* valid RFC 8259 — the imprecision belongs to double-based readers (`JSON.parse` turns `9007199254740993` into `…992`), not to the file. Rejecting them would break the legitimate int64 ids the stores carry.

Both boundaries are now pinned by tests (`test_tuples_are_accepted_and_narrow_to_lists`, `test_ints_wider_than_2_53_are_accepted_and_exact_in_python`) so the scope can't drift silently in either direction. The tuple test also asserts a NaN *inside* a tuple is still caught — the walk descends tuples, it just doesn't reject them.

`atomic_save` already documented this posture — "a non-serializable value … raises `TypeError` before any file is touched" — for sets and ndarrays. The two cases above were the gaps where it silently did not hold. `TypeError` for a non-str key, `ValueError` for a non-finite float (matching `json`'s own `allow_nan=False` error family).

**Why reject rather than coerce.** Coercion *is* the damage. Stringifying keys is precisely the step that merges `1` into `"1"`; mapping NaN to `null` — what jq does — turns "score was NaN" into "score was absent". A silently lossy success is the worst of the available outcomes, so whichever way the contract went, the failure had to be loud.

### ⚠️ This is breaking for one of the two halves

The two halves are **not** equivalent in impact, and an earlier revision of this PR wrongly implied they were:

- **Non-str keys — no working code is affected.** Those saves were already lossy on reload; the previous behaviour reported success for a save that had not preserved the data. Migration: `{str(k): v for k, v in ...}` at the call site.
- **NaN / Infinity — a genuine break.** Python's `json` both writes *and reads* the non-standard tokens, so this metadata round-tripped correctly through turbovec's own `save`/`load`. Verified directly: a store dumped with `{"score": nan, "budget": inf}` under the pre-PR code reloads through the public `load()` with both values intact. That now raises `ValueError`. The change is still right — the file it produced is not JSON, and every non-Python consumer either rejects it or (jq) quietly rewrites the value to `null` — but it breaks code that worked, including this PR's own "realistic scoring pipeline" example. Migration: sanitize before saving, `None` for "no value" (round-trips as `null`, valid JSON) or a finite sentinel.

Both are disclosed this way in the CHANGELOG, with the migration note.

### Save-path cost

Validation is a second Python-level traversal of the payload, so it roughly doubles side-car serialization. Measured on a 200k-document payload with 4-field metadata:

| | time |
|---|---|
| `json.dumps` alone (before) | 0.311 s |
| walk + `json.dumps(allow_nan=False)` (after) | 0.645 s (**2.07×**) |

The walk carries parent links and reconstructs the path string only on the failure branch; eagerly formatting `f"{path}[{key!r}]"` per node cost 0.395 s vs 0.347 s for the lazy form, so that recovers ~12% of the walk. The remainder is inherent to traversing the payload in Python. This is the side-car step only — a full `save()` also writes and fsyncs the index. Disclosed in the CHANGELOG and the `atomic_save` docstring.

**Implementation notes.** The walk is iterative with a visited-container set: metadata is user-supplied and may nest deeply (recursion would raise `RecursionError` before `json.dumps`' own guard fires) or contain shared/cyclic containers (a cycle would otherwise spin forever). Shared subtrees are validated once. All four stores round-trip their *own* int handles via explicit list-of-pairs, so the str-key requirement only ever applies to user metadata — verified against each save payload. `allow_nan=False` on the `dumps` call is defence in depth, not a second mechanism: json's encoder handles exactly the types the walk descends, so there is no known float it reaches that the walk does not. It is there so a future encoder change or a `default=` hook added to that call can't silently re-open the hole.

### Discrimination evidence (#350)

Reverted `_check_json_faithful(payload)` + `allow_nan=False` back to `payload_str = json.dumps(payload)`, everything else unchanged:

```
FAILED tests/test_persist.py::test_atomic_save_rejects_non_str_metadata_keys[int]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_str_metadata_keys[year-int]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_str_metadata_keys[bool]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_str_metadata_keys[none]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_str_metadata_keys[float]
FAILED tests/test_persist.py::test_atomic_save_rejects_colliding_int_and_str_keys
FAILED tests/test_persist.py::test_atomic_save_rejects_non_finite_floats[nan]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_finite_floats[inf]
FAILED tests/test_persist.py::test_atomic_save_rejects_non_finite_floats[-inf]
FAILED tests/test_persist.py::test_atomic_save_finds_bad_values_nested_in_lists
FAILED tests/test_langchain.py::test_dump_rejects_non_str_metadata_keys
FAILED tests/test_langchain.py::test_dump_rejects_non_finite_metadata_floats
12 failed, 1 passed
```

(Re-run after the review revisions: **14 failures**, adding `test_tuples_are_accepted_and_narrow_to_lists` — its NaN-inside-a-tuple half is discriminating — and `test_dump_of_nan_metadata_leaves_no_file_to_misread`.)

Restored → all pass. The tests assert unit-level (`atomic_save` directly) *and* end-to-end through a real store's `dump()`, and each checks the fail-before-touching-files half too: the index's `write` is never called and the destination directory is left empty. Over-rejection is guarded by `test_atomic_save_still_accepts_faithful_payloads` (None, floats, bools, empty-string keys, astral-plane unicode, int *values* in list-of-pairs) plus the two scope-boundary tests above.

`test_dump_sidecar_is_strict_json` from the first revision has been **removed**: its payload could never have emitted a NaN token, so it passed with the feature deleted — zero discrimination. Its replacement, `test_dump_of_nan_metadata_leaves_no_file_to_misread`, asserts the observable a non-Python consumer actually cares about (no unreadable file exists at the path) and that the documented sanitization saves, strict-parses with `parse_constant` wired to raise, and reloads with the value intact.

## #381 — LangChain dict filter over-matched on a None value

**What.** `langchain.py:637` compiled a dict filter to `all(doc.metadata.get(k) == v for k, v in items)`. `dict.get` returns `None` both for "key absent" and for "key present, value None", so `filter={"g": None}` returned every document that had **no `g` key at all**.

### Reference-store comparison

Per the repo standard (how #302 was resolved), I compared against `langchain_core`'s in-tree `InMemoryVectorStore` rather than inventing a contract. Reading its public `_similarity_search_with_score_by_vector`:

```python
filter: Optional[Callable[[Document], bool]] = None
...
docs = [doc for doc in docs
        if filter(Document(page_content=doc["text"], metadata=doc["metadata"]))]
```

The reference **calls the filter** — it accepts callables only and has no dict form at all. So there is no upstream contract for the dict form to match or violate: the dict filter is turbovec's own extension, as the issue notes.

That makes the question "what should the extension mean?", and the answer follows from what it is: sugar for the predicate a user would otherwise write. Nobody writes `lambda d: d.metadata.get("g") is None` meaning "documents without `g`". Two asymmetries settle it:

- Under the loose form, "has `g`, and it's None" is **not expressible at all** — no filter could exclude the key-absent documents.
- Under the strict form, "no `g` key" stays fully expressible via the callable form, which is the form the reference store standardizes on: `lambda doc: "g" not in doc.metadata`.

It also brings the dict filter into agreement with the agno store's `_meta_matches`, which fixed this exact leak class in #144 — the two stores now answer `{'g': None}` identically, which is the divergence the differential test in #381 flagged.

No test here imports private symbols from any third-party package or asserts on locally-installed dependency behaviour; the reference comparison is documented above and the assertions are all against turbovec's public API.

### Discrimination evidence (#381)

Reverted the one-line predicate to `all(doc.metadata.get(k) == v ...)`:

```
FAILED tests/test_langchain.py::test_dict_filter_none_value_requires_the_key_to_be_present
FAILED tests/test_langchain.py::test_dict_filter_presence_requirement_holds_for_every_value_type
E       AssertionError: assert ['both', 'partial'] == ['both']
E         Left contains one more item: 'partial'
2 failed
```

Restored → both pass. The first test also asserts the dict form agrees with the hand-written equivalent predicate, and that absence stays expressible via a callable. The second proves the requirement is not None-specific — a multi-key filter excludes a document missing any one key regardless of the filter value.

## Testing

- Full Python suite: **728 passed, 15 skipped, 1 failed** — the single failure is `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, which fails identically on unmodified `main` (#386, pre-existing).
- `cargo test --release -p turbovec`: all 22 test binaries green, exit 0. (No Rust changed; run for completeness.)
- Built the extension locally for the run and removed the `.so` before committing.

## Coordination

Touches `turbovec-python/python/turbovec/langchain.py` (one predicate in `_compile_filter`) and `_persist.py`, both of which PR #399 also lives near. The diff avoids the async methods and the thread-safety harness entirely — `_compile_filter` is a pure `@staticmethod` and the `_persist.py` change adds a new function plus two lines inside `atomic_save`, so a merge with #399 should be mechanical.

## Left unfixed

Two lower-severity items from #350 are deliberately out of scope, to keep this diff to the two data-integrity bugs:

- **#350 item 3 (MEDIUM) — `atomic_save` never fsyncs the containing directory.** A real durability gap (the Rust side gained parent-dir fsync in #281; the Python side didn't), but it is lost-write rather than silent corruption — `check_persisted_handles` catches the result loudly — and it is a distinct change with its own Windows/portability considerations. Worth a follow-up.
- **#350 item 4 (LOW) — `schema_version` accepts a float**, since `2.0 == 2` in Python. Cosmetic unless a non-Python writer ever exists.
- **#350's scale note** (side-car 5.5× larger than the index it accompanies; `json.dumps` peaks at ~2× payload) is a design observation, not a bug at current targets.

Addresses #350 — items 1 and 2 (the two silent data-integrity bugs). Items 3 and 4 are left open, so the issue stays open.
Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

