### PR TITLE
fix: release the add scratch and snapshot buffers after a bulk load (#333)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,20 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install maturin pytest
 
+      # Every `cargo test` in the repo is `-p turbovec` (the two Rust legs
+      # above and release-crates.yml), and this job only built a wheel and
+      # ran pytest — so `turbovec-python`'s own lib tests, the crate's first
+      # `#[cfg(test)]` module, had no executor at all. Clippy's
+      # `--workspace --all-targets` pass type-checks them, which is not the
+      # same as running them. They run here rather than in the Rust matrix
+      # because they have to link libpython, and this is the job with an
+      # interpreter on all three OSes: `--no-default-features` turns off
+      # `extension-module` (see turbovec-python/Cargo.toml), and pyo3 then
+      # emits the link line plus an rpath to the `setup-python` install.
+      - name: turbovec-python lib tests
+        shell: bash
+        run: cargo test -p turbovec-python --lib --no-default-features --locked
+
       - name: Build turbovec wheel
         shell: bash
         working-directory: turbovec-python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,23 +344,34 @@ appears under each surface it touches.
 #### Fixed
 
 - **A one-shot bulk `add()` no longer pins its rotated-batch scratch for
-  the index's lifetime (#333).** The encode scratch shrank only when
+  the index's lifetime (#333).** The encode scratch only shrank when
   `capacity > 4 x this call's length` — a test the call that *grew* the
-  buffer can never pass — and even when it did pass, `Vec::shrink_to`
-  never goes below `len`, which `encode` leaves at the full `n * dim`.
-  Both halves had to go: retention is now a high-water decay to
-  `max(4 MiB, the previous call's length)`, applied after a `truncate`.
-  A one-shot bulk load therefore releases the buffer on the call that
-  allocated it, while a steady stream of same-size adds keeps `prev ==
-  want` and so keeps its warm allocation — no per-add reallocation.
-  Measured with a counting global allocator, 200k x 768 at 2-bit
-  (37.5 MB of codes): live heap retained after the add and after
-  dropping the input falls from 623.4 MB to 41.5 MB; three such indexes
-  fall from 1870.1 MB to 124.3 MB. Steady-state add throughput is
-  unchanged at both default threads and `RAYON_NUM_THREADS=1` — the new
-  policy costs exactly two extra >=1 MiB allocations over an index's
-  life (one shrink, one regrow if a second large add follows), and none
-  thereafter.
+  buffer can never pass, since growing leaves capacity and length equal.
+  So the batch that allocated the buffer was exactly the one that could
+  not release it, and a copy-paste `index.add(embeddings)` kept a full
+  rotated copy of the batch until the index was dropped. (A later,
+  smaller add *did* release it; retention was permanent only for the
+  common shape where no smaller add follows.)
+  Retention is now sized from the previous call's demand plus half again,
+  and only applied when capacity exceeds twice that. The slack preserves
+  the amortized growth headroom a growing or jittering batch size relies
+  on, and the hysteresis keeps ordinary shapes from shrinking at all;
+  a one-shot bulk add has no previous demand and so releases outright.
+  There is no retention floor — `Vec::reserve` from zero capacity
+  allocates once, so a floor has no allocation cascade to prevent.
+  Measured with a counting global allocator, dim 768 at 2-bit, single
+  thread: a 200k one-shot add retains **623.3 MB before, 37.4 MB after**
+  against a 36.6 MB index, and the total allocation count over a run is
+  unchanged to within one — 520 -> 521 for twelve equal 50k adds,
+  743 -> 744 for twenty adds growing 5% each, 740 -> 741 for twenty
+  jittering between 45k and 55k. Add throughput is unchanged at default
+  threads and at `RAYON_NUM_THREADS=1`.
+  Note the numbers above are live heap. On macOS this does not show up in
+  RSS at all: `ps` reports the same resident size with and without the
+  fix, for reasons not fully established — the freed spans stay resident
+  even in a sequential build-and-drop loop where they ought to be reused.
+  The allocator-level win is solid; the resident-size win is unverified
+  on any platform.
 
 - **A panicking first add no longer wedges a lazy index at a committed
   dim (#380).** `add_2d` locked the inferred dim before the encode, so a
@@ -817,14 +828,14 @@ appears under each surface it touches.
 
 - **A one-shot bulk `add()` / `add_with_ids()` no longer pins its
   GIL-safety snapshot for the index's lifetime (#333).** The snapshot
-  buffer carried the same dead shrink condition as the core scratch and
-  is fixed the same way — a `truncate` followed by a shrink to
-  `max(4 MiB, the previous call's length)`. Combined with the core fix
-  this removes both copies of a bulk batch that an index used to hold
-  after `add()` returned. Note that on macOS this is not visible in
-  RSS: libmalloc keeps the freed spans mapped, so `ps` reports the same
-  resident size before and after the fix even though the live heap
-  drops by an order of magnitude.
+  buffer carried the same unsatisfiable shrink condition as the core's
+  encode scratch and now follows the same policy — retain the previous
+  call's length plus half again, and only shrink when capacity exceeds
+  twice that. Together with the core fix this drops both copies of a bulk
+  batch that an index used to hold after `add()` returned.
+  As with the core entry, the measured win is in live heap and does not
+  appear in macOS RSS, for reasons not fully established; treat the
+  resident-size effect as unverified.
 
 - **agno: a failed load no longer leaves a half-loaded store (#380).**
   `_load_from` replaced `_index`, `_u64_to_doc`, `_next_u64` and all three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,6 +326,25 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A one-shot bulk `add()` no longer pins its rotated-batch scratch for
+  the index's lifetime (#333).** The encode scratch shrank only when
+  `capacity > 4 x this call's length` — a test the call that *grew* the
+  buffer can never pass — and even when it did pass, `Vec::shrink_to`
+  never goes below `len`, which `encode` leaves at the full `n * dim`.
+  Both halves had to go: retention is now a high-water decay to
+  `max(4 MiB, the previous call's length)`, applied after a `truncate`.
+  A one-shot bulk load therefore releases the buffer on the call that
+  allocated it, while a steady stream of same-size adds keeps `prev ==
+  want` and so keeps its warm allocation — no per-add reallocation.
+  Measured with a counting global allocator, 200k x 768 at 2-bit
+  (37.5 MB of codes): live heap retained after the add and after
+  dropping the input falls from 623.4 MB to 41.5 MB; three such indexes
+  fall from 1870.1 MB to 124.3 MB. Steady-state add throughput is
+  unchanged at both default threads and `RAYON_NUM_THREADS=1` — the new
+  policy costs exactly two extra >=1 MiB allocations over an index's
+  life (one shrink, one regrow if a second large add follows), and none
+  thereafter.
+
 - **A caught panic in the eager add's cache repack no longer leaves the
   stored codes ahead of the row count (#388).** The blocked-cache patch is
   fallible, and `packed_codes` and `scales` were published before it while
@@ -744,6 +763,17 @@ appears under each surface it touches.
   unchanged. (#167)
 
 #### Fixed
+
+- **A one-shot bulk `add()` / `add_with_ids()` no longer pins its
+  GIL-safety snapshot for the index's lifetime (#333).** The snapshot
+  buffer carried the same dead shrink condition as the core scratch and
+  is fixed the same way — a `truncate` followed by a shrink to
+  `max(4 MiB, the previous call's length)`. Combined with the core fix
+  this removes both copies of a bulk batch that an index used to hold
+  after `add()` returned. Note that on macOS this is not visible in
+  RSS: libmalloc keeps the freed spans mapped, so `ps` reports the same
+  resident size before and after the fix even though the live heap
+  drops by an order of magnitude.
 
 - **agno: a half-present save loaded silently empty and was then
   overwritten (#328).** `create()` caught the `FileNotFoundError` that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,8 +317,10 @@ appears under each surface it touches.
   unreleased, so no published index is affected.
 - `add` on a populated index no longer holds allocation-sized
   intermediates: encode appends in place and reuses a per-index scratch
-  buffer, which is shrunk whenever it exceeds 4x the current batch's
-  need.
+  buffer. The buffer is retained at the previous call's demand plus half
+  again, and only shrunk when its capacity exceeds twice that — so
+  repeated, growing and jittering batch sizes keep their warm allocation,
+  while a one-shot bulk load has no previous demand and releases outright.
 - **`MAX_DIM` lowered from 65536 to 16384.** A loaded `.tv`/`.tvim`
   header declaring a huge `dim` drives allocations (codebook, blocked
   layout, per-query rotate scratch) not bounded by the file's own size,

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -8,9 +8,22 @@ rust-version = "1.89"
 name = "_turbovec"
 crate-type = ["cdylib"]
 
+[features]
+# On by default, so `cargo build`, clippy and maturin (which also passes
+# `pyo3/extension-module` explicitly, see pyproject.toml) are unaffected.
+# It exists as a feature only so it can be switched *off*: with it on, pyo3
+# emits no libpython link line, which is right for a dynamically-loaded
+# `.so` and wrong for anything that has to link — the crate's own lib tests
+# then fail to link against `Py_IncRef`/`_Py_NoneStruct` (they happen to
+# link in a debug profile only because dead-stripping drops the references,
+# and not under `--release`, where LTO keeps them). CI runs those tests as
+# `--no-default-features` against the interpreter `setup-python` provides.
+default = ["extension-module"]
+extension-module = ["pyo3/extension-module"]
+
 [dependencies]
 turbovec-core = { package = "turbovec", path = "../turbovec" }
-pyo3 = { version = "0.29.0", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
 numpy = "0.29.0"
 # Same major as the core's dep, so both resolve to one rayon-core and the
 # process-local pool `with_pool` installs is the pool the kernels use.

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -343,11 +343,11 @@ const SNAP_RETAIN_MIN: usize = 1 << 20;
 /// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
 /// `len`, and the buffer is left holding the full snapshot, so
 /// `shrink_to` on its own is a no-op whatever target it is given.
+/// (`truncate` is itself a no-op when the length is already at or below
+/// the target, so it needs no guard.)
 fn retain_snap(snap: &mut Vec<f32>, prev: &std::sync::atomic::AtomicUsize, want: usize) {
     let target = SNAP_RETAIN_MIN.max(prev.swap(want, std::sync::atomic::Ordering::Relaxed));
-    if snap.len() > target {
-        snap.truncate(target);
-    }
+    snap.truncate(target);
     snap.shrink_to(target);
 }
 
@@ -1625,6 +1625,23 @@ mod snap_retention_tests {
         assert!(
             snap.capacity() <= SNAP_RETAIN_MIN,
             "one-shot bulk add retained {} snapshot elements (input was {big})",
+            snap.capacity(),
+        );
+    }
+
+    /// See the core's `the_retention_floor_is_four_mib_of_f32`: the two
+    /// direction tests are satisfied by any floor, including zero, so
+    /// the value itself is pinned as a literal.
+    #[test]
+    fn the_retention_floor_is_four_mib_of_f32() {
+        assert_eq!(SNAP_RETAIN_MIN, 1 << 20);
+        assert_eq!(SNAP_RETAIN_MIN * std::mem::size_of::<f32>(), 4 << 20);
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        one_add(&mut snap, &prev, 8 * SNAP_RETAIN_MIN);
+        assert!(
+            snap.capacity() >= SNAP_RETAIN_MIN,
+            "the floor was not retained: capacity {}",
             snap.capacity(),
         );
     }

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -326,29 +326,30 @@ fn lock_write_gil_aware<'l, T: Send + Sync>(
 // free from the GIL). A guard is only ever released from code that does
 // not need the GIL to finish, so no lock/GIL deadlock cycle exists.
 
-/// Floor for snapshot retention, in `f32` elements (4 MiB). Mirrors the
-/// core's scratch policy; see [`retain_snap`].
-const SNAP_RETAIN_MIN: usize = 1 << 20;
-
-/// Shrink a reused snapshot buffer to a high-water decay target, and
-/// record this call's demand in `prev` for the next one.
+/// Release a reused snapshot buffer that is far larger than the adds
+/// around it need, and record this call's demand in `prev` for the next.
 ///
-/// Retaining `max(SNAP_RETAIN_MIN, previous call's length)` releases a
-/// one-shot bulk load's buffer immediately while leaving a steady stream
-/// of same-size adds at `prev == want`, where the target equals the live
-/// length and neither call below does anything — so the warm-buffer
-/// reuse this snapshot exists for is preserved. A one-off big add costs
-/// one shrink now and one regrow if a second big add follows.
+/// The same policy the core applies to its encode scratch, for the same
+/// reasons — see `turbovec_core`'s `retain_scratch`. The target is the
+/// previous call's length plus half again, and the buffer is only
+/// touched when its capacity exceeds twice that: the slack preserves the
+/// amortized growth headroom that a growing or jittering batch size
+/// depends on, and the hysteresis keeps every ordinary shape at zero
+/// extra allocations. A one-shot bulk load has `prev == 0` and so
+/// releases the whole buffer on the call that allocated it.
 ///
-/// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
-/// `len`, and the buffer is left holding the full snapshot, so
-/// `shrink_to` on its own is a no-op whatever target it is given.
-/// (`truncate` is itself a no-op when the length is already at or below
-/// the target, so it needs no guard.)
+/// `truncate` before `shrink_to` is load-bearing on that release path:
+/// `shrink_to` never goes below `len`, and the buffer is left holding
+/// the full snapshot, which is above the target whenever there is
+/// anything to release. (`truncate` is itself a no-op when the length is
+/// already at or below the target.)
 fn retain_snap(snap: &mut Vec<f32>, prev: &std::sync::atomic::AtomicUsize, want: usize) {
-    let target = SNAP_RETAIN_MIN.max(prev.swap(want, std::sync::atomic::Ordering::Relaxed));
-    snap.truncate(target);
-    snap.shrink_to(target);
+    let prev = prev.swap(want, std::sync::atomic::Ordering::Relaxed);
+    let target = prev.saturating_add(prev / 2);
+    if snap.capacity() > target.saturating_mul(2) {
+        snap.truncate(target);
+        snap.shrink_to(target);
+    }
 }
 
 #[pyclass(frozen)]
@@ -360,8 +361,8 @@ struct TurboQuantIndex {
     /// duration of one add and put back after, so concurrent adds
     /// simply fall back to a fresh buffer.
     snap: std::sync::Mutex<Vec<f32>>,
-    /// Element count the *previous* `add` snapshotted, driving
-    /// [`retain_snap`]'s high-water decay (#333). Advisory in the same
+    /// Element count the *previous* `add` snapshotted, sizing
+    /// [`retain_snap`]'s retention target (#333). Advisory in the same
     /// sense `snap` is: concurrent adds may interleave their updates, so
     /// the recorded demand can be a different call's. That only costs a
     /// resize — the buffer is scratch either way.
@@ -1600,11 +1601,12 @@ fn _turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[cfg(test)]
 mod snap_retention_tests {
     //! The `add` snapshot buffer is private scratch with no Python-visible
-    //! handle, and macOS RSS does not fall when it is freed (libmalloc
-    //! keeps the span mapped), so its retention can only be pinned here
-    //! (#333).
+    //! handle, and macOS RSS does not move when it is freed, so its
+    //! retention can only be pinned here (#333). These drive `retain_snap`
+    //! through the buffer sequence `add` performs; the wiring of the call
+    //! into `add` itself is not covered — see the note in the PR.
 
-    use super::{retain_snap, SNAP_RETAIN_MIN};
+    use super::retain_snap;
     use std::sync::atomic::AtomicUsize;
 
     /// One `add`'s worth of buffer handling: the snapshot is refilled to
@@ -1612,43 +1614,27 @@ mod snap_retention_tests {
     /// into the mutex.
     fn one_add(snap: &mut Vec<f32>, prev: &AtomicUsize, len: usize) {
         snap.clear();
+        snap.reserve(len);
         snap.resize(len, 0.0);
         retain_snap(snap, prev, len);
     }
 
     #[test]
     fn one_shot_bulk_add_releases_the_snapshot() {
-        let big = 8 * SNAP_RETAIN_MIN;
+        let big = 8 << 20;
         let prev = AtomicUsize::new(0);
         let mut snap = Vec::new();
         one_add(&mut snap, &prev, big);
         assert!(
-            snap.capacity() <= SNAP_RETAIN_MIN,
+            snap.capacity() < big / 4,
             "one-shot bulk add retained {} snapshot elements (input was {big})",
-            snap.capacity(),
-        );
-    }
-
-    /// See the core's `the_retention_floor_is_four_mib_of_f32`: the two
-    /// direction tests are satisfied by any floor, including zero, so
-    /// the value itself is pinned as a literal.
-    #[test]
-    fn the_retention_floor_is_four_mib_of_f32() {
-        assert_eq!(SNAP_RETAIN_MIN, 1 << 20);
-        assert_eq!(SNAP_RETAIN_MIN * std::mem::size_of::<f32>(), 4 << 20);
-        let prev = AtomicUsize::new(0);
-        let mut snap = Vec::new();
-        one_add(&mut snap, &prev, 8 * SNAP_RETAIN_MIN);
-        assert!(
-            snap.capacity() >= SNAP_RETAIN_MIN,
-            "the floor was not retained: capacity {}",
             snap.capacity(),
         );
     }
 
     #[test]
     fn repeated_same_size_adds_keep_the_snapshot_warm() {
-        let big = 8 * SNAP_RETAIN_MIN;
+        let big = 8 << 20;
         let prev = AtomicUsize::new(0);
         let mut snap = Vec::new();
         for _ in 0..3 {
@@ -1657,6 +1643,45 @@ mod snap_retention_tests {
         assert!(
             snap.capacity() >= big,
             "steady same-size adds dropped the warm snapshot to {} elements (need {big})",
+            snap.capacity(),
+        );
+    }
+
+    /// Shrinking to the bare previous length would leave a growing batch
+    /// size with no headroom, so every add would grow and be shrunk
+    /// again. See the core's `growing_batch_sizes_keep_their_growth_headroom`.
+    #[test]
+    fn growing_batch_sizes_keep_their_growth_headroom() {
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        let mut len = 1 << 20;
+        let mut last = 0;
+        for _ in 0..6 {
+            one_add(&mut snap, &prev, len);
+            last = len;
+            len += len / 20; // +5% per batch
+        }
+        assert!(
+            snap.capacity() >= last,
+            "a growing batch size left only {} snapshot elements after a \
+             {last}-element add",
+            snap.capacity(),
+        );
+    }
+
+    #[test]
+    fn jittering_batch_sizes_keep_their_growth_headroom() {
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        let sizes = [
+            7_200_000, 8_800_000, 7_600_000, 8_640_000, 7_360_000, 8_320_000,
+        ];
+        for len in sizes {
+            one_add(&mut snap, &prev, len);
+        }
+        assert!(
+            snap.capacity() >= 8_320_000,
+            "a jittering batch size left only {} snapshot elements",
             snap.capacity(),
         );
     }

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1688,6 +1688,25 @@ mod snap_retention_tests {
         );
     }
 
+    /// Retention must not equal the largest single add ever made: a
+    /// spike in a run of smaller batches has to be given back. See the
+    /// core's `a_one_off_spike_does_not_stay_pinned`.
+    #[test]
+    fn a_one_off_spike_does_not_stay_pinned() {
+        let n = 2 << 20;
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        one_add(&mut snap, &prev, n);
+        one_add(&mut snap, &prev, 4 * n);
+        one_add(&mut snap, &prev, n);
+        assert!(
+            snap.capacity() < 4 * n,
+            "a 4x spike left {} snapshot elements pinned after the batch \
+             size dropped back to {n}",
+            snap.capacity(),
+        );
+    }
+
     #[test]
     fn jittering_batch_sizes_keep_their_growth_headroom() {
         let prev = AtomicUsize::new(0);

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -772,6 +772,17 @@ impl TurboQuantIndex {
     fn bit_width(&self, py: Python<'_>) -> usize {
         py.detach(|| lock_read(&self.inner).bit_width())
     }
+
+    /// Element capacity currently retained by the `add` snapshot buffer.
+    ///
+    /// Internal, for tests only, and deliberately not part of the public
+    /// API: the buffer is private scratch with no Python-visible handle,
+    /// and macOS RSS does not move when it is freed, so `retain_snap`'s
+    /// effect on a *real* `add` cannot be observed from Python any other
+    /// way (#333). `tests/test_snap_retention.py` is the only caller.
+    fn _snap_capacity(&self) -> usize {
+        self.snap.lock().expect("snap lock poisoned").capacity()
+    }
 }
 
 #[pyclass(frozen)]
@@ -1184,6 +1195,11 @@ impl IdMapIndex {
     #[getter]
     fn bit_width(&self, py: Python<'_>) -> usize {
         py.detach(|| lock_read(&self.inner).bit_width())
+    }
+
+    /// See `TurboQuantIndex::_snap_capacity`. Internal, tests only.
+    fn _snap_capacity(&self) -> usize {
+        self.snap.lock().expect("snap lock poisoned").capacity()
     }
 }
 
@@ -1598,11 +1614,18 @@ fn _turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod snap_retention_tests {
-    //! The `add` snapshot buffer is private scratch with no Python-visible
-    //! handle, and macOS RSS does not move when it is freed, so its
-    //! retention can only be pinned here (#333). These drive `retain_snap`
-    //! through the buffer sequence `add` performs; the wiring of the call
-    //! into `add` itself is not covered — see the note in the PR.
+    //! Policy tests for [`retain_snap`] (#333): they drive it through the
+    //! buffer sequence `add` performs, over the batch-size shapes the
+    //! retention target has to get right (one-shot bulk, steady, growing,
+    //! jittering, step-up, spike). They deliberately do *not* cover the
+    //! wiring — deleting the `retain_snap` call in `add` leaves every test
+    //! here green, because none of them go through `add`.
+    //!
+    //! That wiring is pinned from Python instead, in
+    //! `tests/test_snap_retention.py`, via `_snap_capacity`: reaching the
+    //! real call site from a Rust test would need a live interpreter and a
+    //! numpy round trip inside a crate built as an extension module, and
+    //! the buffer has no Python-visible handle otherwise.
 
     use super::retain_snap;
     use std::sync::atomic::AtomicUsize;

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -326,6 +326,31 @@ fn lock_write_gil_aware<'l, T: Send + Sync>(
 // free from the GIL). A guard is only ever released from code that does
 // not need the GIL to finish, so no lock/GIL deadlock cycle exists.
 
+/// Floor for snapshot retention, in `f32` elements (4 MiB). Mirrors the
+/// core's scratch policy; see [`retain_snap`].
+const SNAP_RETAIN_MIN: usize = 1 << 20;
+
+/// Shrink a reused snapshot buffer to a high-water decay target, and
+/// record this call's demand in `prev` for the next one.
+///
+/// Retaining `max(SNAP_RETAIN_MIN, previous call's length)` releases a
+/// one-shot bulk load's buffer immediately while leaving a steady stream
+/// of same-size adds at `prev == want`, where the target equals the live
+/// length and neither call below does anything — so the warm-buffer
+/// reuse this snapshot exists for is preserved. A one-off big add costs
+/// one shrink now and one regrow if a second big add follows.
+///
+/// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
+/// `len`, and the buffer is left holding the full snapshot, so
+/// `shrink_to` on its own is a no-op whatever target it is given.
+fn retain_snap(snap: &mut Vec<f32>, prev: &std::sync::atomic::AtomicUsize, want: usize) {
+    let target = SNAP_RETAIN_MIN.max(prev.swap(want, std::sync::atomic::Ordering::Relaxed));
+    if snap.len() > target {
+        snap.truncate(target);
+    }
+    snap.shrink_to(target);
+}
+
 #[pyclass(frozen)]
 struct TurboQuantIndex {
     /// Reusable GIL-safety snapshot buffer for `add`. Purely scratch:
@@ -335,6 +360,12 @@ struct TurboQuantIndex {
     /// duration of one add and put back after, so concurrent adds
     /// simply fall back to a fresh buffer.
     snap: std::sync::Mutex<Vec<f32>>,
+    /// Element count the *previous* `add` snapshotted, driving
+    /// [`retain_snap`]'s high-water decay (#333). Advisory in the same
+    /// sense `snap` is: concurrent adds may interleave their updates, so
+    /// the recorded demand can be a different call's. That only costs a
+    /// resize — the buffer is scratch either way.
+    snap_prev: std::sync::atomic::AtomicUsize,
     inner: std::sync::RwLock<turbovec_core::TurboQuantIndex>,
 }
 
@@ -359,6 +390,7 @@ impl TurboQuantIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -431,12 +463,10 @@ impl TurboQuantIndex {
             with_pool_if(pooled, || inner.add_2d(&owned, dim))
         })?
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-        // Shrink before returning the buffer when it is far larger than
-        // this call needed, so a one-time bulk load doesn't pin its full
-        // snapshot capacity for the index lifetime.
-        if owned.capacity() > 4 * slice.len() {
-            owned.shrink_to(slice.len());
-        }
+        // Shrink before returning the buffer, so a one-time bulk load
+        // doesn't pin its full snapshot capacity for the index lifetime
+        // (#333).
+        retain_snap(&mut owned, &self.snap_prev, slice.len());
         *self.snap.lock().expect("snap lock poisoned") = owned;
         Ok(())
     }
@@ -579,6 +609,7 @@ impl TurboQuantIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -619,6 +650,7 @@ impl TurboQuantIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -749,6 +781,8 @@ impl TurboQuantIndex {
 struct IdMapIndex {
     /// See `TurboQuantIndex::snap`.
     snap: std::sync::Mutex<Vec<f32>>,
+    /// See `TurboQuantIndex::snap_prev`.
+    snap_prev: std::sync::atomic::AtomicUsize,
     inner: std::sync::RwLock<turbovec_core::IdMapIndex>,
 }
 
@@ -773,6 +807,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -819,9 +854,7 @@ impl IdMapIndex {
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
         // Same shrink policy as TurboQuantIndex::add.
         let mut v_owned = v_owned;
-        if v_owned.capacity() > 4 * v_slice.len() {
-            v_owned.shrink_to(v_slice.len());
-        }
+        retain_snap(&mut v_owned, &self.snap_prev, v_slice.len());
         *self.snap.lock().expect("snap lock poisoned") = v_owned;
         Ok(())
     }
@@ -1064,6 +1097,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -1105,6 +1139,7 @@ impl IdMapIndex {
         Ok(Self {
             inner: std::sync::RwLock::new(inner),
             snap: std::sync::Mutex::new(Vec::new()),
+            snap_prev: std::sync::atomic::AtomicUsize::new(0),
         })
     }
 
@@ -1560,4 +1595,52 @@ fn _turbovec(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TurboQuantIndex>()?;
     m.add_class::<IdMapIndex>()?;
     Ok(())
+}
+
+#[cfg(test)]
+mod snap_retention_tests {
+    //! The `add` snapshot buffer is private scratch with no Python-visible
+    //! handle, and macOS RSS does not fall when it is freed (libmalloc
+    //! keeps the span mapped), so its retention can only be pinned here
+    //! (#333).
+
+    use super::{retain_snap, SNAP_RETAIN_MIN};
+    use std::sync::atomic::AtomicUsize;
+
+    /// One `add`'s worth of buffer handling: the snapshot is refilled to
+    /// the input length, then passed to `retain_snap` on the way back
+    /// into the mutex.
+    fn one_add(snap: &mut Vec<f32>, prev: &AtomicUsize, len: usize) {
+        snap.clear();
+        snap.resize(len, 0.0);
+        retain_snap(snap, prev, len);
+    }
+
+    #[test]
+    fn one_shot_bulk_add_releases_the_snapshot() {
+        let big = 8 * SNAP_RETAIN_MIN;
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        one_add(&mut snap, &prev, big);
+        assert!(
+            snap.capacity() <= SNAP_RETAIN_MIN,
+            "one-shot bulk add retained {} snapshot elements (input was {big})",
+            snap.capacity(),
+        );
+    }
+
+    #[test]
+    fn repeated_same_size_adds_keep_the_snapshot_warm() {
+        let big = 8 * SNAP_RETAIN_MIN;
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        for _ in 0..3 {
+            one_add(&mut snap, &prev, big);
+        }
+        assert!(
+            snap.capacity() >= big,
+            "steady same-size adds dropped the warm snapshot to {} elements (need {big})",
+            snap.capacity(),
+        );
+    }
 }

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -1669,6 +1669,25 @@ mod snap_retention_tests {
         );
     }
 
+    /// A batch that steps up sharply and then holds must not have the
+    /// step shrunk away underneath it — the hysteresis alone does not
+    /// cover a 3x step. See the core's
+    /// `a_step_up_in_batch_size_is_not_shrunk_back`.
+    #[test]
+    fn a_step_up_in_batch_size_is_not_shrunk_back() {
+        let small = 2 << 20;
+        let big = 3 * small;
+        let prev = AtomicUsize::new(0);
+        let mut snap = Vec::new();
+        one_add(&mut snap, &prev, small);
+        one_add(&mut snap, &prev, big);
+        assert!(
+            snap.capacity() >= big,
+            "a {small}->{big} step left only {} snapshot elements",
+            snap.capacity(),
+        );
+    }
+
     #[test]
     fn jittering_batch_sizes_keep_their_growth_headroom() {
         let prev = AtomicUsize::new(0);

--- a/turbovec-python/tests/test_snap_retention.py
+++ b/turbovec-python/tests/test_snap_retention.py
@@ -1,0 +1,110 @@
+"""A one-shot bulk ``add`` must not pin its GIL-safety snapshot (#333).
+
+Both bindings snapshot the caller's numpy buffer before releasing the GIL
+and keep that buffer on the index so repeated adds reuse one warm
+allocation. The shrink that hands a one-off bulk batch back was dead, so
+``index.add(embeddings)`` retained a full float32 copy of the batch —
+roughly 2x the input array, since the core's encode scratch held the
+other copy — for the index's lifetime.
+
+The Rust-side tests in ``snap_retention_tests`` cover the retention
+*policy* across batch-size shapes, but they drive the helper directly, so
+they cannot see whether ``add`` still calls it. These tests go through the
+real ``add`` / ``add_with_ids`` and read the buffer back through
+``_snap_capacity``, the internal accessor that exists for exactly this
+(the buffer has no other Python-visible handle, and macOS RSS does not
+move when it is freed, so an allocator- or RSS-level assertion would not
+be a gate on every platform). Deleting either ``retain_snap`` call site
+fails a test here.
+
+Note which call reaches the binding with the whole array. The Python layer
+slices an add into ``BATCH_CHUNK_SIZE`` rows for Ctrl-C latency, but only
+once the TQ+ calibration has settled — the calibrating add must run whole
+so slicing cannot change how a vector encodes. So the *first* bulk add on
+a fresh index is delegated entire, which is both the shape the issue
+reported and the only one that can pin a batch-sized buffer. The tests
+assert that precondition rather than assuming it.
+
+Sizes are chosen to be unambiguous rather than large: the buffer either
+holds the whole batch or ~none of it, and the thresholds sit a factor of
+four away from both outcomes, so nothing here depends on allocator
+behaviour or on the exact retention target.
+"""
+
+import numpy as np
+import pytest
+
+import turbovec
+
+# 40k x 128 float32 = 20 MiB. Comfortably above the binding's parallel-copy
+# threshold and big enough that a retained copy is unmistakable, while
+# staying cheap to quantize on a CI runner.
+N_VECTORS = 40_000
+DIM = 128
+N_FLOATS = N_VECTORS * DIM
+
+
+@pytest.fixture(scope="module")
+def vectors():
+    rng = np.random.default_rng(20250730)
+    return rng.standard_normal((N_VECTORS, DIM), dtype=np.float32)
+
+
+def test_one_shot_bulk_add_releases_the_snapshot(vectors):
+    index = turbovec.TurboQuantIndex(dim=DIM, bit_width=4)
+    # Warming up, so this add is delegated whole (see module docstring).
+    assert index.calibration_state == "warming_up"
+    index.add(vectors)
+    assert len(index) == N_VECTORS
+    retained = index._snap_capacity()
+    assert retained < N_FLOATS // 4, (
+        f"a one-shot bulk add retained {retained} float32 snapshot elements "
+        f"of a {N_FLOATS}-element input ({retained * 4 / 2**20:.1f} MiB)"
+    )
+
+
+def test_one_shot_bulk_add_with_ids_releases_the_snapshot(vectors):
+    index = turbovec.IdMapIndex(dim=DIM, bit_width=4)
+    assert index.calibration_state == "warming_up"
+    ids = np.arange(N_VECTORS, dtype=np.uint64)
+    index.add_with_ids(vectors, ids)
+    assert len(index) == N_VECTORS
+    retained = index._snap_capacity()
+    assert retained < N_FLOATS // 4, (
+        f"a one-shot bulk add_with_ids retained {retained} float32 snapshot "
+        f"elements of a {N_FLOATS}-element input "
+        f"({retained * 4 / 2**20:.1f} MiB)"
+    )
+
+
+def test_repeated_same_size_adds_keep_the_snapshot_warm(vectors):
+    """The release must not cost an allocation per add.
+
+    Guards the other direction: a policy that released unconditionally
+    would pass the two tests above while throwing away and re-faulting the
+    whole buffer on every call. ``chunk_size=0`` keeps the whole array
+    going to the binding on every add, so each call really does demand a
+    batch-sized snapshot.
+    """
+    index = turbovec.TurboQuantIndex(dim=DIM, bit_width=4)
+    for _ in range(3):
+        index.add(vectors, chunk_size=0)
+    retained = index._snap_capacity()
+    assert retained >= N_FLOATS, (
+        f"steady same-size adds dropped the warm snapshot to {retained} "
+        f"elements, below the {N_FLOATS} each add needs"
+    )
+
+
+def test_repeated_same_size_adds_with_ids_keep_the_snapshot_warm(vectors):
+    index = turbovec.IdMapIndex(dim=DIM, bit_width=4)
+    for batch in range(3):
+        ids = np.arange(
+            batch * N_VECTORS, (batch + 1) * N_VECTORS, dtype=np.uint64
+        )
+        index.add_with_ids(vectors, ids, chunk_size=0)
+    retained = index._snap_capacity()
+    assert retained >= N_FLOATS, (
+        f"steady same-size add_with_ids calls dropped the warm snapshot to "
+        f"{retained} elements, below the {N_FLOATS} each add needs"
+    )

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -2169,6 +2169,26 @@ mod scratch_retention_tests {
         );
     }
 
+    /// The converse of the step-up case, and the issue's own complaint
+    /// restated: retention must not simply equal the largest single add
+    /// ever made. One spike batch in a run of smaller ones has to be
+    /// given back once the smaller ones resume.
+    #[test]
+    fn a_one_off_spike_does_not_stay_pinned() {
+        let n = 6_000;
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.add_2d(&rows(n, DIM), DIM).unwrap();
+        idx.add_2d(&rows(4 * n, DIM), DIM).unwrap();
+        idx.add_2d(&rows(n, DIM), DIM).unwrap();
+        assert!(
+            idx.encode_scratch.capacity() < 4 * n * DIM,
+            "a 4x spike left {} scratch elements pinned after the batch \
+             size dropped back to {}",
+            idx.encode_scratch.capacity(),
+            n * DIM,
+        );
+    }
+
     /// `shrink_to` never goes below `len`, and the encode path leaves the
     /// scratch at its full length — so on the release path a shrink
     /// without a preceding truncate does nothing. Pin the truncate.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -299,6 +299,40 @@ pub struct TurboQuantIndex {
     /// calls — kept only so repeated adds reuse one allocation instead
     /// of paying a fresh multi-MB mmap + page-fault walk per call.
     encode_scratch: Vec<f32>,
+    /// Element count the *previous* add asked of `encode_scratch`. Half
+    /// of the high-water decay in [`retain_scratch`]: retention tracks
+    /// the last call's demand, so a one-shot bulk load releases its
+    /// buffer while a repeated same-size workload keeps it warm.
+    encode_scratch_prev: usize,
+}
+
+/// Floor for scratch retention, in `f32` elements (4 MiB). Below this the
+/// buffer is not worth releasing: the allocation it saves costs more than
+/// the memory it pins.
+const SCRATCH_RETAIN_MIN: usize = 1 << 20;
+
+/// Shrink a reused scratch buffer to a high-water decay target, and
+/// return the demand this call recorded for the next one.
+///
+/// `prev` is the previous call's demand and `want` is this call's.
+/// Retaining `max(SCRATCH_RETAIN_MIN, prev)` means a buffer only stays
+/// large while *consecutive* calls need it large: a one-shot bulk add
+/// (prev = 0) releases everything above the floor immediately, while a
+/// steady stream of same-size adds has `prev == want`, so the target
+/// equals the live length and both calls below are no-ops — no
+/// per-add reallocation. A size step-down pays one realloc on the call
+/// after the step, then settles.
+///
+/// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
+/// `len`, and the encode path leaves the scratch at full length, so
+/// `shrink_to` alone is a no-op no matter what target it is given.
+fn retain_scratch(scratch: &mut Vec<f32>, prev: usize, want: usize) -> usize {
+    let target = SCRATCH_RETAIN_MIN.max(prev);
+    if scratch.len() > target {
+        scratch.truncate(target);
+    }
+    scratch.shrink_to(target);
+    want
 }
 
 /// Top-`k` results for a batch of queries, as returned by
@@ -434,6 +468,7 @@ impl TurboQuantIndex {
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
             encode_scratch: Vec::new(),
+            encode_scratch_prev: 0,
         })
     }
 
@@ -461,6 +496,7 @@ impl TurboQuantIndex {
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
             encode_scratch: Vec::new(),
+            encode_scratch_prev: 0,
         })
     }
 
@@ -772,11 +808,8 @@ impl TurboQuantIndex {
         };
         // Keep the scratch warm for same-size adds, but don't let a
         // one-time huge bulk load pin its full rotated-batch capacity
-        // for the index lifetime: shrink when the buffer is far larger
-        // than this call needed.
-        if scratch.capacity() > 4 * n * dim {
-            scratch.shrink_to(n * dim);
-        }
+        // for the index lifetime (#333).
+        self.encode_scratch_prev = retain_scratch(&mut scratch, self.encode_scratch_prev, n * dim);
         self.encode_scratch = scratch;
         // `scales` is published per branch below, at the same commit point
         // as the codes and the count — publishing it here would leave it
@@ -1432,6 +1465,7 @@ impl TurboQuantIndex {
                     tqplus_scale,
                     warmup,
                     encode_scratch: Vec::new(),
+                    encode_scratch_prev: 0,
                     rotation: OnceLock::new(),
                     boundaries: boundaries_lock,
                     centroids: centroids_lock,
@@ -1484,6 +1518,7 @@ impl TurboQuantIndex {
                     tqplus_scale,
                     warmup,
                     encode_scratch: Vec::new(),
+                    encode_scratch_prev: 0,
                     rotation: OnceLock::new(),
                     boundaries: boundaries_lock,
                     centroids: centroids_lock,
@@ -1758,6 +1793,7 @@ impl TurboQuantIndex {
             centroids: OnceLock::new(),
             blocked: OnceLock::new(),
             encode_scratch: Vec::new(),
+            encode_scratch_prev: 0,
         })
     }
 
@@ -1921,6 +1957,79 @@ impl TurboQuantIndex {
 
     pub fn bit_width(&self) -> usize {
         self.bit_width
+    }
+}
+
+#[cfg(test)]
+mod scratch_retention_tests {
+    //! The encode scratch is private derived state, so its retention can
+    //! only be pinned from inside the crate (#333). These drive the real
+    //! `add_2d` path and read `encode_scratch.capacity()` afterwards.
+
+    use super::{TurboQuantIndex, SCRATCH_RETAIN_MIN};
+
+    fn rows(n: usize, dim: usize) -> Vec<f32> {
+        (0..n * dim)
+            .map(|i| ((i % 97) as f32 / 97.0) - 0.5)
+            .collect()
+    }
+
+    /// A one-shot bulk add must not pin its rotated-batch buffer for the
+    /// index lifetime. The batch is sized so `n * dim` is far above
+    /// `SCRATCH_RETAIN_MIN`, which is what makes the assertion bite.
+    #[test]
+    fn one_shot_bulk_add_releases_the_encode_scratch() {
+        let dim = 256;
+        let n = 24_000;
+        assert!(
+            n * dim > 4 * SCRATCH_RETAIN_MIN,
+            "batch must exceed the floor"
+        );
+        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+        idx.add_2d(&rows(n, dim), dim).unwrap();
+        assert_eq!(idx.len(), n);
+        assert!(
+            idx.encode_scratch.capacity() <= SCRATCH_RETAIN_MIN,
+            "one-shot bulk add retained {} scratch elements (batch was {})",
+            idx.encode_scratch.capacity(),
+            n * dim,
+        );
+    }
+
+    /// The other half of the high-water decay: a workload that keeps
+    /// asking for the same size must keep its warm buffer, so the shrink
+    /// above does not become a realloc on every add.
+    #[test]
+    fn repeated_same_size_adds_keep_the_scratch_warm() {
+        let dim = 256;
+        let n = 24_000;
+        let batch = rows(n, dim);
+        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+        for _ in 0..3 {
+            idx.add_2d(&batch, dim).unwrap();
+        }
+        assert_eq!(idx.len(), 3 * n);
+        assert!(
+            idx.encode_scratch.capacity() >= n * dim,
+            "steady same-size adds dropped the warm scratch to {} elements (need {})",
+            idx.encode_scratch.capacity(),
+            n * dim,
+        );
+    }
+
+    /// `Vec::shrink_to` never goes below `len`, and the encode path
+    /// leaves the scratch at full length — so a shrink without a
+    /// preceding truncate is a no-op. Pin that the helper truncates.
+    #[test]
+    fn retain_scratch_truncates_before_shrinking() {
+        let mut scratch: Vec<f32> = vec![0.0; 8 * SCRATCH_RETAIN_MIN];
+        let prev = super::retain_scratch(&mut scratch, 0, 8 * SCRATCH_RETAIN_MIN);
+        assert_eq!(prev, 8 * SCRATCH_RETAIN_MIN, "returns this call's demand");
+        assert!(
+            scratch.capacity() <= SCRATCH_RETAIN_MIN,
+            "capacity still {} after retain",
+            scratch.capacity(),
+        );
     }
 }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -326,11 +326,11 @@ const SCRATCH_RETAIN_MIN: usize = 1 << 20;
 /// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
 /// `len`, and the encode path leaves the scratch at full length, so
 /// `shrink_to` alone is a no-op no matter what target it is given.
+/// (`truncate` is itself a no-op when the length is already at or below
+/// the target, so it needs no guard.)
 fn retain_scratch(scratch: &mut Vec<f32>, prev: usize, want: usize) -> usize {
     let target = SCRATCH_RETAIN_MIN.max(prev);
-    if scratch.len() > target {
-        scratch.truncate(target);
-    }
+    scratch.truncate(target);
     scratch.shrink_to(target);
     want
 }
@@ -2028,6 +2028,24 @@ mod scratch_retention_tests {
         assert!(
             scratch.capacity() <= SCRATCH_RETAIN_MIN,
             "capacity still {} after retain",
+            scratch.capacity(),
+        );
+    }
+
+    /// The decay stops at a floor rather than freeing the buffer
+    /// outright: releasing the last 4 MiB would cost the next add a
+    /// fresh allocation to save memory nobody misses. Pinned as a
+    /// literal because the floor's *value* is the policy — the two
+    /// tests above are satisfied by any floor, including zero.
+    #[test]
+    fn the_retention_floor_is_four_mib_of_f32() {
+        assert_eq!(SCRATCH_RETAIN_MIN, 1 << 20);
+        assert_eq!(SCRATCH_RETAIN_MIN * std::mem::size_of::<f32>(), 4 << 20);
+        let mut scratch: Vec<f32> = vec![0.0; 8 * SCRATCH_RETAIN_MIN];
+        super::retain_scratch(&mut scratch, 0, 8 * SCRATCH_RETAIN_MIN);
+        assert!(
+            scratch.capacity() >= SCRATCH_RETAIN_MIN,
+            "the floor was not retained: capacity {}",
             scratch.capacity(),
         );
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -324,18 +324,22 @@ pub struct TurboQuantIndex {
 /// buffer is only touched when its capacity exceeds twice that. Both
 /// margins are load-bearing, for different workloads:
 ///
-/// * The **slack** exists because `shrink_to` sets capacity to *exactly*
-///   the target, discarding the headroom `Vec::reserve`'s amortized
-///   growth had built. Shrinking to the bare previous demand makes every
-///   add whose batch is even slightly larger than the last pay a grow
-///   *and* a shrink — so a workload whose batch size grows or jitters
-///   never settles, and pays two allocations per add forever.
-/// * The **hysteresis** keeps the ordinary shapes at zero extra work.
-///   Equal-sized, growing and jittering adds all sit at a capacity below
-///   `2 * target`, so the branch never fires for them at all. It fires
-///   for the shape this exists to fix: one batch far larger than the run
-///   of adds around it, whose buffer would otherwise stay allocated for
-///   the index's lifetime.
+/// * The **hysteresis** is what keeps ordinary shapes at zero extra
+///   work: equal-sized, growing and jittering adds all sit at a capacity
+///   below `2 * target`, so the branch never fires for them. Without it,
+///   `shrink_to` sets capacity to *exactly* the target and discards the
+///   headroom `Vec::reserve`'s amortized growth had built, so every
+///   batch even slightly larger than the last pays a grow *and* a
+///   shrink.
+/// * The **slack** then covers the jumps the hysteresis alone does not.
+///   Measured over twenty adds growing 5% each, driving a real `Vec`
+///   through this exact sequence: 40 reallocations with neither margin,
+///   7 with hysteresis alone, 9 with slack alone, 5 with both. For a
+///   batch that triples and then holds, only the pair helps — 5, 5 and
+///   3 respectively.
+///
+/// Neither margin changes what a steady same-size or one-shot bulk
+/// workload does; all five variants measured identically on those.
 ///
 /// A one-shot bulk add has `prev == 0`, so it releases the whole buffer
 /// on the call that allocated it. There is no retention floor because
@@ -2141,6 +2145,27 @@ mod scratch_retention_tests {
              the {} the last add needed",
             idx.encode_scratch.capacity(),
             biggest_recent * DIM,
+        );
+    }
+
+    /// A batch that steps up sharply and then holds must not have the
+    /// step shrunk away underneath it. The hysteresis alone does not
+    /// cover this — at a 3x step `capacity == 3 * prev` clears
+    /// `2 * prev`, so without the slack in the target the buffer is cut
+    /// straight back to the smaller batch and the next add regrows it.
+    #[test]
+    fn a_step_up_in_batch_size_is_not_shrunk_back() {
+        let small = 6_000;
+        let big = 3 * small;
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.add_2d(&rows(small, DIM), DIM).unwrap();
+        idx.add_2d(&rows(big, DIM), DIM).unwrap();
+        assert!(
+            idx.encode_scratch.capacity() >= big * DIM,
+            "a {small}->{big} step left only {} scratch elements, below the \
+             {} the larger batch needed",
+            idx.encode_scratch.capacity(),
+            big * DIM,
         );
     }
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -310,39 +310,52 @@ pub struct TurboQuantIndex {
     /// calls — kept only so repeated adds reuse one allocation instead
     /// of paying a fresh multi-MB mmap + page-fault walk per call.
     encode_scratch: Vec<f32>,
-    /// Element count the *previous* add asked of `encode_scratch`. Half
-    /// of the high-water decay in [`retain_scratch`]: retention tracks
-    /// the last call's demand, so a one-shot bulk load releases its
-    /// buffer while a repeated same-size workload keeps it warm.
+    /// Element count the *previous* add asked of `encode_scratch`. Sizes
+    /// the retention target in [`retain_scratch`], so a buffer is only
+    /// kept while the adds around it are still using one that big.
     encode_scratch_prev: usize,
 }
 
-/// Floor for scratch retention, in `f32` elements (4 MiB). Below this the
-/// buffer is not worth releasing: the allocation it saves costs more than
-/// the memory it pins.
-const SCRATCH_RETAIN_MIN: usize = 1 << 20;
-
-/// Shrink a reused scratch buffer to a high-water decay target, and
-/// return the demand this call recorded for the next one.
+/// Release a reused scratch buffer that is far larger than the adds
+/// around it need, and return the demand this call records for the next.
 ///
-/// `prev` is the previous call's demand and `want` is this call's.
-/// Retaining `max(SCRATCH_RETAIN_MIN, prev)` means a buffer only stays
-/// large while *consecutive* calls need it large: a one-shot bulk add
-/// (prev = 0) releases everything above the floor immediately, while a
-/// steady stream of same-size adds has `prev == want`, so the target
-/// equals the live length and both calls below are no-ops — no
-/// per-add reallocation. A size step-down pays one realloc on the call
-/// after the step, then settles.
+/// `prev` is the previous call's demand and `want` is this call's. The
+/// target retained is the previous demand plus half again, and the
+/// buffer is only touched when its capacity exceeds twice that. Both
+/// margins are load-bearing, for different workloads:
 ///
-/// `truncate` first is load-bearing: `Vec::shrink_to` never goes below
-/// `len`, and the encode path leaves the scratch at full length, so
-/// `shrink_to` alone is a no-op no matter what target it is given.
-/// (`truncate` is itself a no-op when the length is already at or below
-/// the target, so it needs no guard.)
+/// * The **slack** exists because `shrink_to` sets capacity to *exactly*
+///   the target, discarding the headroom `Vec::reserve`'s amortized
+///   growth had built. Shrinking to the bare previous demand makes every
+///   add whose batch is even slightly larger than the last pay a grow
+///   *and* a shrink — so a workload whose batch size grows or jitters
+///   never settles, and pays two allocations per add forever.
+/// * The **hysteresis** keeps the ordinary shapes at zero extra work.
+///   Equal-sized, growing and jittering adds all sit at a capacity below
+///   `2 * target`, so the branch never fires for them at all. It fires
+///   for the shape this exists to fix: one batch far larger than the run
+///   of adds around it, whose buffer would otherwise stay allocated for
+///   the index's lifetime.
+///
+/// A one-shot bulk add has `prev == 0`, so it releases the whole buffer
+/// on the call that allocated it. There is no retention floor because
+/// there is nothing for one to save: `Vec::reserve` from a zero capacity
+/// allocates once, exactly as it would from any smaller capacity.
+///
+/// `truncate` before `shrink_to` is load-bearing on that release path.
+/// `shrink_to` never goes below `len`, and the encode path leaves the
+/// scratch at the full `n * dim` it just rotated — which is above the
+/// target whenever there is anything to release, so `shrink_to` on its
+/// own would do nothing there. (It is *not* inert in general: against a
+/// short `len` it does shrink, which is why the old condition released
+/// on a large-then-small pair.) `truncate` is itself a no-op when the
+/// length is already at or below the target.
 fn retain_scratch(scratch: &mut Vec<f32>, prev: usize, want: usize) -> usize {
-    let target = SCRATCH_RETAIN_MIN.max(prev);
-    scratch.truncate(target);
-    scratch.shrink_to(target);
+    let target = prev.saturating_add(prev / 2);
+    if scratch.capacity() > target.saturating_mul(2) {
+        scratch.truncate(target);
+        scratch.shrink_to(target);
+    }
     want
 }
 
@@ -2043,7 +2056,9 @@ mod scratch_retention_tests {
     //! only be pinned from inside the crate (#333). These drive the real
     //! `add_2d` path and read `encode_scratch.capacity()` afterwards.
 
-    use super::{TurboQuantIndex, SCRATCH_RETAIN_MIN};
+    use super::TurboQuantIndex;
+
+    const DIM: usize = 256;
 
     fn rows(n: usize, dim: usize) -> Vec<f32> {
         (0..n * dim)
@@ -2052,78 +2067,96 @@ mod scratch_retention_tests {
     }
 
     /// A one-shot bulk add must not pin its rotated-batch buffer for the
-    /// index lifetime. The batch is sized so `n * dim` is far above
-    /// `SCRATCH_RETAIN_MIN`, which is what makes the assertion bite.
+    /// index's lifetime.
     #[test]
     fn one_shot_bulk_add_releases_the_encode_scratch() {
-        let dim = 256;
         let n = 24_000;
-        assert!(
-            n * dim > 4 * SCRATCH_RETAIN_MIN,
-            "batch must exceed the floor"
-        );
-        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
-        idx.add_2d(&rows(n, dim), dim).unwrap();
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.add_2d(&rows(n, DIM), DIM).unwrap();
         assert_eq!(idx.len(), n);
         assert!(
-            idx.encode_scratch.capacity() <= SCRATCH_RETAIN_MIN,
+            idx.encode_scratch.capacity() < n * DIM / 4,
             "one-shot bulk add retained {} scratch elements (batch was {})",
             idx.encode_scratch.capacity(),
-            n * dim,
+            n * DIM,
         );
     }
 
-    /// The other half of the high-water decay: a workload that keeps
-    /// asking for the same size must keep its warm buffer, so the shrink
-    /// above does not become a realloc on every add.
+    /// A workload that keeps asking for the same size must keep its warm
+    /// buffer, or the release above becomes a realloc on every add.
     #[test]
     fn repeated_same_size_adds_keep_the_scratch_warm() {
-        let dim = 256;
         let n = 24_000;
-        let batch = rows(n, dim);
-        let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+        let batch = rows(n, DIM);
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
         for _ in 0..3 {
-            idx.add_2d(&batch, dim).unwrap();
+            idx.add_2d(&batch, DIM).unwrap();
         }
         assert_eq!(idx.len(), 3 * n);
         assert!(
-            idx.encode_scratch.capacity() >= n * dim,
+            idx.encode_scratch.capacity() >= n * DIM,
             "steady same-size adds dropped the warm scratch to {} elements (need {})",
             idx.encode_scratch.capacity(),
-            n * dim,
+            n * DIM,
         );
     }
 
-    /// `Vec::shrink_to` never goes below `len`, and the encode path
-    /// leaves the scratch at full length — so a shrink without a
-    /// preceding truncate is a no-op. Pin that the helper truncates.
+    /// The regression that shrinking to the bare previous demand causes:
+    /// `shrink_to` sets capacity *exactly*, so a batch even slightly
+    /// larger than the last one finds no headroom and has to grow — then
+    /// gets shrunk right back, on every add, forever. The buffer must
+    /// stay at or above what the most recent add needed.
+    #[test]
+    fn growing_batch_sizes_keep_their_growth_headroom() {
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        let mut n = 8_000;
+        let mut last = 0;
+        for _ in 0..6 {
+            idx.add_2d(&rows(n, DIM), DIM).unwrap();
+            last = n;
+            n += n / 20; // +5% per batch
+        }
+        assert!(
+            idx.encode_scratch.capacity() >= last * DIM,
+            "a growing batch size left only {} scratch elements after a \
+             {}-element add, so the next add must grow and be shrunk again",
+            idx.encode_scratch.capacity(),
+            last * DIM,
+        );
+    }
+
+    /// The same headroom property for a batch size that jitters rather
+    /// than grows monotonically — the shape a real ingest loop has.
+    #[test]
+    fn jittering_batch_sizes_keep_their_growth_headroom() {
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        let sizes = [9_000, 11_000, 9_500, 10_800, 9_200, 10_400];
+        for n in sizes {
+            idx.add_2d(&rows(n, DIM), DIM).unwrap();
+        }
+        let biggest_recent = 10_400;
+        assert!(
+            idx.encode_scratch.capacity() >= biggest_recent * DIM,
+            "a jittering batch size left only {} scratch elements, below \
+             the {} the last add needed",
+            idx.encode_scratch.capacity(),
+            biggest_recent * DIM,
+        );
+    }
+
+    /// `shrink_to` never goes below `len`, and the encode path leaves the
+    /// scratch at its full length — so on the release path a shrink
+    /// without a preceding truncate does nothing. Pin the truncate.
     #[test]
     fn retain_scratch_truncates_before_shrinking() {
-        let mut scratch: Vec<f32> = vec![0.0; 8 * SCRATCH_RETAIN_MIN];
-        let prev = super::retain_scratch(&mut scratch, 0, 8 * SCRATCH_RETAIN_MIN);
-        assert_eq!(prev, 8 * SCRATCH_RETAIN_MIN, "returns this call's demand");
-        assert!(
-            scratch.capacity() <= SCRATCH_RETAIN_MIN,
-            "capacity still {} after retain",
+        let big = 8 << 20;
+        let mut scratch: Vec<f32> = vec![0.0; big];
+        let prev = super::retain_scratch(&mut scratch, 0, big);
+        assert_eq!(prev, big, "returns this call's demand");
+        assert_eq!(
             scratch.capacity(),
-        );
-    }
-
-    /// The decay stops at a floor rather than freeing the buffer
-    /// outright: releasing the last 4 MiB would cost the next add a
-    /// fresh allocation to save memory nobody misses. Pinned as a
-    /// literal because the floor's *value* is the policy — the two
-    /// tests above are satisfied by any floor, including zero.
-    #[test]
-    fn the_retention_floor_is_four_mib_of_f32() {
-        assert_eq!(SCRATCH_RETAIN_MIN, 1 << 20);
-        assert_eq!(SCRATCH_RETAIN_MIN * std::mem::size_of::<f32>(), 4 << 20);
-        let mut scratch: Vec<f32> = vec![0.0; 8 * SCRATCH_RETAIN_MIN];
-        super::retain_scratch(&mut scratch, 0, 8 * SCRATCH_RETAIN_MIN);
-        assert!(
-            scratch.capacity() >= SCRATCH_RETAIN_MIN,
-            "the floor was not retained: capacity {}",
-            scratch.capacity(),
+            0,
+            "a buffer no recent add needed was not released",
         );
     }
 }


### PR DESCRIPTION
Addresses finding 1 of #333 — the permanent retention. Findings 2 and 3 are deliberately left and carried in #409; see the bottom. **Deliberately no auto-dismiss keyword anywhere in this body:** 4 of the 5 findings in that issue stay outstanding after this merges, so it must remain open.

## What was wrong

Both the core's `encode_scratch` (`turbovec/src/lib.rs`) and the binding's `snap` buffer (`turbovec-python/src/lib.rs`, two call sites) shrank on `capacity > 4 * this call's length`. Two independent reasons that never fired:

1. The call that **grew** the buffer has `capacity ~= length`, so it can never satisfy `capacity > 4 * length`.
2. Even when the test passes, `Vec::shrink_to` never goes below `len` — and `encode` leaves the scratch at the full `n * dim`, just as `add` leaves the snapshot at the full input length. So `shrink_to(len)` is a no-op regardless.

The shrink was dead twice over, and the copy-paste `index.add(embeddings)` from the README pinned a full copy of the batch in each buffer for the index's lifetime.

## The policy, and why this one

*(Revised after review — see the [review response](https://github.com/RyanCodrai/turbovec/pull/404#issuecomment-5124083638). The first revision shrank to exactly `max(4 MiB, prev)`, which destroyed `Vec::reserve`'s amortized headroom and made growing or jittering batch sizes pay a grow **and** a shrink on every add, forever.)*

A shrink that fires on every add costs an allocation per add; one that never fires pins peak memory forever. The policy is:

**target = the previous call's demand plus half again, applied only when capacity exceeds twice that.**

- The **hysteresis** does the main work: equal-sized, growing and jittering adds all sit below `2 * target`, so the branch never fires for them.
- The **slack** covers the jumps hysteresis alone does not. Measured by driving a real `Vec` through the exact clear/reserve/retain sequence, twenty adds growing 5% each: 40 reallocations with neither margin, 7 with hysteresis alone, 9 with slack alone, **5 with both**. For a batch that triples then holds: 5, 5 and **3**.
- **No retention floor.** An earlier revision had a 4 MiB one; measuring it showed it costs 4 MB per index plus an extra large allocation and buys nothing, because `Vec::reserve` from zero capacity allocates *once* rather than doubling up from nothing.

A one-shot bulk add has no previous demand, so it releases outright on the call that allocated it.

Rejected: a plain absolute cap (always shrink to a fixed size), which reallocates on *every* add — the `repeated_same_size_adds_keep_the_scratch_warm` test fails under it.

## Memory and allocations — before/after

Counting global allocator wrapping `System`, release build, dim 768 at 2-bit, driving the real `add_2d`. Shown at `RAYON_NUM_THREADS=1`, which removes rayon's noise — these counts are bit-stable across runs. Default threads agrees within that noise.

| shape | pre-#333 allocs | **now** | pre-#333 retained | **now** |
|---|---|---|---|---|
| steady 50k x12 | 14 | **15** | 296.1 MB | 296.1 MB |
| **bulk 200k once** | 8 | **8** | **623.3 MB** | **37.4 MB** |
| bulk then 5 tiny | 10 | **10** | 74.8 MB | 74.8 MB |
| growing 5% x20 | 19 | **20** | 479.6 MB | 491.4 MB |
| jitter 45k–55k | 17 | **18** | 562.6 MB | 588.9 MB |
| shrinking 5% x20 | 15 | **16** | 473.7 MB | 462.5 MB |
| alternating 50k/1k | 23 | **23** | 77.7 MB | 79.2 MB |

The bulk row is the fix: 623.3 MB retained against a **36.6 MB** index becomes 37.4 MB. Everything else is within **+1 allocation over an entire run** (total allocation counts: 520→521 steady, 743→744 growing, 740→741 jitter).

The slack costs a little extra retention on growing and jittering shapes (+11.8 MB and +26.3 MB against the old code). That is the price of the headroom, stated rather than buried.

Interleaved timing A/B at both thread counts shows no regression on any shape.

### Note on RSS, and on finding 5

I could not reproduce **any** RSS movement on macOS, matching the caveat in your first comment. Python RSS across k concurrently-live indexes, 40k x 768, same array, old vs new extension:

| k | old | new |
|---|---|---|
| 1 | +311.6 MB | +311.6 MB |
| 2 | +553.2 MB | +553.6 MB |
| 4 | +1037.4 MB | +1038.1 MB |
| 8 | +2005.2 MB | +2005.2 MB |

Identical to within 1 MB, while the counting allocator at the same shape reports 374.2 -> 34.6 MB. Review reproduced this for indexes built *sequentially* too (2803 MB with the fix vs 2802 MB without), where the freed span ought to be reused — and a plain `malloc/free/malloc` of 600 MB on the same box *does* reuse it. So the mechanism is **not established**; my earlier "serves new requests from fresh pages" was a guess and is withdrawn. **The user-visible RSS win is unverified on any platform** and needs confirming on Linux/glibc.

**I did not act on finding 5.** #374 reads it as self-refuting and I agree with that reading on its own merits — a counting allocator showing +2.00 MB and zero extra allocations for the identical core sequence. I am no longer offering these numbers as *support* for it, though: an unexplained RSS gap cannot corroborate a diagnosis of another unexplained RSS gap.

## Throughput — no regression at either thread count

Interleaved A/B, two binaries built from the same tree with only this patch differing, alternating old/new within one run. 50k x 768 adds x 12, steady = calls 3-12.

**Rust core**, median of 8 interleaved steady medians:

| | old | new | |
|---|---|---|---|
| default threads | 23.20 ms | 23.33 ms | +0.5% |
| `RAYON_NUM_THREADS=1` | 90.18 ms | 90.49 ms | +0.34% |

**Python `add`**, 4 interleaved rounds:

| | old | new |
|---|---|---|
| default threads | 66.5 ms | 63.6 ms |
| `RAYON_NUM_THREADS=1` | 122.9 ms | 113.4 ms |

Timing on a shared box is noisy, so the load-bearing evidence is the allocation count, which is not. Per-call count of allocations >= 1 MiB, same 12-add sequence:

```
default threads   old [26, 1, 1, 0, 2, 0, 0, 0, 2, 0, 0, 0]
                  new [27, 2, 1, 0, 2, 0, 0, 0, 2, 0, 0, 0]
RAYON_NUM_THREADS=1
                  old [ 8, 1, 1, 0, 2, 0, 0, 0, 2, 0, 0, 0]
                  new [ 9, 2, 1, 0, 2, 0, 0, 0, 2, 0, 0, 0]
```

Exactly +1 on call 1 (the shrink) and +1 on call 2 (the regrow), then **byte-identical from call 3 onward** at both thread counts. The steady state costs zero extra allocations. The single visible cost is the second add: 90.2 -> 99.8 ms at `RAYON_NUM_THREADS=1`, one-time, and not distinguishable from noise at default threads.

## Tests, with discrimination evidence

Every test run against all three policies — the pre-#333 code, the first (reviewed) revision, and this one. Both directions are covered and no test is decorative:

| test (mirrored in both crates) | pre-#333 | first revision | now |
|---|---|---|---|
| `one_shot_bulk_add_releases_the_*` | **FAIL** | pass | pass |
| `retain_scratch_truncates_before_shrinking` | **FAIL** | **FAIL** | pass |
| `growing_batch_sizes_keep_their_growth_headroom` | pass | **FAIL** | pass |
| `jittering_batch_sizes_keep_their_growth_headroom` | pass | **FAIL** | pass |
| `a_step_up_in_batch_size_is_not_shrunk_back` | pass | pass | pass |
| `a_one_off_spike_does_not_stay_pinned` | pass | pass | pass |
| `repeated_same_size_adds_keep_the_*_warm` | pass | pass | pass |

The last three are guards rather than bug-detectors, so each is discriminated against the specific wrong policy it guards: the absolute-cap variant for the warm test, and the no-slack (`prev % 2`) and 3x-slack (`prev * 2`) mutants for the step-up and spike tests respectively.

**Mutation coverage**, run locally at CI's pinned `cargo-mutants` 27.1.0: **13 mutants, 10 caught, 3 unviable, 0 missed** — no `[skip mutants]` needed. The first local run had 3 survivors on the tuning margins; investigating them found a false claim in my own doc comment (that the slack, rather than the hysteresis, was what prevented per-add thrashing) and produced the two behavioural tests above.

### The binding's call sites, and the coverage gap that was here

The gap this section used to describe is closed. It was two things, and review was right that both mattered:

**The `turbovec-python` tests had no executor.** Every `cargo test` in the repo is `-p turbovec` (`ci.yml:45,107`, `release-crates.yml:54`) and the python job only built a wheel and ran pytest, so this crate's lib tests — the first `#[cfg(test)]` module it has ever had — would have run nowhere. Clippy's `--workspace --all-targets` pass type-checks them, which is not the same as executing them. One invocation is added to the existing python job, on all three OSes.

It goes there rather than in the Rust matrix because it has to link libpython, and that job is the one with an interpreter on every OS. With `extension-module` on, pyo3 emits no libpython link line, which is correct for a dynamically-loaded `.so` and wrong for anything that links: `Py_IncRef` / `Py_DecRef` / `_Py_NoneStruct` come out undefined. That happens to link in a debug profile, because dead-stripping drops the references — and **not** under `--release`, where LTO keeps them, so `cargo test --workspace --release` fails to link the lib-test target (true before this PR too — the target is built whether or not it contains tests). Rather than lean on dead-stripping, `extension-module` is now an on-by-default feature so it can be switched *off*: `cargo test -p turbovec-python --lib --no-default-features`, which links and passes in both profiles. `cargo build`, clippy and maturin are unaffected — maturin passes `pyo3/extension-module` explicitly anyway (`pyproject.toml`).

**The tests did not reach the real call sites.** They drove `retain_snap` through the buffer sequence `add` performs, so deleting `retain_snap(&mut owned, …)` or `retain_snap(&mut v_owned, …)` left all six green. Reaching the real site from a Rust test needs a live interpreter and a numpy round trip inside a crate built as an extension module, so the wiring is pinned from Python instead, in `turbovec-python/tests/test_snap_retention.py`, through a new internal `_snap_capacity()` accessor (the buffer has no other Python-visible handle, and macOS RSS does not move when it is freed, so an allocator- or RSS-level assertion would not be a gate on every platform).

Both call sites are now discriminated, verified by deleting each and rebuilding the wheel:

| deleted call site | failing test | retained |
|---|---|---|
| `lib.rs:481` (`TurboQuantIndex::add`) | `test_one_shot_bulk_add_releases_the_snapshot` | 5 120 000 of a 5 120 000-element input (19.5 MiB) |
| `lib.rs:865` (`IdMapIndex::add_with_ids`) | `test_one_shot_bulk_add_with_ids_releases_the_snapshot` | 5 120 000 of a 5 120 000-element input (19.5 MiB) |

Worth recording what writing those turned up: the Python layer slices an add into `BATCH_CHUNK_SIZE` (1000) rows for Ctrl-C latency, but only once the TQ+ calibration has settled, since the calibrating add must run whole. So the *first* bulk add on a fresh index is the one delegated entire, and it is the only one that can pin a batch-sized buffer — exactly the shape the issue reported. The steady-state adds that follow only ever snapshot 1000 rows. The two tests assert that precondition (`calibration_state == "warming_up"`) instead of assuming it, and the warm-buffer tests pass `chunk_size=0` so each add really does demand a batch-sized snapshot.

The Rust-side module keeps the policy tests, and its doc comment now says plainly that it does not cover the wiring and points at the pytest file.

**Suites.** `cargo test --workspace --locked`: 334 passed, 0 failed. `cargo test -p turbovec-python --lib --no-default-features --locked`: 6 passed (also 6 passed with `--release`). `pytest turbovec-python/tests/ -q` against a wheel built from this branch: **763 passed, 15 skipped, 1 failed** — `test_llama_index.py::test_query_returns_node_with_full_field_fidelity`, the pre-existing #386 failure on unmodified main. Clippy with CI's flag set reports nothing in `turbovec-python/src`; `cargo fmt --check` unchanged at the pre-existing drift.

## Deliberately left — tracked in #409

Findings 2 and 3 are both real and both measured; each is filed in **#409** with the numbers and file:line, so they survive this merge rather than depending on #333 staying open.

- **Finding 2** (one allocation per vector on the first search, `pack.rs:260` `extract_codes_flat`). It is in `pack.rs` and other work is in flight there. Your own comment measured the win as 1600x fewer allocations for ~8% latency, and noted the issue's 227 ms vs 3.87 ms framing over-credits allocation — worth doing on its own, with an x86 re-measurement.
- **Finding 3** (`to_bytes` needs ~3x the output, `lib.rs:914-933`). `with_capacity(serialized_len())` gets 2.97x -> 1.99x everywhere, and the warm-cache passthrough that reaches 1.00x is `cfg(not(x86_64))`-only — on x86 the nibble de-interleave needs a materialized copy unless someone streams the transform chunk-wise. That asymmetry makes it a separate PR.
- **Finding 4** is a doc line, **finding 5** is the macOS artifact discussed above, **findings 6 and 7** are informational.

So this PR is one of at least two changes against #333, which stays open on merge. Note the trap that made this worth spelling out: the first line of this body used to pair the verb "f‑i‑x‑e‑s" with the issue reference, three words apart — and GitHub parses straight through the interposed words. `closingIssuesReferences` for this PR returned that issue, i.e. merging would have auto-dismissed one with four findings outstanding. The query now returns an empty list.

## Also in this PR

- **CHANGELOG.** The `[Unreleased]` → `### turbovec — Rust crate` section asserted both halves of the bug: one entry said the scratch buffer "is shrunk whenever it exceeds 4x the current batch's need" while another, in the same section, said that exact 4x condition was dead and could never fire. The first now states the current policy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

