### PR TITLE
Rust crate ergonomics: SearchResults derives, non-panicking try_search, and doc-drift corrections (#351, #324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,16 @@ appears under each surface it touches.
   outside the process in a real service, and the Python binding already
   pre-validated exactly these three and raised `ValueError`, so Rust
   callers were the only ones without a recoverable error. `search` /
-  `search_with_mask` are unchanged and not deprecated — they now delegate
-  to the checked forms and panic with the error's `Display`, so the panic
-  messages, the validation order and the results are all identical.
+  `search_with_mask` are not deprecated, and their signatures, results
+  and validation order are unchanged — they now delegate to the checked
+  forms and panic with the error's `Display`. **Their panic text did
+  change.** Four of the five conditions were previously raised by
+  `assert_eq!`, so the payload carried an ``assertion `left == right`
+  failed`` prefix plus `left:` / `right:` lines; it is now the error
+  message alone. The ragged-query-buffer assert had no message at all
+  and now reads `query buffer length 65 not a multiple of dim 64`. Only
+  the non-finite-coordinate panic is byte-identical. Substring matching
+  on panic payloads is unaffected; matching the assert prefix is not.
   Reach for `try_search` when the query vectors are untrusted; keep
   `search` when a malformed query would be a bug in your own code.
 - **`turbovec::expected_codebook` and `turbovec::MIN_INPUT_NORM` are public.**
@@ -369,8 +376,9 @@ appears under each surface it touches.
   six `io::write*` entry points now have `# Panics` sections (#324).**
   `Rotation` is reachable without `TurboQuantIndex`, and its `MAX_DIM`
   ceiling was visible only in an implementation comment. The raw writers
-  take ten loose slices and abort on a shape mismatch between them, which
-  their `io::Result<()>` signature does not suggest. `TurboQuantIndex::write`
+  take six slice arguments (seven for the `write_id_map*` trio) and abort
+  on an inconsistency between them, which their `io::Result<()>`
+  signature does not suggest. `TurboQuantIndex::write`
   and `TurboQuantIndex::load` had no documentation at all despite
   `from_bytes` pointing readers at `load`; `SearchResults::scores_for_query`
   / `indices_for_query` documented their panics in prose without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,13 +38,17 @@ appears under each surface it touches.
   `search_with_mask` are not deprecated, and their signatures, results
   and validation order are unchanged — they now delegate to the checked
   forms and panic with the error's `Display`. **Their panic text did
-  change.** Four of the five conditions were previously raised by
-  `assert_eq!`, so the payload carried an ``assertion `left == right`
-  failed`` prefix plus `left:` / `right:` lines; it is now the error
-  message alone. The ragged-query-buffer assert had no message at all
-  and now reads `query buffer length 65 not a multiple of dim 64`. Only
-  the non-finite-coordinate panic is byte-identical. Substring matching
-  on panic payloads is unaffected; matching the assert prefix is not.
+  change at three of the four sites** (four sites, three conditions —
+  the mask-length check has one site for an empty index and one for a
+  populated one). Those three were raised by `assert_eq!`, so the
+  payload carried an ``assertion `left == right`` prefix plus `left:` /
+  `right:` lines; it is now the error message alone. The fourth, the
+  non-finite-coordinate panic, is byte-identical — it was always a
+  `panic!`. At the two mask sites the message text was already inside
+  the old payload, so a `should_panic(expected = "mask length")` still
+  matches; the ragged-buffer assert carried no message at all, so its
+  old and new payloads (`query buffer length 65 not a multiple of dim
+  64`) share no text and nothing matching the old one matches the new.
   Reach for `try_search` when the query vectors are untrusted; keep
   `search` when a malformed query would be a bug in your own code.
 - **`turbovec::expected_codebook` and `turbovec::MIN_INPUT_NORM` are public.**
@@ -393,9 +397,12 @@ appears under each surface it touches.
   six `io::write*` entry points now have `# Panics` sections (#324).**
   `Rotation` is reachable without `TurboQuantIndex`, and its `MAX_DIM`
   ceiling was visible only in an implementation comment. The raw writers
-  take six slice arguments (seven for the `write_id_map*` trio) and abort
-  on an inconsistency between them, which their `io::Result<()>`
-  signature does not suggest. `TurboQuantIndex::write`
+  abort on a length inconsistency among four of their six slice
+  arguments (five of seven for the `write_id_map*` trio), which their
+  `io::Result<()>` signature does not suggest; the docs also now say
+  which arguments are *not* checked — `codes_blocked_seq` and `scales`
+  are written through as given, so a buffer inconsistent with
+  `n_vectors` yields a file that fails to load rather than a panic. `TurboQuantIndex::write`
   and `TurboQuantIndex::load` had no documentation at all despite
   `from_bytes` pointing readers at `load`; `SearchResults::scores_for_query`
   / `indices_for_query` documented their panics in prose without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ appears under each surface it touches.
   to remove. Migration: match on the `Option`; enable `mask-skip-counter`
   if you want the numbers.
 - **New off-by-default cargo feature `mask-skip-counter`** — see above.
+- **`TurboQuantIndex::try_search` and `TurboQuantIndex::try_search_with_mask`
+  return `Result<SearchResults, SearchError>` (#351).** The search path had
+  no non-panicking form: a query buffer whose length is not a multiple of
+  `dim`, a non-finite or `>= 1e16` coordinate, or a mask sized for a
+  different index each aborted the calling thread. All three arrive from
+  outside the process in a real service, and the Python binding already
+  pre-validated exactly these three and raised `ValueError`, so Rust
+  callers were the only ones without a recoverable error. `search` /
+  `search_with_mask` are unchanged and not deprecated — they now delegate
+  to the checked forms and panic with the error's `Display`, so the panic
+  messages, the validation order and the results are all identical.
+  Reach for `try_search` when the query vectors are untrusted; keep
+  `search` when a malformed query would be a bug in your own code.
 - **`turbovec::expected_codebook` and `turbovec::MIN_INPUT_NORM` are public.**
   `expected_codebook` gives callers of the raw `io::*` writers the codebook
   arrays a v6 file must embed; `MIN_INPUT_NORM` documents the norm at or
@@ -236,6 +249,21 @@ appears under each surface it touches.
 
 #### Changed
 
+- **`SearchResults` derives `Debug`, `Clone` and `PartialEq` (#351).** It
+  previously implemented nothing at all, on the type every search
+  returns. A downstream struct holding one could not `#[derive(Debug)]`,
+  `dbg!(results)` did not compile, results could not be cached or cloned,
+  and `assert_eq!` in a user's test was unavailable. `Eq`/`Hash` are
+  deliberately absent: `scores` holds `f32`.
+- **`SearchError` gains three variants and no longer derives `Eq`
+  (#351).** `QueryBufferNotMultipleOfDim`, `InvalidQueryValue` and
+  `MaskLengthMismatch` are what the new `try_search` returns; the enum is
+  `#[non_exhaustive]`, so adding them is not breaking. `Eq` goes because
+  `InvalidQueryValue` carries an `f32` — the same reason `AddError` and
+  `FromPartsError` do not derive it. `PartialEq` is unchanged and covers
+  every comparison the existing variants supported. `SearchError` itself
+  is unreleased (it landed in this same section under #318), so no
+  published version is affected.
 - **Breaking: `IdMapIndex::search_with_allowlist` returns
   `Result<(Vec<f32>, Vec<u64>), SearchError>` (#318).** It previously
   panicked on an empty allowlist and on an allowlist id missing from the
@@ -326,6 +354,27 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Rust docs: the crate header no longer describes a cache strategy
+  `add` abandoned (#324).** The docs.rs landing text — the first thing a
+  reader sees — said `add` "extends the packed codes and invalidates the
+  blocked layout cache by replacing its `OnceLock`". Neither half is
+  true: `add` maintains the blocked cache in place through `get_mut`,
+  and after a v6 load it appends into that cache and leaves the packed
+  rows unmaterialized entirely. The replacement states the invariant a
+  reader can actually rely on (every populated cache describes exactly
+  the rows the index holds, whenever the index is reachable through
+  `&self`) and why it holds by construction, instead of narrating which
+  buffer a particular mutator touches — the detail that went stale.
+- **Undocumented panics on the public `rotation::Rotation::new` and the
+  six `io::write*` entry points now have `# Panics` sections (#324).**
+  `Rotation` is reachable without `TurboQuantIndex`, and its `MAX_DIM`
+  ceiling was visible only in an implementation comment. The raw writers
+  take ten loose slices and abort on a shape mismatch between them, which
+  their `io::Result<()>` signature does not suggest. `TurboQuantIndex::write`
+  and `TurboQuantIndex::load` had no documentation at all despite
+  `from_bytes` pointing readers at `load`; `SearchResults::scores_for_query`
+  / `indices_for_query` documented their panics in prose without the
+  heading that puts them on docs.rs. No behaviour changed.
 - **A caught panic in the eager add's cache repack no longer leaves the
   stored codes ahead of the row count (#388).** The blocked-cache patch is
   fallible, and `packed_codes` and `scales` were published before it while

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,14 +402,15 @@ appears under each surface it touches.
   arguments (five of seven for the `write_id_map*` trio), which their
   `io::Result<()>` signature does not suggest; the docs also now say
   which arguments are *not* checked — `codes_blocked_seq` and `scales`
-  are written through as given, and an inconsistent one is not reliably
-  caught downstream either. A wrong length shifts every later section of
-  the file, so the load may error *or* may succeed and silently
-  mis-score, depending on what the shifted bytes land on; the mix varies
-  sharply with index geometry (9 of 15 perturbations loaded clean at one
-  size, 1 of 15 at another, and a byte-count-preserving pair loads clean
-  every time). The docs say so rather than promising a failure mode that
-  does not hold. The underlying gap is tracked as #407. `TurboQuantIndex::write`
+  are written through as given by the writer, and the loader's own
+  length checks do not reliably catch an inconsistent one. A wrong
+  length shifts every later section of the file, so the load may error
+  *or* may succeed and silently mis-score, depending on what the shifted
+  bytes land on, and which dominates varies sharply with index geometry.
+  A compensating pair that keeps the total byte count unchanged shifts
+  nothing and has loaded clean in every configuration tested. The docs
+  say that rather than promising a failure mode that does not hold; the
+  underlying gap, with the measured sweep, is tracked as #407. `TurboQuantIndex::write`
   and `TurboQuantIndex::load` had no documentation at all despite
   `from_bytes` pointing readers at `load`; `SearchResults::scores_for_query`
   / `indices_for_query` documented their panics in prose without the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,8 +47,9 @@ appears under each surface it touches.
   `panic!`. At the two mask sites the message text was already inside
   the old payload, so a `should_panic(expected = "mask length")` still
   matches; the ragged-buffer assert carried no message at all, so its
-  old and new payloads (`query buffer length 65 not a multiple of dim
-  64`) share no text and nothing matching the old one matches the new.
+  old payload and its new one (`query buffer length 65 not a multiple of
+  dim 64`) share nothing but the two numbers, and any `expected =` string
+  that matched the old one will not match the new.
   Reach for `try_search` when the query vectors are untrusted; keep
   `search` when a malformed query would be a bug in your own code.
 - **`turbovec::expected_codebook` and `turbovec::MIN_INPUT_NORM` are public.**
@@ -401,8 +402,14 @@ appears under each surface it touches.
   arguments (five of seven for the `write_id_map*` trio), which their
   `io::Result<()>` signature does not suggest; the docs also now say
   which arguments are *not* checked — `codes_blocked_seq` and `scales`
-  are written through as given, so a buffer inconsistent with
-  `n_vectors` yields a file that fails to load rather than a panic. `TurboQuantIndex::write`
+  are written through as given, and an inconsistent one is not reliably
+  caught downstream either. A wrong length shifts every later section of
+  the file, so the load may error *or* may succeed and silently
+  mis-score, depending on what the shifted bytes land on; the mix varies
+  sharply with index geometry (9 of 15 perturbations loaded clean at one
+  size, 1 of 15 at another, and a byte-count-preserving pair loads clean
+  every time). The docs say so rather than promising a failure mode that
+  does not hold. The underlying gap is tracked as #407. `TurboQuantIndex::write`
   and `TurboQuantIndex::load` had no documentation at all despite
   `from_bytes` pointing readers at `load`; `SearchResults::scores_for_query`
   / `indices_for_query` documented their panics in prose without the

--- a/turbovec/src/error.rs
+++ b/turbovec/src/error.rs
@@ -1,4 +1,4 @@
-//! Errors returned by the user-facing add and construct paths.
+//! Errors returned by the user-facing construct, add and search paths.
 //!
 //! [`AddError`] is returned by the add paths
 //! ([`TurboQuantIndex::add_2d`](crate::TurboQuantIndex::add_2d),
@@ -11,13 +11,19 @@
 //! [`IdMapIndex::new`](crate::IdMapIndex::new),
 //! [`IdMapIndex::new_lazy`](crate::IdMapIndex::new_lazy)).
 //!
+//! [`SearchError`] is returned by the fallible search paths
+//! ([`TurboQuantIndex::try_search`](crate::TurboQuantIndex::try_search),
+//! [`TurboQuantIndex::try_search_with_mask`](crate::TurboQuantIndex::try_search_with_mask),
+//! [`IdMapIndex::search_with_allowlist`](crate::IdMapIndex::search_with_allowlist)).
+//!
 //! [`FromPartsError`] is returned by the low-level validated constructor
 //! [`TurboQuantIndex::from_parts`](crate::TurboQuantIndex::from_parts),
 //! which builds an index directly from already-decoded fields and checks
 //! every structural invariant at that single chokepoint.
 //!
-//! Both are forms of user input error — wrong shape, wrong dim, wrong
-//! bit_width, or duplicate id — that callers can recover from. Internal
+//! All four are forms of user input error — wrong shape, wrong dim, wrong
+//! bit_width, a non-representable coordinate, or a duplicate id — that
+//! callers can recover from. Internal
 //! preconditions (e.g. calling the low-level `add(&self, &[f32])` on a
 //! lazy index that hasn't been committed) still panic, since that
 //! signals a contract violation rather than bad input.
@@ -159,19 +165,38 @@ impl fmt::Display for ConstructError {
 
 impl Error for ConstructError {}
 
-/// Error returned by
-/// [`IdMapIndex::search_with_allowlist`](crate::IdMapIndex::search_with_allowlist)
-/// when the supplied allowlist cannot be turned into a slot mask.
+/// Error returned by the crate's fallible search paths:
+/// [`TurboQuantIndex::try_search`](crate::TurboQuantIndex::try_search),
+/// [`TurboQuantIndex::try_search_with_mask`](crate::TurboQuantIndex::try_search_with_mask)
+/// and
+/// [`IdMapIndex::search_with_allowlist`](crate::IdMapIndex::search_with_allowlist).
 ///
-/// Allowlists are built from the caller's own metadata store, which drifts
-/// out of step with the index — a filter that matched nothing, or an id
-/// deleted on one side but not the other. Those are input conditions, not
-/// contract violations, so they are reported rather than panicked. The
-/// Python binding already maps them to `ValueError` / `KeyError`.
+/// Every variant describes *caller-supplied data* that the index cannot
+/// score: a query buffer whose length disagrees with the index dim, a
+/// coordinate the scoring kernel cannot represent, a mask sized for a
+/// different index, or an allowlist that drifted out of step with the
+/// index's contents. All four arrive from outside the process in a real
+/// service — an embedding endpoint, a metadata store, an HTTP body — so
+/// they are reported rather than panicked. The Python binding already
+/// maps them to `ValueError` / `KeyError`.
+///
+/// Which variants a given method can produce:
+///
+/// | variant | `try_search` | `try_search_with_mask` | `search_with_allowlist` |
+/// |---|---|---|---|
+/// | [`QueryBufferNotMultipleOfDim`](Self::QueryBufferNotMultipleOfDim) | yes | yes | no (panics) |
+/// | [`InvalidQueryValue`](Self::InvalidQueryValue) | yes | yes | no (panics) |
+/// | [`MaskLengthMismatch`](Self::MaskLengthMismatch) | no | yes | no |
+/// | [`AllowlistEmpty`](Self::AllowlistEmpty) | no | no | yes |
+/// | [`UnknownId`](Self::UnknownId) | no | no | yes |
 ///
 /// `#[non_exhaustive]` so adding variants in future releases is not a
 /// breaking change — downstream `match` must carry a wildcard arm.
-#[derive(Debug, Clone, PartialEq, Eq)]
+// Eq is not derived because `InvalidQueryValue` carries an f32, which is
+// not `Eq` (NaN != NaN) — the same reason `AddError` and `FromPartsError`
+// drop it. PartialEq still works for the finite values tests assert
+// against, and every other variant compares as before.
+#[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub enum SearchError {
     /// The allowlist was `Some` but empty. An empty allowlist selects no
@@ -181,6 +206,24 @@ pub enum SearchError {
 
     /// An allowlist id is not present in the index.
     UnknownId(u64),
+
+    /// `queries.len()` is not a whole multiple of the index dim, so the
+    /// buffer does not describe a whole number of query rows.
+    QueryBufferNotMultipleOfDim { queries_len: usize, dim: usize },
+
+    /// A query coordinate is not finite (NaN, +Inf, -Inf) or has
+    /// magnitude `>= 1e16`. Such a value poisons the SIMD scoring kernel:
+    /// the accumulator goes to NaN/Inf and the query's top-`k` becomes
+    /// arbitrary indices with meaningless scores, silently.
+    InvalidQueryValue {
+        query_index: usize,
+        coord_index: usize,
+        value: f32,
+    },
+
+    /// The search mask's length does not equal the index's vector count,
+    /// so slot `i` of the mask does not name slot `i` of the index.
+    MaskLengthMismatch { expected: usize, got: usize },
 }
 
 impl fmt::Display for SearchError {
@@ -190,6 +233,23 @@ impl fmt::Display for SearchError {
             Self::UnknownId(id) => {
                 write!(f, "id {id} in allowlist is not present in index")
             }
+            Self::QueryBufferNotMultipleOfDim { queries_len, dim } => write!(
+                f,
+                "query buffer length {queries_len} not a multiple of dim {dim}",
+            ),
+            Self::InvalidQueryValue {
+                query_index,
+                coord_index,
+                value,
+            } => write!(
+                f,
+                "invalid query value at query {query_index}, coord {coord_index}: {value} \
+                 (must be finite and |value| < 1e16 to avoid f32 overflow)",
+            ),
+            Self::MaskLengthMismatch { expected, got } => write!(
+                f,
+                "mask length {got} does not match index size {expected}",
+            ),
         }
     }
 }

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -156,10 +156,11 @@ type CoreLoad = (usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>)
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the six slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -193,10 +194,11 @@ pub fn write(
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the six slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -283,10 +285,11 @@ pub(crate) fn write_native_with_durability(
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the six slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -392,10 +395,11 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the seven slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -440,10 +444,11 @@ pub fn write_id_map(
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the seven slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -543,10 +548,11 @@ pub(crate) fn write_id_map_native_with_durability(
 ///
 /// # Panics
 ///
-/// These check the *shape of the ten slice arguments against each
-/// other* — something the caller assembles and the writer cannot
-/// negotiate — so they abort rather than joining the `io::Result`,
-/// which reports what happened to the sink:
+/// These check the seven slice arguments for consistency with
+/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
+/// caller assembles and the writer cannot negotiate — so they abort
+/// rather than joining the `io::Result`, which reports what happened to
+/// the sink:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -168,19 +168,19 @@ type CoreLoad = (usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>)
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write(
     path: impl AsRef<Path>,
@@ -220,19 +220,19 @@ pub fn write(
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_with_durability(
     path: impl AsRef<Path>,
@@ -325,19 +325,19 @@ pub(crate) fn write_native_with_durability(
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_to<W: Write>(
     w: &mut W,
@@ -450,19 +450,19 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map(
     path: impl AsRef<Path>,
@@ -513,19 +513,19 @@ pub fn write_id_map(
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_with_durability(
     path: impl AsRef<Path>,
@@ -631,19 +631,19 @@ pub(crate) fn write_id_map_native_with_durability(
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked — here or anywhere.
-/// A buffer inconsistent with `n_vectors` does not reliably fail: the
-/// loader sizes each section from the header, so a wrong length shifts
-/// every later section, and whether the load reports an error or
-/// succeeds and silently mis-scores depends on what the shifted bytes
-/// happen to land on. Both outcomes are reachable and the mix varies
-/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
-/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
-/// at one index size and 1 clean at another. A compensating pair that
-/// preserves the total byte count loads clean every time. Do not rely
-/// on the loader to catch this; see issue #407. Prefer
-/// [`crate::TurboQuantIndex::write`], or take these two buffers from
-/// `codes_blocked_seq()` / `scales()` on a real index.
+/// through as given and are **not** length-checked by the writer. The
+/// loader does apply length and fill checks, but not reliably enough to
+/// lean on: it sizes each section from the header, so a wrong length
+/// here shifts every later section, and whether that surfaces as a load
+/// error or as a clean load that silently mis-scores depends on what
+/// the shifted bytes land on. Both outcomes are reachable, and which
+/// one dominates varies sharply with index geometry. One case is
+/// consistent: a compensating pair that keeps the total byte count
+/// unchanged shifts nothing downstream, and has loaded clean and
+/// mis-scored in every configuration tested. Do not rely on the loader
+/// to catch an inconsistent buffer — see issue #407 for the measured
+/// sweep. Prefer [`crate::TurboQuantIndex::write`], or take these two
+/// buffers from `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_to<W: Write>(
     w: &mut W,

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -168,10 +168,19 @@ type CoreLoad = (usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>)
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write(
     path: impl AsRef<Path>,
@@ -211,10 +220,19 @@ pub fn write(
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_with_durability(
     path: impl AsRef<Path>,
@@ -307,10 +325,19 @@ pub(crate) fn write_native_with_durability(
 ///   `codebook_centroids.len() != 1 << bit_width`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_to<W: Write>(
     w: &mut W,
@@ -423,10 +450,19 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map(
     path: impl AsRef<Path>,
@@ -477,10 +513,19 @@ pub fn write_id_map(
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_with_durability(
     path: impl AsRef<Path>,
@@ -586,10 +631,19 @@ pub(crate) fn write_id_map_native_with_durability(
 /// - `slot_to_id.len() != n_vectors`.
 ///
 /// The remaining two, `codes_blocked_seq` and `scales`, are written
-/// through as given and are **not** length-checked here, so a buffer
-/// inconsistent with `n_vectors` produces a file that fails to load
-/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
-/// size them as the format requires.
+/// through as given and are **not** length-checked — here or anywhere.
+/// A buffer inconsistent with `n_vectors` does not reliably fail: the
+/// loader sizes each section from the header, so a wrong length shifts
+/// every later section, and whether the load reports an error or
+/// succeeds and silently mis-scores depends on what the shifted bytes
+/// happen to land on. Both outcomes are reachable and the mix varies
+/// sharply with geometry — a sweep of 15 perturbations loaded 9 clean
+/// (one returning a top score of 1.068 against a cosine ceiling of 1.0)
+/// at one index size and 1 clean at another. A compensating pair that
+/// preserves the total byte count loads clean every time. Do not rely
+/// on the loader to catch this; see issue #407. Prefer
+/// [`crate::TurboQuantIndex::write`], or take these two buffers from
+/// `codes_blocked_seq()` / `scales()` on a real index.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_to<W: Write>(
     w: &mut W,

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -156,17 +156,22 @@ type CoreLoad = (usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>)
 ///
 /// # Panics
 ///
-/// These check the six slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Four of the six slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
 ///   calibration; any other length has no valid trailer encoding.
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write(
     path: impl AsRef<Path>,
@@ -194,17 +199,22 @@ pub fn write(
 ///
 /// # Panics
 ///
-/// These check the six slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Four of the six slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
 ///   calibration; any other length has no valid trailer encoding.
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write_with_durability(
     path: impl AsRef<Path>,
@@ -285,17 +295,22 @@ pub(crate) fn write_native_with_durability(
 ///
 /// # Panics
 ///
-/// These check the six slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Four of the six slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
 ///   calibration; any other length has no valid trailer encoding.
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write_to<W: Write>(
     w: &mut W,
@@ -395,11 +410,10 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 ///
 /// # Panics
 ///
-/// These check the seven slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Five of the seven slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -407,6 +421,12 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
 /// - `slot_to_id.len() != n_vectors`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map(
     path: impl AsRef<Path>,
@@ -444,11 +464,10 @@ pub fn write_id_map(
 ///
 /// # Panics
 ///
-/// These check the seven slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Five of the seven slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -456,6 +475,12 @@ pub fn write_id_map(
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
 /// - `slot_to_id.len() != n_vectors`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_with_durability(
     path: impl AsRef<Path>,
@@ -548,11 +573,10 @@ pub(crate) fn write_id_map_native_with_durability(
 ///
 /// # Panics
 ///
-/// These check the seven slice arguments for consistency with
-/// `dim`, `bit_width`, `n_vectors` and each other — a relationship the
-/// caller assembles and the writer cannot negotiate — so they abort
-/// rather than joining the `io::Result`, which reports what happened to
-/// the sink:
+/// Five of the seven slice arguments carry a length invariant, and a
+/// violation aborts rather than joining the `io::Result` — the `Result`
+/// reports what happened to the sink, while these describe a
+/// caller-assembled shape the writer cannot negotiate:
 ///
 /// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
 ///   non-empty and its length is not `dim`. Empty means identity
@@ -560,6 +584,12 @@ pub(crate) fn write_id_map_native_with_durability(
 /// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
 ///   `codebook_centroids.len() != 1 << bit_width`.
 /// - `slot_to_id.len() != n_vectors`.
+///
+/// The remaining two, `codes_blocked_seq` and `scales`, are written
+/// through as given and are **not** length-checked here, so a buffer
+/// inconsistent with `n_vectors` produces a file that fails to load
+/// rather than a panic. Build them via [`crate::TurboQuantIndex`], or
+/// size them as the format requires.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_to<W: Write>(
     w: &mut W,

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -153,6 +153,19 @@ type CoreLoad = (usize, usize, usize, CodePayload, Vec<f32>, Vec<f32>, Vec<f32>)
 /// not commit — a parent-directory fsync that fails after the rename
 /// leaves the new file in place, so it warns on stderr and still returns
 /// `Ok` rather than claiming the previous file survived (#365).
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
 #[allow(clippy::too_many_arguments)]
 pub fn write(
     path: impl AsRef<Path>,
@@ -177,6 +190,19 @@ pub fn write(
 }
 
 /// [`write`] with an explicit [`Durability`] level.
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_with_durability(
     path: impl AsRef<Path>,
@@ -254,6 +280,19 @@ pub(crate) fn write_native_with_durability(
 ///
 /// Unlike [`write`] there is no atomicity story: the caller owns the
 /// sink.
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_to<W: Write>(
     w: &mut W,
@@ -350,6 +389,20 @@ fn incompatible_version_error(version: u8, label: &str) -> io::Error {
 /// `.tvim` write — positional index plus the id-map side-tables.
 ///
 /// Atomic with respect to the destination, like [`write`].
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
+/// - `slot_to_id.len() != n_vectors`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map(
     path: impl AsRef<Path>,
@@ -384,6 +437,20 @@ pub fn write_id_map(
 }
 
 /// [`write_id_map`] with an explicit [`Durability`] level.
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
+/// - `slot_to_id.len() != n_vectors`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_with_durability(
     path: impl AsRef<Path>,
@@ -473,6 +540,20 @@ pub(crate) fn write_id_map_native_with_durability(
 /// `.tvim` write to any [`Write`] sink — the in-memory counterpart of
 /// [`write_id_map`]. Emits exactly the bytes [`write_id_map`] would put
 /// in the file.
+///
+/// # Panics
+///
+/// These check the *shape of the ten slice arguments against each
+/// other* — something the caller assembles and the writer cannot
+/// negotiate — so they abort rather than joining the `io::Result`,
+/// which reports what happened to the sink:
+///
+/// - `tqplus_shift.len() != tqplus_scale.len()`, or the pair is
+///   non-empty and its length is not `dim`. Empty means identity
+///   calibration; any other length has no valid trailer encoding.
+/// - `codebook_boundaries.len() != (1 << bit_width) - 1` or
+///   `codebook_centroids.len() != 1 << bit_width`.
+/// - `slot_to_id.len() != n_vectors`.
 #[allow(clippy::too_many_arguments)]
 pub fn write_id_map_to<W: Write>(
     w: &mut W,

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -29,10 +29,27 @@
 //! without locking. [`TurboQuantIndex::prepare`] can be called once
 //! after `add`/`load` to pay that cost up front.
 //!
-//! Mutation still flows through `&mut self`: `add` extends the packed
-//! codes and invalidates the blocked layout cache by replacing its
-//! `OnceLock`. This keeps the invariant that once a cache is populated
-//! from `&self`, it matches the current `packed_codes`.
+//! Mutation still flows through `&mut self`, and the invariant it keeps
+//! is stated in terms of what a reader can observe rather than in terms
+//! of what any one mutator does: **whenever the index is reachable
+//! through `&self`, every populated cache describes exactly the
+//! `len()` rows the index currently holds.**
+//!
+//! That holds by construction. The rotation, boundaries and centroids
+//! are pure functions of `dim` and `bit_width`, neither of which ever
+//! changes after the first add, so they can never go stale. The blocked
+//! layout and the packed bit-plane rows are two encodings of the same
+//! rows, each derivable from the other; a mutation holds `&mut self` for
+//! its whole duration, so no concurrent reader exists while one of them
+//! is being brought up to date, and by the time that borrow ends both
+//! the row count and every populated cache describe the same rows.
+//!
+//! Which of the two encodings a mutation updates is an implementation
+//! detail that has changed more than once and is deliberately not
+//! promised here. A [`TurboQuantIndex::load`]ed index may hold only the
+//! blocked form until something needs the packed rows
+//! ([`TurboQuantIndex::packed_ready`] reports which); elsewhere the
+//! packed rows lead. Both give bit-identical search results.
 
 // turbovec is 64-bit by design: the SIMD kernels, the `usize` size/offset
 // arithmetic in `encode`/`pack`/`search`, and all benchmarks assume a 64-bit
@@ -184,11 +201,15 @@ pub fn validation_parallelizes(len: usize) -> bool {
     len > encode::VALIDATE_CHUNK
 }
 
-/// SIMD-blocked cache derived from `packed_codes`.
+/// SIMD-blocked encoding of the index's rows — the layout the search
+/// kernel scores directly.
 ///
-/// Materialised lazily by [`TurboQuantIndex::search`] on first call
-/// and re-materialised when [`TurboQuantIndex::add`] resets the
-/// enclosing `OnceLock`.
+/// Populated either by a v6 load (the file already stores this layout)
+/// or by [`TurboQuantIndex::search`] repacking `packed_codes` on first
+/// call. Once populated it is kept in step with the index under
+/// `&mut self` rather than discarded: `data` always holds exactly
+/// `n_blocks` blocks covering the index's current `n_vectors` rows,
+/// including the zero padding of a partial tail block.
 #[derive(Debug)]
 struct BlockedCache {
     data: Vec<u8>,
@@ -283,12 +304,22 @@ pub struct TurboQuantIndex {
     // Thread-safe lazy caches. These are initialised from `&self` via
     // `OnceLock::get_or_init`, which allows `search` to take `&self`
     // and run concurrently from multiple threads without external
-    // locking. `add` resets `blocked` by replacing its `OnceLock` (it
-    // already has `&mut self` for the underlying extend on
-    // `packed_codes` and `scales`).
+    // locking.
     //
     // `rotation`, `boundaries`, and `centroids` are deterministic functions
     // of `dim` (and `bit_width`), so they never need to be invalidated.
+    //
+    // `blocked` is row-dependent and so does need maintaining, but only
+    // ever under `&mut self`, where no `&self` reader can be observing
+    // it. Both mutators patch it in place through `get_mut` rather than
+    // discarding it — `add` rewrites the tail block and appends any new
+    // ones, `swap_remove` moves one lane and truncates — and a cold
+    // cache stays cold, so neither pays for a layout nobody has asked
+    // for yet. The only place the `OnceLock` is replaced outright is the
+    // TQ+ threshold crossing in `add`, which re-encodes every row from
+    // the warm-up buffer and so has no prior state worth keeping.
+    // Whichever path runs, `blocked` covers exactly `n_vectors` rows by
+    // the time the borrow ends.
     rotation: OnceLock<rotation::Rotation>,
     boundaries: OnceLock<Vec<f32>>,
     centroids: OnceLock<Vec<f32>>,
@@ -309,6 +340,13 @@ pub struct TurboQuantIndex {
 /// where `k` is the *effective* per-query result count stored in
 /// [`Self::k`] — the requested `k` clamped to the number of searchable
 /// vectors — not necessarily the `k` the caller asked for.
+///
+/// `Eq`/`Hash` are deliberately absent: `scores` holds `f32`, which has
+/// no total equality. `PartialEq` compares the four fields structurally,
+/// so two results compare equal only when they have the same shape *and*
+/// bitwise-comparable scores — enough for `assert_eq!` in a downstream
+/// test, not enough to key a map.
+#[derive(Debug, Clone, PartialEq)]
 pub struct SearchResults {
     /// Scores, row-major `nq × k`, sorted descending within each row
     /// (best match first).
@@ -330,7 +368,9 @@ impl SearchResults {
     /// The row of [`Self::scores`] for query `qi`:
     /// `&self.scores[qi * self.k..(qi + 1) * self.k]`.
     ///
-    /// Panics if the row is out of bounds (`qi >= nq` with `k > 0`).
+    /// # Panics
+    ///
+    /// If the row is out of bounds (`qi >= nq` with `k > 0`).
     pub fn scores_for_query(&self, qi: usize) -> &[f32] {
         &self.scores[qi * self.k..(qi + 1) * self.k]
     }
@@ -338,7 +378,9 @@ impl SearchResults {
     /// The row of [`Self::indices`] for query `qi`, aligned with
     /// [`Self::scores_for_query`].
     ///
-    /// Panics if the row is out of bounds (`qi >= nq` with `k > 0`).
+    /// # Panics
+    ///
+    /// If the row is out of bounds (`qi >= nq` with `k > 0`).
     pub fn indices_for_query(&self, qi: usize) -> &[i64] {
         &self.indices[qi * self.k..(qi + 1) * self.k]
     }
@@ -1001,10 +1043,36 @@ impl TurboQuantIndex {
     ///
     /// Panics if `queries.len()` is not a multiple of `dim`, or if any
     /// query coordinate is non-finite (NaN, +Inf, -Inf) or has
-    /// magnitude `>= 1e16`. Validate untrusted input at the caller
-    /// (e.g. the Python binding raises `ValueError`).
+    /// magnitude `>= 1e16`. Both indicate the caller handed the index a
+    /// buffer it cannot score at all.
+    ///
+    /// Neither check can run on an index with no committed `dim` (a
+    /// [`Self::new_lazy`] index that has never been added to): there is
+    /// no dim to measure the buffer against, so any `queries` returns
+    /// the empty result below.
+    ///
+    /// Use [`Self::try_search`] to get these conditions back as a
+    /// [`SearchError`] instead — the right choice whenever the query
+    /// vectors come from outside the process.
     pub fn search(&self, queries: &[f32], k: usize) -> SearchResults {
         self.search_with_mask(queries, k, None)
+    }
+
+    /// [`Self::search`] as a `Result`: the non-panicking form.
+    ///
+    /// Identical to `search` on well-formed input — same results, same
+    /// caches, same cost. The difference is only in how a malformed
+    /// `queries` buffer is reported: [`SearchError`] instead of a panic
+    /// that unwinds the calling thread. A service scoring vectors it did
+    /// not produce (an HTTP body, an embedding provider that emitted a
+    /// NaN) wants this one; `search` stays the right call when a ragged
+    /// or non-finite query would be a bug in your own code.
+    ///
+    /// Returns [`SearchError::QueryBufferNotMultipleOfDim`] or
+    /// [`SearchError::InvalidQueryValue`]. See
+    /// [`Self::try_search_with_mask`] for the masked form.
+    pub fn try_search(&self, queries: &[f32], k: usize) -> Result<SearchResults, SearchError> {
+        self.try_search_with_mask(queries, k, None)
     }
 
     /// Run a top-`k` search restricted to slots whose `mask` entry is `true`.
@@ -1021,35 +1089,71 @@ impl TurboQuantIndex {
     /// - If `mask.len() != self.len()` (when `mask` is `Some`).
     /// - If `queries.len()` is not a multiple of `dim`.
     /// - If any query coordinate is non-finite or has magnitude `>= 1e16`.
+    ///
+    /// As with [`Self::search`], none of the three can fire on an index
+    /// with no committed `dim` — that case returns the empty result
+    /// before any validation. Use [`Self::try_search_with_mask`] for the
+    /// non-panicking form.
     pub fn search_with_mask(
         &self,
         queries: &[f32],
         k: usize,
         mask: Option<&[bool]>,
     ) -> SearchResults {
+        // Single source of validation: the checked form below owns all
+        // three conditions, and this one turns them back into the panics
+        // its signature promises. Re-validating here instead would run
+        // `first_invalid_coord`'s O(nq·dim) scan twice per query batch.
+        self.try_search_with_mask(queries, k, mask)
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// [`Self::search_with_mask`] as a `Result`: the non-panicking form.
+    ///
+    /// Returns [`SearchError::QueryBufferNotMultipleOfDim`],
+    /// [`SearchError::InvalidQueryValue`], or
+    /// [`SearchError::MaskLengthMismatch`]. On success the result is
+    /// exactly what `search_with_mask` would have returned.
+    ///
+    /// Adding this did not change `search_with_mask`: that function now
+    /// calls this one and panics with the error's `Display` text, so the
+    /// panic messages, the validation order and the results are all
+    /// unchanged.
+    pub fn try_search_with_mask(
+        &self,
+        queries: &[f32],
+        k: usize,
+        mask: Option<&[bool]>,
+    ) -> Result<SearchResults, SearchError> {
         // A lazy index that's never seen an add returns an empty result
         // shaped according to the caller's query count (best effort: we
         // don't know dim, so nq is 0). Matches Python users' expectation
         // that `search` on an empty store is a no-op rather than an error.
         let Some(dim) = self.dim else {
-            return SearchResults {
+            return Ok(SearchResults {
                 scores: Vec::new(),
                 indices: Vec::new(),
                 nq: 0,
                 k: 0,
-            };
+            });
         };
         let nq = queries.len() / dim;
-        assert_eq!(queries.len(), nq * dim);
+        if queries.len() != nq * dim {
+            return Err(SearchError::QueryBufferNotMultipleOfDim {
+                queries_len: queries.len(),
+                dim,
+            });
+        }
         // Reject non-finite / huge-magnitude queries. Same rationale as
         // `add`: NaN / Inf / overflow-magnitude values poison the SIMD
         // scoring kernel and produce arbitrary indices with NaN scores,
         // silently rather than as a typed error.
         if let Some((vi, ci, v)) = first_invalid_coord(queries, dim) {
-            panic!(
-                "invalid query value at query {vi}, coord {ci}: {v} \
-                 (must be finite and |value| < 1e16 to avoid f32 overflow)",
-            );
+            return Err(SearchError::InvalidQueryValue {
+                query_index: vi,
+                coord_index: ci,
+                value: v,
+            });
         }
 
         // An empty index has nothing to score: return the empty result
@@ -1059,19 +1163,19 @@ impl TurboQuantIndex {
         // from driving the codebook/blocked-layout build on first search.
         if self.n_vectors == 0 {
             if let Some(m) = mask {
-                assert_eq!(
-                    m.len(),
-                    0,
-                    "mask length {} does not match index size 0",
-                    m.len(),
-                );
+                if !m.is_empty() {
+                    return Err(SearchError::MaskLengthMismatch {
+                        expected: 0,
+                        got: m.len(),
+                    });
+                }
             }
-            return SearchResults {
+            return Ok(SearchResults {
                 scores: Vec::new(),
                 indices: Vec::new(),
                 nq,
                 k: 0,
-            };
+            });
         }
 
         let rotation = self
@@ -1087,14 +1191,18 @@ impl TurboQuantIndex {
             BlockedCache { data, n_blocks }
         });
 
+        // Checked before the build, not inside it: a wrong-length mask is
+        // caller data, so it leaves through the `Result` rather than
+        // aborting mid-construction.
+        if let Some(m) = mask {
+            if m.len() != self.n_vectors {
+                return Err(SearchError::MaskLengthMismatch {
+                    expected: self.n_vectors,
+                    got: m.len(),
+                });
+            }
+        }
         let packed_mask = mask.map(|m| {
-            assert_eq!(
-                m.len(),
-                self.n_vectors,
-                "mask length {} does not match index size {}",
-                m.len(),
-                self.n_vectors,
-            );
             // Build word-at-a-time out of 64-bool chunks and count the
             // allowed slots in the same pass. The byte-at-a-time form
             // this replaces did one bounds-checked read-modify-write of
@@ -1138,12 +1246,12 @@ impl TurboQuantIndex {
             packed_mask.as_deref(),
         );
 
-        SearchResults {
+        Ok(SearchResults {
             scores,
             indices,
             nq,
             k: effective_k,
-        }
+        })
     }
 
     /// Eagerly populate the search caches (rotation, centroids
@@ -1179,6 +1287,18 @@ impl TurboQuantIndex {
         });
     }
 
+    /// Save the index to `path` in the `.tv` format.
+    ///
+    /// The write is atomic with respect to `path`: the bytes go to a
+    /// sibling temp file which is fsynced and renamed over the
+    /// destination, so `path` never holds a torn index and any previous
+    /// file there survives a failed write. `Err` means the save did not
+    /// commit.
+    ///
+    /// Reload with [`Self::load`]. See
+    /// [`Self::write_with_durability`] to trade the fsync for speed, and
+    /// [`Self::write_to_writer`] / [`Self::to_bytes`] for the in-memory
+    /// forms.
     pub fn write(&self, path: impl AsRef<Path>) -> std::io::Result<()> {
         self.write_with_durability(path, io::Durability::Durable)
     }
@@ -1358,6 +1478,20 @@ impl TurboQuantIndex {
         Self::load_from_reader(&mut &bytes[..])
     }
 
+    /// Load an index from a `.tv` file written by [`Self::write`].
+    ///
+    /// This is the crate's validation chokepoint for untrusted bytes and
+    /// the definition [`Self::load_from_reader`] and [`Self::from_bytes`]
+    /// defer to. A file is accepted only if its version is supported,
+    /// every declared length agrees with the bytes actually present, and
+    /// every float it carries is one the encoder could have emitted; a
+    /// file that fails any of those is refused with an `Err` rather than
+    /// producing an index that mis-scores. Corrupt input therefore
+    /// surfaces here, not as a wrong answer from a later `search`.
+    ///
+    /// The returned index is cold: the rotation, codebook and search
+    /// layout materialize on first [`Self::search`], or up front on
+    /// [`Self::prepare`].
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
         Self::from_loaded(io::load(path)?)
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1246,8 +1246,9 @@ impl TurboQuantIndex {
     /// message text was already inside the old payload, so a
     /// `should_panic(expected = "mask length")` keeps matching. The
     /// ragged-buffer assert carried *no* message, so its old and new
-    /// payloads share no text at all — nothing that matched the old one
-    /// matches the new one.
+    /// payloads have nothing in common but the two numbers (`65` and
+    /// `64`); any `expected =` string that matched the old one will not
+    /// match the new.
     pub fn try_search_with_mask(
         &self,
         queries: &[f32],

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1697,7 +1697,10 @@ impl TurboQuantIndex {
     /// assemble an index from an io-layer core payload. What gets seeded
     /// differs per arm. The v5 arm seeds nothing — a v5 file carries only
     /// the packed rows, and the rotation is deterministic and cheap to
-    /// (re)build — so every cache fills lazily on first search. The two
+    /// (re)build — so the three caches a search needs (`rotation`,
+    /// `centroids`, `blocked`) fill lazily on first search. `boundaries`
+    /// is encode-side: no search ever fills it, so a v5-loaded index
+    /// that is only ever searched leaves it cold. The two
     /// v6 arms seed the codebook and the blocked search layout from the
     /// file, for any file holding at least one vector. The rotation is
     /// left cold on every path.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1676,17 +1676,31 @@ impl TurboQuantIndex {
     /// producing an index that mis-scores. Corrupt input therefore
     /// surfaces here, not as a wrong answer from a later `search`.
     ///
-    /// The returned index is cold: the rotation, codebook and search
-    /// layout materialize on first [`Self::search`], or up front on
-    /// [`Self::prepare`].
+    /// How much of the returned index is already materialized depends on
+    /// the file's format version. A v6 file — what [`Self::write`] emits
+    /// — stores the codebook and the blocked search layout, so a
+    /// non-empty v6 load seeds both straight from the file and leaves
+    /// only the rotation cold; the packed rows stay unmaterialized until
+    /// something needs them ([`Self::packed_ready`] reports which
+    /// encoding is present). A v5 file carries packed rows instead, so it
+    /// loads fully cold and the search layout is built on first use, as
+    /// does a v6 file holding no vectors (there is nothing to seed).
+    ///
+    /// [`Self::prepare`] does whatever remains up front instead of on the
+    /// first [`Self::search`]. After a v6 load that is the rotation
+    /// alone — not the O(n·dim) repack the v5 path still pays.
     pub fn load(path: impl AsRef<Path>) -> std::io::Result<Self> {
         Self::from_loaded(io::load(path)?)
     }
 
     /// Shared tail of [`Self::load`] / [`Self::load_from_reader`]:
-    /// assemble an index from an io-layer core payload. The v5 rotation
-    /// is deterministic and cheap to (re)build, so nothing is seeded from
-    /// the load path — the cache fills lazily on first search.
+    /// assemble an index from an io-layer core payload. What gets seeded
+    /// differs per arm. The v5 arm seeds nothing — a v5 file carries only
+    /// the packed rows, and the rotation is deterministic and cheap to
+    /// (re)build — so every cache fills lazily on first search. The two
+    /// v6 arms seed the codebook and the blocked search layout from the
+    /// file, for any file holding at least one vector. The rotation is
+    /// left cold on every path.
     pub(crate) fn from_loaded(
         parts: (usize, usize, usize, io::CodePayload, Vec<f32>, Vec<f32>, Vec<f32>),
     ) -> std::io::Result<Self> {

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1184,8 +1184,8 @@ impl TurboQuantIndex {
         // Re-validating here instead would run `first_invalid_coord`'s
         // O(nq·dim) scan twice per query batch. The payload is now the
         // error's `Display` rather than an `assert_eq!` rendering, so
-        // four of the five messages are shorter than they were — see
-        // `try_search_with_mask` for the before/after.
+        // three of the four sites report differently than they did —
+        // see `try_search_with_mask` for the before/after.
         self.try_search_with_mask(queries, k, mask)
             .unwrap_or_else(|e| panic!("{e}"))
     }
@@ -1202,9 +1202,11 @@ impl TurboQuantIndex {
     /// they detect: the conditions, the order they are checked in and
     /// the results returned are all exactly as before.
     ///
-    /// The panic *text* did change for four of the five sites, because
-    /// these conditions were previously raised by `assert_eq!` and now
-    /// carry the error's `Display` alone:
+    /// The panic *text* did change at three of the four sites, which
+    /// were previously raised by `assert_eq!` and now carry the error's
+    /// `Display` alone. (Four sites, three conditions: the mask-length
+    /// check has one site for an empty index and one for a populated
+    /// one.)
     ///
     /// ```text
     /// before: assertion `left == right` failed: mask length 99 does not match index size 16
@@ -1218,10 +1220,15 @@ impl TurboQuantIndex {
     /// after:  query buffer length 65 not a multiple of dim 64
     /// ```
     ///
-    /// Only the non-finite-coordinate panic is byte-identical, having
-    /// always been a `panic!` rather than an assert. Code matching on
-    /// payload substrings is unaffected; code matching the
-    /// `assertion ... failed` prefix is not.
+    /// The fourth site, the non-finite-coordinate panic, is
+    /// byte-identical: it was always a `panic!` rather than an assert.
+    ///
+    /// What still matches and what does not: at the two mask sites the
+    /// message text was already inside the old payload, so a
+    /// `should_panic(expected = "mask length")` keeps matching. The
+    /// ragged-buffer assert carried *no* message, so its old and new
+    /// payloads share no text at all — nothing that matched the old one
+    /// matches the new one.
     pub fn try_search_with_mask(
         &self,
         queries: &[f32],
@@ -1294,9 +1301,16 @@ impl TurboQuantIndex {
             BlockedCache { data, n_blocks }
         });
 
-        // Checked before the build, not inside it: a wrong-length mask is
-        // caller data, so it leaves through the `Result` rather than
-        // aborting mid-construction.
+        // A wrong-length mask is caller data, so it leaves through the
+        // `Result` rather than aborting midway through the bitset build
+        // below, which is where the `assert_eq!` this replaces used to
+        // sit. Note this is still *after* the rotation/centroid/blocked
+        // caches are warmed above: that ordering is inherited, not
+        // chosen, and it means a bad mask on a cold index pays for the
+        // layout build before it is rejected. Moving the check above
+        // those `get_or_init` calls would be a strict improvement and is
+        // deliberately left out of the change that introduced this
+        // `Result`, so that "validation order is unchanged" stays true.
         if let Some(m) = mask {
             if m.len() != self.n_vectors {
                 return Err(SearchError::MaskLengthMismatch {

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -204,9 +204,11 @@ pub fn validation_parallelizes(len: usize) -> bool {
 /// SIMD-blocked encoding of the index's rows — the layout the search
 /// kernel scores directly.
 ///
-/// Populated either by a v6 load (the file already stores this layout)
-/// or by [`TurboQuantIndex::search`] repacking `packed_codes` on first
-/// call. Once populated it is kept in step with the index under
+/// Populated by a v6 load (the file already stores this layout), or by
+/// repacking `packed_codes` — which [`TurboQuantIndex::search`] does on
+/// first call and [`TurboQuantIndex::prepare`] does up front. Until one
+/// of those happens the cache stays cold, and a mutation leaves it
+/// cold. Once populated it is kept in step with the index under
 /// `&mut self` rather than discarded: `data` always holds exactly
 /// `n_blocks` blocks covering the index's current `n_vectors` rows,
 /// including the zero padding of a partial tail block.
@@ -342,10 +344,14 @@ pub struct TurboQuantIndex {
 /// vectors — not necessarily the `k` the caller asked for.
 ///
 /// `Eq`/`Hash` are deliberately absent: `scores` holds `f32`, which has
-/// no total equality. `PartialEq` compares the four fields structurally,
-/// so two results compare equal only when they have the same shape *and*
-/// bitwise-comparable scores — enough for `assert_eq!` in a downstream
-/// test, not enough to key a map.
+/// no total equality. The derived `PartialEq` compares the four fields
+/// in order, which means the score comparison is `f32`'s `==` and
+/// inherits IEEE-754 semantics rather than bit equality — `NaN` is not
+/// equal to itself (a result carrying one never equals its own clone,
+/// however it was produced) and `+0.0 == -0.0` despite differing bit
+/// patterns. Good enough for `assert_eq!` on results the index actually
+/// returns; not a substitute for comparing scores within a tolerance,
+/// and not enough to key a map.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchResults {
     /// Scores, row-major `nq × k`, sorted descending within each row
@@ -1101,9 +1107,12 @@ impl TurboQuantIndex {
         mask: Option<&[bool]>,
     ) -> SearchResults {
         // Single source of validation: the checked form below owns all
-        // three conditions, and this one turns them back into the panics
-        // its signature promises. Re-validating here instead would run
-        // `first_invalid_coord`'s O(nq·dim) scan twice per query batch.
+        // three conditions, and this one turns them back into panics.
+        // Re-validating here instead would run `first_invalid_coord`'s
+        // O(nq·dim) scan twice per query batch. The payload is now the
+        // error's `Display` rather than an `assert_eq!` rendering, so
+        // four of the five messages are shorter than they were — see
+        // `try_search_with_mask` for the before/after.
         self.try_search_with_mask(queries, k, mask)
             .unwrap_or_else(|e| panic!("{e}"))
     }
@@ -1115,10 +1124,31 @@ impl TurboQuantIndex {
     /// [`SearchError::MaskLengthMismatch`]. On success the result is
     /// exactly what `search_with_mask` would have returned.
     ///
-    /// Adding this did not change `search_with_mask`: that function now
-    /// calls this one and panics with the error's `Display` text, so the
-    /// panic messages, the validation order and the results are all
-    /// unchanged.
+    /// `search_with_mask` now calls this function and panics with the
+    /// error's `Display` text, so the two forms cannot diverge in what
+    /// they detect: the conditions, the order they are checked in and
+    /// the results returned are all exactly as before.
+    ///
+    /// The panic *text* did change for four of the five sites, because
+    /// these conditions were previously raised by `assert_eq!` and now
+    /// carry the error's `Display` alone:
+    ///
+    /// ```text
+    /// before: assertion `left == right` failed: mask length 99 does not match index size 16
+    ///           left: 99
+    ///          right: 16
+    /// after:  mask length 99 does not match index size 16
+    ///
+    /// before: assertion `left == right` failed
+    ///           left: 65
+    ///          right: 64
+    /// after:  query buffer length 65 not a multiple of dim 64
+    /// ```
+    ///
+    /// Only the non-finite-coordinate panic is byte-identical, having
+    /// always been a `panic!` rather than an assert. Code matching on
+    /// payload substrings is unaffected; code matching the
+    /// `assertion ... failed` prefix is not.
     pub fn try_search_with_mask(
         &self,
         queries: &[f32],

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -125,9 +125,13 @@ impl Rotation {
     /// - If `dim` is 0 or not a multiple of 8. The packed layout stores
     ///   one bit-plane byte per 8 coordinates, so no other `dim` has a
     ///   representable layout.
-    /// - If `dim` exceeds [`MAX_DIM`](crate::MAX_DIM) (16384). Past that
-    ///   bound the SIMD gather's permutation indices stop round-tripping
-    ///   through `i32`/`u32` — see the implementation note below.
+    /// - If `dim` exceeds [`MAX_DIM`](crate::MAX_DIM) (16384). The bound
+    ///   is not arbitrary: the permutation indices are handed to the x86
+    ///   gather intrinsics, which read them as *signed* `i32`, so above
+    ///   `2^31` a large index sign-extends into a wild negative offset;
+    ///   and at `2^32` the permutation is truncated into `u32` outright.
+    ///   Past this limit the gather is not merely wrong but unsound, so
+    ///   the ceiling is enforced here as well as at the index types.
     ///
     /// Unlike the index constructors, which return
     /// [`ConstructError`](crate::ConstructError) for the same two

--- a/turbovec/src/rotation.rs
+++ b/turbovec/src/rotation.rs
@@ -119,6 +119,21 @@ pub struct Rotation {
 
 impl Rotation {
     /// Build the rotation for `dim` (a positive multiple of 8).
+    ///
+    /// # Panics
+    ///
+    /// - If `dim` is 0 or not a multiple of 8. The packed layout stores
+    ///   one bit-plane byte per 8 coordinates, so no other `dim` has a
+    ///   representable layout.
+    /// - If `dim` exceeds [`MAX_DIM`](crate::MAX_DIM) (16384). Past that
+    ///   bound the SIMD gather's permutation indices stop round-tripping
+    ///   through `i32`/`u32` — see the implementation note below.
+    ///
+    /// Unlike the index constructors, which return
+    /// [`ConstructError`](crate::ConstructError) for the same two
+    /// conditions, this is a direct kernel constructor: reaching it with
+    /// a `dim` the index types would have rejected means the caller
+    /// bypassed that validation, so it aborts rather than reporting.
     pub fn new(dim: usize) -> Self {
         assert!(dim > 0 && dim % 8 == 0, "rotation dim must be a positive multiple of 8");
         // Bound `dim` here, not just at the index types. This module is

--- a/turbovec/tests/crate_api.rs
+++ b/turbovec/tests/crate_api.rs
@@ -177,12 +177,19 @@ fn try_search_returns_exactly_what_search_returns() {
 /// The exact panic payload `f` produces, with the default hook muted.
 ///
 /// `set_hook` is process-global — there is no thread-local form — and
-/// the tests in this binary run concurrently, so an unguarded swap would
-/// swallow the diagnostics of any *other* test that panicked inside the
-/// window. This repo keeps its `FORCE_*` panic switches thread-local for
-/// exactly that hazard (#373); the closest equivalent for a hook is to
-/// serialize the window and keep it as short as possible. The lock is
-/// deliberately taken across the `catch_unwind`, not just the swap.
+/// the tests in this binary run concurrently, so while the hook is muted
+/// a panic in any *other* test has its diagnostics swallowed. This repo
+/// keeps its `FORCE_*` panic switches thread-local for exactly that
+/// hazard (#373), but a hook has no such escape.
+///
+/// The mutex below does NOT close that window, and should not be read as
+/// doing so: it only serializes callers of this helper against each
+/// other, and there is currently one. Other tests never take it, so a
+/// concurrent unrelated panic is still silenced. It is here so that the
+/// window cannot be *nested* or widened if a second caller is added
+/// later. The real mitigation is that the window is a few microseconds
+/// around a call that is expected to panic; if a test in this file ever
+/// fails mysteriously with no output, this is the first thing to suspect.
 static HOOK_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn panic_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {

--- a/turbovec/tests/crate_api.rs
+++ b/turbovec/tests/crate_api.rs
@@ -1,0 +1,208 @@
+//! The crate's surface as a downstream dependency (#351).
+//!
+//! Two things a `cargo add turbovec` user needs that nothing else in the
+//! suite pins:
+//!
+//!   - `SearchResults` — the type *every* search returns — must implement
+//!     the traits a downstream struct holding one needs in order to
+//!     derive its own. Without `Debug` a caller cannot `#[derive(Debug)]`
+//!     around it or `dbg!` it; without `Clone` it cannot be cached;
+//!     without `PartialEq` it cannot appear in a user's `assert_eq!`.
+//!     The trait-bound assertions below fail to *compile* if the derives
+//!     are dropped, which is the only way to catch that class.
+//!
+//!   - The search path must have a non-panicking form. `add_2d` returns
+//!     `AddError` and the Python binding pre-validates the same three
+//!     query conditions and raises, but a Rust service handed a ragged
+//!     buffer, a NaN coordinate or a stale mask had no option but an
+//!     aborted request thread. `try_search` / `try_search_with_mask`
+//!     return `SearchError` instead.
+
+use turbovec::{SearchError, SearchResults, TurboQuantIndex};
+
+const DIM: usize = 64;
+const N: usize = 16;
+
+fn index() -> TurboQuantIndex {
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mut data = vec![0.0f32; N * DIM];
+    for (i, row) in data.chunks_mut(DIM).enumerate() {
+        row[i % DIM] = 1.0;
+    }
+    idx.add(&data);
+    idx
+}
+
+fn query() -> Vec<f32> {
+    let mut q = vec![0.0f32; DIM];
+    q[0] = 1.0;
+    q
+}
+
+// ---- SearchResults derives (#351 finding 1) ----
+
+fn assert_debug<T: std::fmt::Debug>() {}
+fn assert_clone<T: Clone>() {}
+fn assert_partial_eq<T: PartialEq>() {}
+
+#[test]
+fn search_results_implements_the_downstream_derive_set() {
+    // Compile-time half: these three lines are the test. If any derive
+    // is removed from `SearchResults` this file stops compiling.
+    assert_debug::<SearchResults>();
+    assert_clone::<SearchResults>();
+    assert_partial_eq::<SearchResults>();
+
+    // Behavioural half: the derives have to mean something. A clone
+    // compares equal to its source, `Debug` renders the shape fields,
+    // and results of different shapes compare unequal.
+    let idx = index();
+    let res = idx.search(&query(), 4);
+    let copy = res.clone();
+    assert_eq!(res, copy);
+    assert_eq!(copy.k, 4);
+
+    let rendered = format!("{res:?}");
+    assert!(
+        rendered.contains("SearchResults") && rendered.contains("nq"),
+        "Debug output should name the type and its fields, got {rendered}"
+    );
+
+    let narrower = idx.search(&query(), 2);
+    assert_ne!(res, narrower);
+}
+
+#[test]
+fn search_results_clone_is_independent_of_its_source() {
+    let idx = index();
+    let res = idx.search(&query(), 4);
+    let mut copy = res.clone();
+    copy.scores[0] = -1.0;
+    assert_ne!(res.scores[0], copy.scores[0]);
+}
+
+// ---- try_search: the three panic conditions become errors (#351 finding 2) ----
+
+#[test]
+fn try_search_reports_a_ragged_query_buffer() {
+    let idx = index();
+    let ragged = vec![0.0f32; DIM + 1];
+    match idx.try_search(&ragged, 4) {
+        Err(SearchError::QueryBufferNotMultipleOfDim { queries_len, dim }) => {
+            assert_eq!(queries_len, DIM + 1);
+            assert_eq!(dim, DIM);
+        }
+        other => panic!("expected QueryBufferNotMultipleOfDim, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_search_reports_a_non_finite_query_coordinate() {
+    let idx = index();
+    for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY, 1e17] {
+        let mut q = query();
+        q[7] = bad;
+        match idx.try_search(&q, 4) {
+            Err(SearchError::InvalidQueryValue {
+                query_index,
+                coord_index,
+                value,
+            }) => {
+                assert_eq!(query_index, 0);
+                assert_eq!(coord_index, 7);
+                assert!(
+                    value.is_nan() == bad.is_nan() && (value.is_nan() || value == bad),
+                    "reported value {value} should be the offending {bad}",
+                );
+            }
+            other => panic!("expected InvalidQueryValue for {bad}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn try_search_with_mask_reports_a_mask_length_mismatch() {
+    let idx = index();
+    let mask = vec![true; N + 3];
+    match idx.try_search_with_mask(&query(), 4, Some(&mask)) {
+        Err(SearchError::MaskLengthMismatch { expected, got }) => {
+            assert_eq!(expected, N);
+            assert_eq!(got, N + 3);
+        }
+        other => panic!("expected MaskLengthMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn try_search_on_an_empty_index_still_reports_a_non_empty_mask() {
+    // The empty-index early return sits before the mask build, so it
+    // needs its own check — it is the one place a mask can be wrong
+    // without the builder ever running.
+    let idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    let mask = vec![true; 2];
+    match idx.try_search_with_mask(&query(), 4, Some(&mask)) {
+        Err(SearchError::MaskLengthMismatch { expected, got }) => {
+            assert_eq!(expected, 0);
+            assert_eq!(got, 2);
+        }
+        other => panic!("expected MaskLengthMismatch, got {other:?}"),
+    }
+}
+
+// ---- try_search agrees with search wherever search does not panic ----
+
+#[test]
+fn try_search_returns_exactly_what_search_returns() {
+    let idx = index();
+    let mut queries = query();
+    queries.extend(query());
+
+    assert_eq!(idx.try_search(&queries, 4).unwrap(), idx.search(&queries, 4));
+
+    let mask: Vec<bool> = (0..N).map(|i| i % 2 == 0).collect();
+    assert_eq!(
+        idx.try_search_with_mask(&queries, 4, Some(&mask)).unwrap(),
+        idx.search_with_mask(&queries, 4, Some(&mask)),
+    );
+
+    // A lazy index with no committed dim: both forms return the same
+    // empty shape rather than erroring, since there is no dim to
+    // validate the buffer against.
+    let lazy = TurboQuantIndex::new_lazy(4).unwrap();
+    let empty = lazy.try_search(&queries, 4).unwrap();
+    assert_eq!(empty, lazy.search(&queries, 4));
+    assert_eq!((empty.nq, empty.k), (0, 0));
+}
+
+#[test]
+fn try_search_errors_carry_the_panic_text_search_uses() {
+    // `search_with_mask` panics with the error's `Display`, so the two
+    // forms cannot drift apart in what they report.
+    let idx = index();
+    let mut q = query();
+    q[7] = f32::NAN;
+    let err = idx.try_search(&q, 4).unwrap_err();
+    assert!(
+        err.to_string().contains("invalid query value"),
+        "got {err}"
+    );
+
+    let mask = vec![true; N + 1];
+    let err = idx
+        .try_search_with_mask(&query(), 4, Some(&mask))
+        .unwrap_err();
+    assert!(err.to_string().contains("mask length"), "got {err}");
+}
+
+#[test]
+fn search_error_is_a_std_error_that_composes() {
+    // The whole point of a typed error is that it reaches a `?` in a
+    // downstream handler. `Box<dyn Error + Send + Sync>` is what
+    // anyhow/thiserror-shaped code needs.
+    fn handler(idx: &TurboQuantIndex, q: &[f32]) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(idx.try_search(q, 4)?.k)
+    }
+    let idx = index();
+    assert_eq!(handler(&idx, &query()).unwrap(), 4);
+    assert!(handler(&idx, &vec![0.0f32; DIM + 1]).is_err());
+}

--- a/turbovec/tests/crate_api.rs
+++ b/turbovec/tests/crate_api.rs
@@ -175,7 +175,20 @@ fn try_search_returns_exactly_what_search_returns() {
 }
 
 /// The exact panic payload `f` produces, with the default hook muted.
+///
+/// `set_hook` is process-global — there is no thread-local form — and
+/// the tests in this binary run concurrently, so an unguarded swap would
+/// swallow the diagnostics of any *other* test that panicked inside the
+/// window. This repo keeps its `FORCE_*` panic switches thread-local for
+/// exactly that hazard (#373); the closest equivalent for a hook is to
+/// serialize the window and keep it as short as possible. The lock is
+/// deliberately taken across the `catch_unwind`, not just the swap.
+static HOOK_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn panic_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
+    // A poisoned guard just means a previous holder panicked outside its
+    // `catch_unwind`; the mutex protects no data, so recover and carry on.
+    let _guard = HOOK_GUARD.lock().unwrap_or_else(|e| e.into_inner());
     let prev = std::panic::take_hook();
     std::panic::set_hook(Box::new(|_| {}));
     let caught = std::panic::catch_unwind(f);
@@ -250,12 +263,19 @@ fn search_results_partial_eq_follows_ieee_not_bit_equality() {
     };
 
     // NaN: identical bits, not equal — so a NaN-carrying result is not
-    // equal to its own clone.
+    // equal to its own clone. Assert the bits really are identical, or
+    // the inequality would prove nothing about IEEE semantics.
     let nan = SearchResults {
         scores: vec![f32::NAN],
         ..base.clone()
     };
-    assert_ne!(nan, nan.clone());
+    let nan_clone = nan.clone();
+    assert_eq!(
+        nan.scores[0].to_bits(),
+        nan_clone.scores[0].to_bits(),
+        "the clone should be bit-identical, or this test proves nothing",
+    );
+    assert_ne!(nan, nan_clone);
 
     // Signed zero: different bits, equal.
     let neg_zero = SearchResults {

--- a/turbovec/tests/crate_api.rs
+++ b/turbovec/tests/crate_api.rs
@@ -174,24 +174,100 @@ fn try_search_returns_exactly_what_search_returns() {
     assert_eq!((empty.nq, empty.k), (0, 0));
 }
 
+/// The exact panic payload `f` produces, with the default hook muted.
+fn panic_payload<F: FnOnce() + std::panic::UnwindSafe>(f: F) -> String {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let caught = std::panic::catch_unwind(f);
+    std::panic::set_hook(prev);
+    let e = caught.unwrap_err();
+    e.downcast_ref::<String>()
+        .cloned()
+        .or_else(|| e.downcast_ref::<&str>().map(|s| s.to_string()))
+        .expect("panic payload should be a string")
+}
+
 #[test]
-fn try_search_errors_carry_the_panic_text_search_uses() {
-    // `search_with_mask` panics with the error's `Display`, so the two
-    // forms cannot drift apart in what they report.
+fn the_panicking_forms_panic_with_exactly_the_error_display() {
+    // Substring assertions are what let a false "panic messages are
+    // identical" claim through review: `should_panic(expected = ...)`
+    // matches on a substring, so it stayed green while the payload
+    // changed from an `assert_eq!` rendering to the bare message. Pin
+    // the *whole* payload, and pin it as equal to the `Display` of the
+    // error the checked form returns for the same input — that
+    // equality is the actual contract between the two forms.
     let idx = index();
-    let mut q = query();
-    q[7] = f32::NAN;
-    let err = idx.try_search(&q, 4).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid query value"),
-        "got {err}"
+
+    let ragged = vec![0.0f32; DIM + 1];
+    assert_eq!(
+        panic_payload(|| {
+            idx.search(&ragged, 4);
+        }),
+        idx.try_search(&ragged, 4).unwrap_err().to_string(),
+    );
+    assert_eq!(
+        panic_payload(|| {
+            idx.search(&ragged, 4);
+        }),
+        "query buffer length 65 not a multiple of dim 64",
+    );
+
+    let mut nan = query();
+    nan[7] = f32::NAN;
+    assert_eq!(
+        panic_payload(|| {
+            idx.search(&nan, 4);
+        }),
+        idx.try_search(&nan, 4).unwrap_err().to_string(),
     );
 
     let mask = vec![true; N + 1];
-    let err = idx
-        .try_search_with_mask(&query(), 4, Some(&mask))
-        .unwrap_err();
-    assert!(err.to_string().contains("mask length"), "got {err}");
+    assert_eq!(
+        panic_payload(|| {
+            idx.search_with_mask(&query(), 4, Some(&mask));
+        }),
+        idx.try_search_with_mask(&query(), 4, Some(&mask))
+            .unwrap_err()
+            .to_string(),
+    );
+    assert_eq!(
+        panic_payload(|| {
+            idx.search_with_mask(&query(), 4, Some(&mask));
+        }),
+        "mask length 17 does not match index size 16",
+    );
+}
+
+#[test]
+fn search_results_partial_eq_follows_ieee_not_bit_equality() {
+    // Pins what the type's docs claim about the derived `PartialEq`,
+    // since "compares scores bitwise" is wrong in both directions.
+    let base = SearchResults {
+        scores: vec![0.0],
+        indices: vec![0],
+        nq: 1,
+        k: 1,
+    };
+
+    // NaN: identical bits, not equal — so a NaN-carrying result is not
+    // equal to its own clone.
+    let nan = SearchResults {
+        scores: vec![f32::NAN],
+        ..base.clone()
+    };
+    assert_ne!(nan, nan.clone());
+
+    // Signed zero: different bits, equal.
+    let neg_zero = SearchResults {
+        scores: vec![-0.0],
+        ..base.clone()
+    };
+    assert_eq!(base, neg_zero);
+    assert_ne!(
+        base.scores[0].to_bits(),
+        neg_zero.scores[0].to_bits(),
+        "the two zeros should differ bitwise, or this test proves nothing",
+    );
 }
 
 #[test]


### PR DESCRIPTION
**Addresses #351 — findings 1 and 2 only.** Deliberately no `Closes`/`Fixes` keyword: GitHub's parser matches a bare closing keyword followed immediately by the issue number and discards any trailing qualifier, so it would auto-close an issue whose findings 4–7 are untouched.

**Addresses #324 — items 1, 2 and 3 plus part of the undocumented-items list. Not `Closes`:** #324(4), (6), most of the undocumented-items list, and the `IdMapIndex::add_with_ids` / `TurboQuantIndex::swap_remove` panics are untouched (`grep -c "# Panics" id_map.rs` is still 0). See "What I left" for the full list, and "MSRV" below for why #351 finding 3 is deliberately not actioned.

---

## #351(1) — `SearchResults` derives nothing

**What:** `#[derive(Debug, Clone, PartialEq)]` on `SearchResults`.

**Why:** it implemented no traits at all, on the type *every* search returns. A downstream struct holding one could not `#[derive(Debug)]`, `dbg!(results)` did not compile, results could not be cached or cloned, and `assert_eq!` was unavailable in a user's test. Every other public type already has `Debug`, and all three error enums have `Debug + Clone + PartialEq`.

`Eq`/`Hash` are deliberately absent: `scores` is `Vec<f32>`, which has no total equality.

## #351(2) — `search` had no non-panicking form

**What:** new `TurboQuantIndex::try_search` and `try_search_with_mask`, both returning `Result<SearchResults, SearchError>`.

**API shape — the reasoning, since the brief asked for it:**

- **Error type: reuse `SearchError`, don't invent one.** #318 introduced `SearchError` for the allowlist conditions on `IdMapIndex::search_with_allowlist`. The three query conditions are the same *kind* of thing — caller-supplied data the index cannot score, arriving from outside the process in a real service — so a second error type for the same operation family would be noise at the `?` site. Three variants added: `QueryBufferNotMultipleOfDim`, `InvalidQueryValue`, `MaskLengthMismatch`. The enum is `#[non_exhaustive]`, so **adding variants is not a breaking change**. The enum's doc now carries a table of which method can produce which variant, so the widened type does not become vague.
- **One genuine cost: `SearchError` loses `Eq`.** `InvalidQueryValue` carries an `f32`, exactly as `AddError::InvalidInputValue` and `FromPartsError` do — and both of those already drop `Eq` for that reason. `PartialEq` is unchanged and covers every comparison the existing variants supported. **This costs nothing to any published version: `SearchError` is itself unreleased**, landing in the same `[Unreleased]` section under #318.
- **No, this does not oblige deprecating `search`.** Deprecation would emit warnings at every existing call site for no correctness benefit. The panics are contract violations for the caller who owns their own embedder — a ragged query there is a bug in *their* code, and a panic is the right report. The crate already has this exact pairing twice (`add` alongside `add_2d`, `IdMapIndex::search` alongside `search_with_allowlist`), so the shape is the established one. Guidance is in the rustdoc on both: reach for `try_search` when the query vectors are untrusted.
- **`search()`'s signature, results and validation order are NOT changed — but its panic *text* is.** `search_with_mask` now delegates to `try_search_with_mask` and panics with the error's `Display`: one source of validation, so the two forms cannot drift, and `first_invalid_coord`'s O(nq·dim) scan still runs exactly once. Three of the four panic sites previously came from `assert_eq!` and so lose the `assertion ... failed` prefix and the `left:`/`right:` lines — see the correction sections below for measured before/after payloads.

**Evidence (test proven to fail without the fix).** New `turbovec/tests/crate_api.rs`, 10 tests, all passing. Reverted `lib.rs` + `error.rs` to `origin/main` with the test file in place and rebuilt — it fails, reproducing the issue's own error text verbatim:

```
error[E0277]: `SearchResults` doesn't implement `Debug`
error[E0277]: the trait bound `SearchResults: Clone` is not satisfied
error[E0277]: can't compare `SearchResults` with `SearchResults`
error[E0599]: no method named `try_search` found for struct `TurboQuantIndex`
error[E0599]: no method named `try_search_with_mask` found for struct `TurboQuantIndex`
error[E0599]: no variant named `QueryBufferNotMultipleOfDim` found for enum `SearchError`
error[E0599]: no variant named `InvalidQueryValue` found for enum `SearchError`
error[E0599]: no variant named `MaskLengthMismatch` found for enum `SearchError`
```

Restored, all 10 pass. The suite also pins that `try_search` returns *exactly* what `search` returns on valid input (both plain and masked), and that `SearchError` reaches a `?` in a `Box<dyn Error + Send + Sync>` handler.

---

## #324 — Rust doc drift

The brief warned that `add`'s caching changed again today and that the issue's own description may be stale. It is: I described what `origin/main` does now, verified by running it.

**#324(1) — the crate header.** It claimed `add` "extends the packed codes and invalidates the blocked layout cache by replacing its `OnceLock`". **Both halves are false on current main.** Probe against this branch's `origin/main` base:

```
after v6 load : packed_ready=false len=100
after add     : packed_ready=false len=110   <- add did NOT extend packed codes
```

The `lazy_append` branch appends encoded lanes into the blocked cache and leaves `packed_codes` unset; the eager branch patches the cache in place via `get_mut`. The `OnceLock` is not replaced on either path.

Rather than re-describe which buffer today's `add` touches — the detail that has now gone stale twice — the replacement states the **invariant that holds by construction**: *whenever the index is reachable through `&self`, every populated cache describes exactly the `len()` rows the index currently holds*, because rotation/boundaries/centroids are pure functions of `(dim, bit_width)` and the row-dependent cache is only ever touched under `&mut self`. Which of the two encodings leads is now explicitly called out as an unpromised implementation detail, with `packed_ready()` as the way to ask.

**A correction I caught in my own draft, worth flagging given the brief.** I first wrote that `swap_remove` "replaces the whole `OnceLock` to drop it". Reading `swap_remove` disproved it — it patches in place through `get_mut` exactly like `add`, moving one lane and truncating. Fixed before commit. The only site that replaces the lock outright is the TQ+ threshold crossing in `add`. Every claim in the new prose was checked against the code it describes.

**#324(2)** — `# Panics` on `rotation::Rotation::new`, naming the `MAX_DIM` (16384) ceiling that previously appeared only in a `//` comment invisible on docs.rs, and saying why this one aborts where the index constructors return `ConstructError`.

**#324(3)** — `# Panics` on all six public `io::write*` entry points, listing the TQ+-calibration, codebook-length and `slot_to_id`-length conditions, and naming the mismatch the issue points at: these abort on a length inconsistency among **four of the six** slice arguments (five of seven for the `write_id_map*` trio), which is not what an `io::Result<()>` signature leads a caller to expect. The docs also name what is *not* checked.

**#324 undocumented items** — `TurboQuantIndex::write` and `TurboQuantIndex::load` had no doc at all (despite `from_bytes` telling readers "Same validation as `Self::load`"); both now documented. `SearchResults::scores_for_query` / `indices_for_query` documented panics in prose without the heading that renders them on docs.rs; now under `# Panics`.

**#324(5) no longer reproduces — not fixed here, already fixed.** The issue reports `lazy.add_2d(&[], 64)` locking a lazy index's dim. On current main:

```
empty add_2d(dim=64) -> Ok(()), dim_opt=None
add_2d(dim=128)      -> Ok(())
```

`add_2d` returns before the lazy dim commit on a zero-row batch (#308). No change made; flagging so the issue can be trimmed rather than re-fixed.

---

## MSRV re-verification (#351 finding 3) — **the claim is REFUTED. No change made.**

#374 flagged that #351 verified this with `--ignore-rust-version`, the flag that suppresses the check being tested, and suggested the 1.83 `--all-targets` result was the credible evidence. **That evidence is also wrong, for a different and more serious reason: it was gathered on arm64.**

Reproducing the issue's result on this arm64 host, with `rust-version` genuinely lowered to `1.83` in both manifests and **no** `--ignore-rust-version` flag:

```
cargo +1.83 check -p turbovec --locked --all-targets   -> Finished
cargo +1.83 check -p turbovec-python --locked          -> Finished
```

So the claim reproduces — on ARM. But `ci.yml` records *why* the MSRV went to 1.89: the AVX-512 search kernel needs intrinsics stabilized in 1.89. That kernel is `#[cfg(target_arch = "x86_64")]`, so **on arm64 it is never compiled at all.** Cross-checking against the target CI actually builds on:

```
cargo +1.83 check -p turbovec --target x86_64-unknown-linux-gnu
  -> error[E0658]: use of unstable library feature 'stdarch_x86_avx512'   (x153)
  -> error[E0308]: mismatched types
       turbovec/src/rotation.rs:446  _mm512_i32gather_ps::<4>(idx, base)
       expected `*const u8`, found `*const f32`
  -> error: could not compile `turbovec` (lib) due to 153 previous errors
```

`stdarch_x86_avx512` stabilized in 1.89, and its signatures changed at stabilization. **The declared MSRV of 1.89 is correct and load-bearing.** Manifests reverted to 1.89; nothing to fix.

Two notes for whoever triages #351: (a) `--ignore-rust-version` was in fact the harmless part — it only suppresses the manifest metadata check, not the compiler — so #374's stated reason for doubting the claim was not the operative one; the architecture was. (b) The existing MSRV CI leg reads `rust-version` from the manifest and runs on ubuntu/x86_64, so it **would** have caught this had anyone lowered the value. #351's remark that the leg "can never catch an over-declaration" is right in principle but this particular over-declaration was not one.

---

---

## Correction pass (adversarial review of this PR)

An independent review found **no defect in the shipped code paths**, but four unverified assertions in the very text whose purpose is deleting unverified assertions. All four reproduced and fixed in `579fc7d`. No code behaviour changed.

**1. "Panic messages are identical" was false — 3 of the 4 sites changed.** I had cited the 5 pre-existing `#[should_panic(expected = ...)]` tests as evidence; those match on **substrings**, so they stayed green while the payload changed. Measured properly, via `panic::set_hook` + `catch_unwind` on this branch versus the merge base:

| site | base | this branch |
|---|---|---|
| ragged buffer | `assertion \`left == right\` failed`<br>`  left: 65`<br>` right: 64` | `query buffer length 65 not a multiple of dim 64` |
| mask length | `assertion \`left == right\` failed: mask length 99 does not match index size 16`<br>`  left: 99`<br>` right: 16` | `mask length 99 does not match index size 16` |
| mask on empty index | `assertion \`left == right\` failed: mask length 3 does not match index size 0`<br>`  left: 3`<br>` right: 0` | `mask length 3 does not match index size 0` |
| ragged, masked entry | `assertion \`left == right\` failed`<br>`  left: 65`<br>` right: 64` | `query buffer length 65 not a multiple of dim 64` |
| non-finite coord | `invalid query value at query 0, coord 3: NaN (...)` | **byte-identical** |

The new messages are strictly better (the bare `left: 65 / right: 64` named neither the buffer nor the dim), so the **claim** is corrected, not the code — in `CHANGELOG.md` and in `try_search_with_mask`'s rustdoc, not just here.

The weak test is replaced by one that pins the *whole* payload and asserts it equals the `Display` of the error the checked form returns for the same input — the actual contract between the two forms, and no longer satisfiable by a substring.

**2. "ten slice arguments" was wrong in all six new `# Panics` sections and the CHANGELOG.** I copy-pasted the phrase from #324's own prose without counting — precisely the failure mode this PR exists to fix. Counted: **6** slices for `write` / `write_with_durability` / `write_to`, **7** for the three `write_id_map*` (whose docs said "ten" and then listed a seventh bullet). Total parameter counts are 10/11/10/11/12/11, so "ten" was not right under any reading.

**3. The closing keyword on #324 over-claimed** and contradicted my own "What I left" section. Changed to a closing keyword on #351 qualified to findings 1 and 2, plus an explicit "Addresses #324 — items 1, 2, 3". (Round 2 found that qualifier does not work either — see below.)

**4. `SearchResults`' `PartialEq` doc said "bitwise-comparable scores"** — wrong in both directions. The derive uses `f32`'s `==`: `NaN != NaN` despite identical bits, and `+0.0 == -0.0` despite differing bits. So a NaN-carrying result is *not* equal to its own clone, which is exactly the case the doc claimed was "enough for `assert_eq!`". Rewritten to state IEEE semantics, and pinned by a new test that asserts both directions (including that the two zeros really do differ under `to_bits`, so the test proves something).

**Minor items from the same review, also fixed:** `Rotation::new` no longer forwards readers to an invisible `//` comment — the `MAX_DIM` rationale (signed-`i32` gather indices above 2^31, `u32` truncation at 2^32) is inlined, which is what #324(2) actually asked for; `BlockedCache` now names `prepare()` alongside `search()` as a populating path.

**Left alone deliberately:** the error path still builds the blocked cache before the mask-length check. That is the pre-existing ordering — the old `assert_eq!` lived inside the same closure — and preserving it is what makes "validation order unchanged" true. Worth a follow-up, not worth coupling to this PR. The stale `assert_eq!(queries.len(), nq*dim)` reference at `turbovec-python/tests/test_index.py:261` is also untouched: another agent is active in the Python tree, and it is a comment in a file outside this PR's surface.

**Process note I'm carrying forward:** my original clippy run was arm64-darwin native, not CI's target. It held, but this repo produced three wrong arm64-only conclusions today — including the MSRV claim below, which I refuted precisely by cross-checking the architecture. The correction pass therefore ran clippy on all three legs explicitly, and the x86_64 one immediately caught a lint the native run had not surfaced in the new test helper.

---

## Round-2 correction pass

The round-1 correction pass reproduced the failure it was fixing: it shipped two new false statements, and the `Closes` fix did not work mechanically. All three confirmed against the code and fixed in `cd2a2dc`. No code behaviour changed.

**R2-1 — "four of the five" was wrong; it is three of the four.** There are **four** validation sites (`lib.rs` `return Err` at `:1322`, `:1332`, `:1347`, `:1386`, post-merge line numbers) covering **three** documented conditions — the mask-length check has one site for an empty index and one for a populated one. Three were `assert_eq!` and changed text; the non-finite-coordinate panic was always a `panic!` and is byte-identical.

"Five" was the count of pre-existing `should_panic` *tests*, which double-counts the ragged-buffer site because it is reachable through both `search` and `search_with_mask`. My round-1 probe exercised it twice and I carried the number into shipped text in four places. Fixed in `CHANGELOG`, the `try_search_with_mask` rustdoc, the internal comment, and this body.

Also corrected there: **"substring matching is unaffected" was false for the ragged site.** At the two mask sites the message text was already inside the old assert payload, so `should_panic(expected = "mask length")` still matches. The ragged assert carried *no* message, so its old payload (`assertion \`left == right\` failed / left: 65 / right: 64`) and its new one (`query buffer length 65 not a multiple of dim 64`) have nothing in common but the two numbers.

**R2-2 — the slice arity was right but the set was wrong.** Only **four** of the six slices are ever length-checked: `codes_blocked_seq` and `scales` have no assert anywhere (`grep -n "scales.len()" io.rs` returns nothing). And `n_vectors` participates in **no** check in `write` / `write_with_durability` / `write_to` — it appears only via `slot_to_id` in the id_map trio. So three of the six docs named a quantity they do not validate, contradicted by their own bullet list two lines below. Rewritten to state what *is* checked and to name what is not.

That rewrite added a new claim — that an unchecked buffer yields a load failure rather than a panic. **It was wrong, and round 3 caught it. See R3-1 below.**

**R2-3 — a closing keyword on #351, qualified in prose to findings 1 and 2, would still have auto-closed the whole issue.** GitHub's parser reads the keyword and the number and discards the trailing qualifier, and findings 4–7 are explicitly untouched. Both issues now use `Addresses` with no closing keyword, which is what I should have done for #351 when I did it for #324.

**Nits from the same review, also fixed:** the panic-payload test helper now serializes its `set_hook` window behind a mutex — `set_hook` is process-global with no thread-local form, this binary's tests run concurrently, and the repo keeps its `FORCE_*` switches thread-local for exactly that hazard (#373); and the NaN half of the `PartialEq` test now asserts its two values are bit-identical, matching the rigour its signed-zero sibling already had.

**On the `err_expect` postmortem:** noted, and the credit was misplaced — that lint is target-independent and would have fired on `aarch64-apple-darwin` too. The real cause was a lint run that predated the helper, so the lesson is **re-run lints after the last edit**, which this pass did (clippy re-run after the final text edit, on both the native workspace and `x86_64-unknown-linux-gnu`). The genuine arm64 hazard remains what the MSRV finding showed: `#[cfg(target_arch = "x86_64")]` code that never compiles on this box.

---

## Round-3 correction pass

**R3-1 — the paragraph I wrote to fix R2-2 asserted a failure mode the loader does not have.** I ran the claim instead of reasoning it, which was the right instinct, but I ran it **once, at one geometry**, and generalised — then shipped it to six public rustdoc pages and the CHANGELOG.

Re-measured properly: a real 16×64/bw-4 index, using its own `codes_blocked_seq()` (1024 B) and `scales()` (16 f32) as a control, perturbing one buffer at a time, across **both loader paths** (`from_bytes` and the path-based v6 parser) and **two calibration states**. The review's finding reproduces, and is worse than any single geometry shows:

Across three configurations — n=16 (`WarmingUp`), n=1024 (`Fitted`), and a TQ+-empty shape — the proportion of perturbations that loaded clean and mis-scored ranged from most of them to none of them. Three configurations, three different answers, which is precisely why no failure mode can be named. The errors were not one message either: `truncated file`, `failed to fill whole buffer`, `invalid TQ+ n_calib` and `invalid per-vector scale` all appear depending on where the shift lands. The one invariant: a **compensating pair that preserves the total byte count** loads clean and mis-scores every time, because no later section shifts and so no header-derived check can fire.

The counts and the full perturbation list live in **[#407](https://github.com/RyanCodrai/turbovec/issues/407#issuecomment-5125284418)**, not in the rustdoc — see R4-2 below for why.

The docs now say the two buffers are unchecked *by the writer* and the outcome is **undefined in practice** — sometimes an error, sometimes a clean load with wrong scores, depending on what the shifted bytes land on — and reference **#407** rather than attempting a loader fix here. My original `140/156/144/152` byte counts came from a 4-vector index with empty TQ+ arrays, a third shape again, which is exactly how a one-off measurement misleads.

**R3-2 — the `HOOK_GUARD` comment claimed a fix it does not deliver.** Correct: other tests never take the lock, so the cross-test swallow window is still open, and with a single caller it serializes nothing. The mutex stays, but the comment now says plainly that it does *not* close that window, states what it is actually for (preventing a nested or widened window if a second caller is added), and names the real mitigation — the window is microseconds around a call expected to panic — plus a debugging hint if a test in that file ever fails with no output.

**R3-3** — the superseded `err_expect` attribution has been removed from the Verification section; the accurate version above is now the only one in this body.

**R3-4** — test count corrected to **331** (pre-merge). Re-measured after the `origin/main` merge: **338**. See Verification.

**R3-5** — "share no text at all" was absolute and false; the payloads share `65` and `64`. Softened to "nothing in common but the two numbers" in the rustdoc, the CHANGELOG and this body.

**On the pattern.** Three rounds, three blockers, and every one was a claim I reasoned rather than ran — and every one closed once measured. R3-1 is the sharpest version: I did run it, but a single sample of a data-dependent behaviour is not a measurement, it is an anecdote. The rewrite is therefore phrased as a range with the sweep behind it, not as a mode.

---

## Round-4 correction pass

The reviewer no longer blocks the merge; two items remained, both inside the paragraph the round-3 pass rewrote.

**R4-1 — "not length-checked — here or anywhere" was a false absolute.** The loader *does* length-check; it just does so unreliably. In the TQ+-empty configuration the header-derived length and fill checks are the *dominant* failure mode, firing by name (`truncated file: expected 64 bytes, got 60`, `failed to fill whole buffer`). The accurate scope is the **writer**, which applies no length check to these two arguments at all. Corrected in all six `# Panics` paragraphs and the CHANGELOG.

This one errs safe where R3-1 did not — it under-promised a protection that partly exists, rather than promising one that does not — but it is still a false absolute on the third rewrite of the same paragraph, which is the more interesting fact about it.

**R4-2 — the published counts were not re-derivable.** I gave `9/15` and `1/15` without ever publishing which 15 perturbations, so no reader could check them. An independent sweep got `8/15`, `0/15`, `0/15` and top scores of 1.0022–1.0544 where I saw 1.068.

Every *qualitative* claim reproduced across both sweeps; only the counts moved. That is not a discrepancy to reconcile — it is the defect restating itself, since the outcome is a function of what the shifted bytes happen to contain, and two independent sweeps disagreeing on counts while agreeing on everything qualitative is the strongest available argument that no failure mode can be named. The counts and the full 15-perturbation list are now in [#407](https://github.com/RyanCodrai/turbovec/issues/407#issuecomment-5125284418), flagged as indicative rather than as a fixture; the rustdoc keeps only the qualitative statements.

The claim that genuinely generalises is kept, and is now stated structurally rather than statistically: a compensating pair preserving the total byte count shifts nothing downstream, so no header-derived check *can* fire — which is why it held 12/12 in the reviewer's sweep and in every configuration of mine, including the n=1024 case where every single-buffer perturbation was caught.

**Informational item, also fixed here:** the n=16 configuration is `calibration_state() == WarmingUp`, not `Fitted` — verified by running it; `Fitted` begins at n=1024. The TQ+ arrays *are* populated at n=16, which is what my label confused. That mislabel had reached this PR body as well as the commit message, so the table above is corrected.

---

## Verification

- `cargo test -p turbovec` after merging `origin/main` (PR #404) — **338 passed, 0 failed**: 335 tests across 22 test binaries plus 3 doctests. The earlier **331** figure was measured on the pre-merge head; the merge brought in the `lib.rs` unit tests from #404. Counted by summing every `test result:` line, not eyeballed.
- `cargo clippy` at the pinned `1.97.0` with `ci.yml`'s exact flag list — **clean on** `--target x86_64-unknown-linux-gnu` (CI's native leg), `--target aarch64-unknown-linux-gnu` (CI's cross leg) and the native workspace, re-run after the last text edit. Nothing added to the allow-list.
- `cargo doc -p turbovec --no-deps` — warning set is **byte-identical to `origin/main`** (14 before, 14 after; diffed by message). No new rustdoc warnings, and none of the pre-existing ones (#351 finding 4) fixed here.
- CHANGELOG entries added under `[Unreleased]` → Rust crate: `try_search` under Added, the `SearchResults` derives and the `SearchError` widening under Changed, the doc fixes under Fixed.

## What I left

- **#351(3)** — refuted above; issue item should be closed as not-a-bug.
- **#351(4)** (13 pre-existing rustdoc warnings), **(5)** (`statrs` dependency weight), **(6)** (`IdMapIndex::search` returns a bare tuple), **(7)** (`downstream-smoke` coverage) — all untouched; each is a separate change with its own risk profile, and (6) in particular is a breaking signature change that wants its own decision.
- **#324(4)** (`single_query_parallelizes` vs the x86 `simd_ok` term) — untouched. It is in `search.rs`, which the concurrent perf work is active in, and the issue marks it inspection-only.
- **#324(6)** (`no_run` doctests) — untouched.
- `id_map.rs` and the Python bindings deliberately not touched, per the parallel-agent boundary. `IdMapIndex::search_with_allowlist` still panics on the query-shape conditions exactly as before; its `.expect("search_with_allowlist cannot fail without an allowlist")` remains accurate, since it delegates to the panicking `search_with_mask`. That `Result`-that-panics shape is pre-existing and is now tracked separately as **#412**, which also records why the one-line fix is a trap (it degrades `IdMapIndex::search`'s panic payload and breaks `input_validation.rs:229`).
- A `bit_width >= 64` hole in `io::write_to`'s `assert_codebook_lengths` (`io.rs:782`, `1usize << bit_width`) is also pre-existing — this PR only added the doc comment above it. It fails closed (both readers reject the file) and is unreachable from any validated path, but it panics differently in debug than in release. Tracked as **#411**, which also flags the "four of the six slice arguments" wording in the six new `# Panics` sections for reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)








