### PR TITLE
ci: disable issue intake auto-triage

### DIFF
--- a/.github/workflows/intake.yml
+++ b/.github/workflows/intake.yml
@@ -18,6 +18,9 @@ concurrency:
 
 jobs:
   intake:
+    # Disabled: auto-triage no longer runs on newly opened issues. The workflow
+    # is kept intact so re-enabling it is a matter of deleting this one line.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 10 # hard cap on subscription spend per issue
     permissions:


### PR DESCRIPTION
Turns off the automatic triage run that fired on every newly opened issue.

The `intake` job is guarded with `if: false` rather than deleting the workflow: the trigger, the locked-down `permissions:` block, the pinned action SHAs and the read-only tool set all stay in place, so re-enabling is a one-line deletion. No jobs execute and no subscription spend is incurred while the guard is present.

Nothing else in the repo depends on this workflow — the `@claude` workflow (`claude.yml`) and the `/summarize` command workflow are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)