### PR TITLE
fix: the two Claude-agent checkouts no longer persist credentials, and the zizmor audit gates (#347)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,9 +61,16 @@ jobs:
                 await react('createForIssue', p.pull_request.number, 'issue_number');
             } catch (e) { core.info('reaction skipped: ' + e.message); }
 
+      # persist-credentials: false — the checkout credential is not needed and
+      # must not be left in .git/config, because the steps after this one hand a
+      # Bash-enabled agent content third parties can write (PR diffs, comments,
+      # issue bodies). claude-code-action supplies its own git credential: it
+      # unsets checkout's http.extraheader and points origin at a URL built from
+      # the `github_token` input below.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       # Native deps so Claude can actually build and run the test suite
       # (turbovec links CBLAS via OpenBLAS on Linux).

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -81,11 +81,15 @@ jobs:
       # or run `--min-severity informational` locally.
       #
       # A severity floor is the blunt instrument here, chosen because it is
-      # contained. The sharper fix is an inline `# zizmor: ignore[...]` on those
-      # three ci.yml lines, which documents each exemption where it applies and
-      # lets every tier gate; it was left out only to keep this change scoped to
-      # the workflows it is about. Prefer that if the informational tier ever
-      # needs to be visible again.
+      # contained. The sharper fix is an inline `# zizmor: ignore[...]`, which
+      # documents each exemption where it applies and lets every tier gate; it
+      # was left out only to keep this change scoped to the workflows it is
+      # about. Prefer that if the informational tier ever needs to be visible
+      # again — but note it goes on the two `run:` keys, ci.yml:256 and :259,
+      # so two comments cover all three findings. Not on 260/261: those are
+      # inside a `run: |` block scalar, where a trailing `#...` is shell text
+      # rather than a YAML comment, so zizmor never sees it and the fragment
+      # would be passed to cargo.
       #
       # Do not reintroduce continue-on-error to dodge a low/medium/high
       # finding, and do not raise this threshold to silence one; fix it.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -47,10 +47,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # Pinned, for the same reason actions here are pinned by SHA: the
-          # step below is a hard gate, so an upstream release that ships a new
-          # low/medium/high lint would fail every pull request in the repo
-          # without a commit having changed anything. Bump this deliberately
-          # and fix whatever the new version finds in the same PR.
+          # step below is a hard gate, so an upstream release shipping a new
+          # low/medium/high lint would start failing this workflow with no
+          # commit having changed anything — every pull request that touches
+          # .github/workflows/**, every push to main, and the weekly cron (see
+          # the triggers above). Bump this deliberately and fix whatever the
+          # new version finds in the same pull request.
           python -m pip install zizmor==1.28.0
       # `--offline` keeps the audit hermetic (no GitHub API calls, no token
       # needed).
@@ -69,14 +71,21 @@ jobs:
       # severity* with `audit confidence → Low`, and it gates; the filter here
       # would not have spared it.
       #
-      # The threshold exists because the informational tier is advisory by
-      # construction — findings worth a human glance rather than defects. The
-      # three the repo has today are `template-injection` on
-      # `${{ steps.msrv.outputs.version }}` in ci.yml, a value produced by an
+      # Be aware of the cost: the excluded findings are filtered out entirely,
+      # not merely un-gated. They do not appear in the log — they collapse into
+      # the trailing `(N ignored, ...)` count, so nothing draws attention to
+      # them. The repo has three today, all `template-injection` on
+      # `${{ steps.msrv.outputs.version }}` in ci.yml: a value produced by an
       # earlier step in the same workflow rather than by anything an attacker
-      # can reach. They still print in the log. Gating on that tier would
-      # block unrelated pull requests on non-vulnerabilities, which is the
-      # reason this step was non-gating in the first place.
+      # can reach, which is why they are tolerable. To see them, drop the flag
+      # or run `--min-severity informational` locally.
+      #
+      # A severity floor is the blunt instrument here, chosen because it is
+      # contained. The sharper fix is an inline `# zizmor: ignore[...]` on those
+      # three ci.yml lines, which documents each exemption where it applies and
+      # lets every tier gate; it was left out only to keep this change scoped to
+      # the workflows it is about. Prefer that if the informational tier ever
+      # needs to be visible again.
       #
       # Do not reintroduce continue-on-error to dodge a low/medium/high
       # finding, and do not raise this threshold to silence one; fix it.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -88,8 +88,9 @@ jobs:
       # again — but note it goes on the two `run:` keys, ci.yml:256 and :259,
       # so two comments cover all three findings. Not on 260/261: those are
       # inside a `run: |` block scalar, where a trailing `#...` is shell text
-      # rather than a YAML comment, so zizmor never sees it and the fragment
-      # would be passed to cargo.
+      # rather than a YAML comment, so zizmor never sees it. The shell then
+      # discards it as a comment, so the misplacement is silent: no error,
+      # the exemption simply does not take.
       #
       # Do not reintroduce continue-on-error to dodge a low/medium/high
       # finding, and do not raise this threshold to silence one; fix it.

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -46,7 +46,12 @@ jobs:
       - name: Install zizmor
         run: |
           python -m pip install --upgrade pip
-          python -m pip install zizmor
+          # Pinned, for the same reason actions here are pinned by SHA: the
+          # step below is a hard gate, so an upstream release that ships a new
+          # low/medium/high lint would fail every pull request in the repo
+          # without a commit having changed anything. Bump this deliberately
+          # and fix whatever the new version finds in the same PR.
+          python -m pip install zizmor==1.28.0
       # `--offline` keeps the audit hermetic (no GitHub API calls, no token
       # needed).
       #
@@ -56,15 +61,25 @@ jobs:
       # those severities is a real regression and must fail the build instead
       # of being buried in the logs of a green run.
       #
-      # `--min-severity low` keeps *informational* findings advisory. They
-      # still print, but they don't gate: they are the tier zizmor uses for
-      # low-confidence heuristics (e.g. `template-injection` on a
-      # `${{ steps.*.outputs.* }}` value produced by an earlier step in the
-      # same workflow), and new informational lints arrive with upstream
-      # releases. Gating on them would wedge unrelated PRs on findings that
-      # are not vulnerabilities — the original reason this step was
-      # non-gating. Do not reintroduce continue-on-error to dodge a
-      # low/medium/high finding; fix the finding.
+      # `--min-severity low` excludes exactly one of zizmor's four severity
+      # tiers — informational, low, medium, high — namely `informational`.
+      # Everything from `low` upwards still gates. Severity is not confidence:
+      # `--min-confidence` is a separate flag on a separate axis, and this
+      # threshold says nothing about it. `artipacked` is reported as *medium
+      # severity* with `audit confidence → Low`, and it gates; the filter here
+      # would not have spared it.
+      #
+      # The threshold exists because the informational tier is advisory by
+      # construction — findings worth a human glance rather than defects. The
+      # three the repo has today are `template-injection` on
+      # `${{ steps.msrv.outputs.version }}` in ci.yml, a value produced by an
+      # earlier step in the same workflow rather than by anything an attacker
+      # can reach. They still print in the log. Gating on that tier would
+      # block unrelated pull requests on non-vulnerabilities, which is the
+      # reason this step was non-gating in the first place.
+      #
+      # Do not reintroduce continue-on-error to dodge a low/medium/high
+      # finding, and do not raise this threshold to silence one; fix it.
       - name: Run zizmor
         run: |
           zizmor --version

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -48,11 +48,24 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install zizmor
       # `--offline` keeps the audit hermetic (no GitHub API calls, no token
-      # needed). Non-gating for now (continue-on-error) so a newly-shipped
-      # zizmor lint can't wedge unrelated PRs; the baseline is clean today, so
-      # this can be tightened to a hard gate once it has proven stable.
+      # needed).
+      #
+      # Gating (no continue-on-error): every workflow now complies with the
+      # low-and-above lints — notably `artipacked`, which is what a checkout
+      # that omits `persist-credentials: false` trips — so a new finding at
+      # those severities is a real regression and must fail the build instead
+      # of being buried in the logs of a green run.
+      #
+      # `--min-severity low` keeps *informational* findings advisory. They
+      # still print, but they don't gate: they are the tier zizmor uses for
+      # low-confidence heuristics (e.g. `template-injection` on a
+      # `${{ steps.*.outputs.* }}` value produced by an earlier step in the
+      # same workflow), and new informational lints arrive with upstream
+      # releases. Gating on them would wedge unrelated PRs on findings that
+      # are not vulnerabilities — the original reason this step was
+      # non-gating. Do not reintroduce continue-on-error to dodge a
+      # low/medium/high finding; fix the finding.
       - name: Run zizmor
-        continue-on-error: true
         run: |
           zizmor --version
-          zizmor --offline --persona regular .github/workflows/
+          zizmor --offline --persona regular --min-severity low .github/workflows/

--- a/.github/workflows/summarize-command.yml
+++ b/.github/workflows/summarize-command.yml
@@ -42,10 +42,15 @@ jobs:
               });
             } catch (e) { core.info('reaction skipped: ' + e.message); }
 
+      # persist-credentials: false — the agent below reads PR diffs and comments,
+      # i.e. third-party-writable content, so no git credential should be sitting
+      # in .git/config. Nothing here pushes: the summary is posted with `gh`,
+      # authenticated by GH_TOKEN.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Summarize and comment
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183


### PR DESCRIPTION
## Related issue

Addresses the main finding of #347. **Deliberately not `Closes`** — #347 also
carries four repo-hygiene sub-items from the same audit (`.claude/worktrees/`
not gitignored, orphaned `.github/claude/__pycache__/`, stray untracked `=` and
`err.log`, and the `examples/downstream-smoke/Cargo.toml` version comment) that
this PR does not touch. The issue should stay open for those.

## Summary

- `persist-credentials: false` on the checkouts in `.github/workflows/claude.yml`
  and `.github/workflows/summarize-command.yml`.
- `.github/workflows/security-audit.yml`: dropped `continue-on-error: true` from
  the zizmor step, added `--min-severity low`, and pinned `zizmor==1.28.0`.

Nothing else changes about what any workflow does.

## Motivation

### The two checkouts

I re-inventoried every `actions/checkout` in `.github/` — there are **20** on
current `main`, and exactly these two omitted `persist-credentials: false`:

| Workflow | Line | Had it? |
|---|---|---|
| `ci.yml` | 26, 90, 163, 237, 286, 362, 445 | yes (7) |
| `release-pypi.yml` | 26, 129, 164, 196 | yes (4) |
| `supply-chain.yml` | 48, 69 | yes (2) |
| `changelog.yml` | 25 | yes |
| `intake.yml` | 28 | yes |
| `mutants.yml` | 60 | yes |
| `release-crates.yml` | 23 | yes |
| `security-audit.yml` | 40 | yes |
| **`claude.yml`** | **64** | **no** |
| **`summarize-command.yml`** | **46** | **no** |

They are also the two that hand a `Bash`-enabled Claude agent content third
parties can write — PR diffs, review comments, issue bodies. `actions/checkout`
leaves a credential in `.git/config` by default, so any later step in the job,
including one driven by model output, can reach it. The `github.actor_id`
guards make *triggering* owner-only; they say nothing about the content the
agent reads once triggered.

### Why `false` is safe in both

I checked what each workflow does after checkout rather than assuming:

- **`claude.yml`** has `contents: write` and the agent does push branches and
  open PRs, so this one needed verifying. `claude-code-action` supplies its own
  git credential — [`src/github/operations/git-config.ts`](https://github.com/anthropics/claude-code-action/blob/be7b93b1907a4abad570368f3c74b6fe3807510b/src/github/operations/git-config.ts)
  at the pinned SHA explicitly *unsets* `http.<server>/.extraheader` ("Remove
  the authorization header that actions/checkout sets") and then
  `git remote set-url origin` to a URL built from the `github_token` input.
  `configureGitAuth` is reached from both `src/modes/tag/index.ts` and
  `src/modes/agent/index.ts` whenever `use_commit_signing` is false, which is
  the default and what this workflow uses. So the credential this PR removes was
  being discarded by the action anyway.
- **`summarize-command.yml`** never pushes: the job is `contents: read`, the
  prompt is explicitly read-only, and the summary is posted via `gh pr comment`
  authenticated by `GH_TOKEN`.

No checkout was left unfixed.

### Why the lint was non-gating, and why `--min-severity low`

The lint is zizmor's `artipacked` rule, run from `security-audit.yml:54`. The
non-gating cause was a plain `continue-on-error: true` on the step (not a
schedule-only trigger, and not a lint that fails to report — it does report,
the step result was just being discarded).

Removing `continue-on-error` **alone would have broken CI immediately.** zizmor
exits non-zero on findings of *any* severity, and `main` already has three
pre-existing **informational** `template-injection` findings on
`${{ steps.msrv.outputs.version }}` in `ci.yml:256-261`. That value is produced
by an earlier step in the same workflow, and zizmor rates it Low confidence —
it is not attacker-controllable. Fixing it would mean editing `ci.yml`, which is
outside this PR's scope.

So the step now passes `--min-severity low`, which excludes exactly one of
zizmor's four severity tiers (informational, low, medium, high): the
informational one. Low, medium and high all fail the build. To be precise about
two axes that are easy to conflate — severity is not confidence.
`--min-confidence` is a separate flag, and this threshold says nothing about it:
`artipacked` is reported at **medium severity** with `audit confidence → Low`,
and it gates. The threshold does not filter low-confidence findings, only the
informational tier.

The cost is worth stating plainly: the excluded findings are **filtered out
entirely, not merely un-gated.** They do not appear in the log at all — they
collapse into the trailing `(3 ignored, 22 suppressed)` count. Verified: the
workflow's exact command prints zero `template-injection` blocks and exits 0,
while `--min-severity informational` surfaces all three (`ci.yml:256:43`,
`260:22`, `261:22`) and exits 11. So nobody gets a passive "human glance" at
them; seeing them requires dropping the flag deliberately. They are tolerable
because the value is produced by an earlier step in the same workflow, not by
anything an attacker can reach.

A severity floor is the blunt instrument, chosen because it is contained. If the
informational tier should stay visible, the sharper fix is an inline
`# zizmor: ignore[template-injection]`, which documents each exemption at the
site and lets every tier gate. That is my preference on the merits, but it means
editing `ci.yml`, so it is deliberately not in this PR; the comment in
`security-audit.yml` records it for whoever revisits this.

It goes on the two `run:` keys — `ci.yml:256` and `:259` — so **two** comments
cover all three findings, not three. Verified both ways: ignores on 256/259 give
`No findings to report. Good job! (3 ignored, 22 suppressed)` and exit 0, whereas
putting them on 256/260/261 gives `2 informational` and **exit 11**, only one
honoured. Lines 260-261 sit inside a `run: |` block scalar, so a trailing `#…` is
shell text rather than a YAML comment: zizmor never sees it, and the fragment
would be appended to the `cargo check` command line.

### Pinning zizmor

`zizmor` was installed unpinned. That was harmless while the step was
`continue-on-error`, because a newly-shipped lint could only print. This PR
changes its blast radius: with the step gating, an upstream release adding a
low/medium/high lint would start failing this workflow with no commit having
changed anything, and `--min-severity low` only mitigates the informational
slice of that.

To scope that claim accurately — this workflow triggers on `pull_request` with
`paths: [".github/workflows/**"]`, plus pushes to `main` and a weekly cron. So
the exposure is every workflow-touching PR, every push to main, and the cron —
not literally every PR in the repo. (Confirmed: `gh run list
--workflow=security-audit.yml` has no run for `60c6114`/#405, which touched no
workflow files.) Narrower than "everything", still a gate that can go red
without anyone changing anything, which is what the pin is for.

Pinned to the version this PR was verified against, `zizmor==1.28.0` (currently
also the latest release).

## Test plan

Workflow-only change, so verification is static plus running the lint itself.
Local zizmor **1.28.0** (same `pip install zizmor` the workflow does):

- [x] **The lint is now gating — demonstrated, not asserted.** On the tree as
      committed, `zizmor --offline --persona regular --min-severity low
      .github/workflows/` prints `No findings to report. Good job!` and
      **exits 0**. I then temporarily deleted `persist-credentials: false` from
      `claude.yml` and re-ran the identical command: it reported
      `warning[artipacked]: credential persistence through GitHub Actions
      artifacts --> .github/workflows/claude.yml` at **medium** severity and
      **exited 13**. Restored, and confirmed the working tree matched the commit.
- [x] **Re-verified after pinning**, in a clean `python3.11 -m venv` running the
      same `pip install --upgrade pip` + `pip install zizmor==1.28.0` the
      workflow does: the spec resolves, `zizmor --version` reports `1.28.0`, and
      the clean tree exits 0. Also confirmed `zizmor==1.28.0` is present on PyPI
      and is the latest release, so the pin cannot fail to resolve in CI.
- [x] **Confirmed the old command was masking a failure**: without
      `--min-severity low`, the same clean tree exits **11** on the three
      informational `ci.yml` findings. This is why `continue-on-error` could not
      simply be deleted, and it is worth knowing that the step has been exiting
      non-zero on every run.
- [x] YAML parses for all three touched files
      (`python3 -c "import yaml; yaml.safe_load(open(f))"`).
- [ ] `Analyze (actions)` (CodeQL) — cannot run locally; actionlint is not
      installed on this machine, so I did not lint the workflows with it. Relying
      on the CI leg. The change adds one documented `actions/checkout` input,
      removes one step key, and adds one CLI flag, so there is no new expression
      or structure for it to object to.
- [ ] `cargo test -p turbovec --release` — not run; no Rust or Python source is
      touched by this PR.
- [ ] `pytest turbovec-python/tests/` — same.

The changelog gate scopes itself to `turbovec/src`, `turbovec-python/src` and
the shipped Python package, so it is not tripped.

**No CHANGELOG entry.** The CHANGELOG documents the crate and Python surfaces,
neither of which moves here, and precedent agrees. Recent CI-focused commits —
`53186c6`, `e9bc36a`, `5df6f3a`, `845bf3c`, `b471cf7`, `c954946` — **none added a
CHANGELOG entry** (`git show --name-only --format="" <sha> | grep -c CHANGELOG`
returns 0 for each). Most touch only `.github/`; `e9bc36a` is the strongest case,
because it also changed `.gitignore`, `CONTRIBUTING.md` and five files under
`turbovec/` including `src/encode.rs`, `src/lib.rs` and `src/rotation.rs`, and
*still* added no entry. A workflow-only change like this one is well inside that
precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
