### PR TITLE
fix(#349): record the empty-batch divide-by-zero and pin its filtered forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -594,10 +594,14 @@ appears under each surface it touches.
   `(n_threads * 4).div_ceil(n_quads)` ranges, where
   `n_quads = nq.div_ceil(QBS)` — zero when `nq == 0`, so `search(&[], k)`
   aborted the calling thread with `attempt to divide by zero`. It hit at
-  every index size and on both index types, `search`, `search_with_mask`,
-  `IdMapIndex::search` and `search_with_allowlist` alike, whenever the
-  search ran on a rayon pool with more than one thread; a single-threaded
-  pool returns before the division. `n_quads` is now clamped to 1 at both
+  every index size and on both index types whenever the search ran on a
+  rayon pool with more than one thread; a single-threaded pool returns
+  before the division. The unmasked forms, `search` and
+  `IdMapIndex::search`, hit it on aarch64 and on SIMD-capable x86_64
+  alike; the masked forms — `search_with_mask`, and
+  `search_with_allowlist` when an allowlist is supplied — only on
+  aarch64, because the x86_64 dispatch marks a masked search serial and
+  so returns before dividing. `n_quads` is now clamped to 1 at both
   batch dispatches. The tile loop is empty at `nq == 0` either way, so the
   merge yields the same empty result. An empty batch stays a legal no-op
   returning an empty `SearchResults` rather than becoming a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,21 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **An empty query batch no longer panics with a divide-by-zero (#349).**
+  The batch dispatch splits the block axis into
+  `(n_threads * 4).div_ceil(n_quads)` ranges, where
+  `n_quads = nq.div_ceil(QBS)` — zero when `nq == 0`, so `search(&[], k)`
+  aborted the calling thread with `attempt to divide by zero`. It hit at
+  every index size and on both index types, `search`, `search_with_mask`,
+  `IdMapIndex::search` and `search_with_allowlist` alike, whenever the
+  search ran on a rayon pool with more than one thread; a single-threaded
+  pool returns before the division. `n_quads` is now clamped to 1 at both
+  batch dispatches. The tile loop is empty at `nq == 0` either way, so the
+  merge yields the same empty result. An empty batch stays a legal no-op
+  returning an empty `SearchResults` rather than becoming a
+  `SearchError`: it is a routine input — a filter that matched nothing,
+  an empty request page — and it already returned empty results wherever
+  it did not panic.
 - **The public Rust surface is fully documented, and two more panics have
   a `# Panics` heading (#324).** `RUSTFLAGS="-W missing_docs" cargo build
   -p turbovec` reported 55 warnings and now reports 0: the `AddError` and
@@ -1274,6 +1289,20 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **`search()` on an empty query batch no longer raises `PanicException`
+  (#349).** `ix.search(np.zeros((0, dim), np.float32), k)` reached a
+  divide-by-zero in the core's block-range tiling (see the Rust entry),
+  which crossed the PyO3 boundary as `pyo3_runtime.PanicException` rather
+  than any exception a caller would think to catch. It needed the batch to
+  run in the fork-safe pool, and for `nq == 0` that happens only when
+  `single_query_parallelizes(len(index))` is true — `len` rounded up to
+  32-vector blocks reaching `SINGLE_QUERY_PARALLEL_MIN_BLOCKS`, then 256,
+  so 8161 vectors and up, matching the bisect in the issue (8160 fine,
+  8161 panicking). Below that the extension's global rayon pool is pinned
+  to a single sentinel thread and the one-thread path returns before the
+  division. `TurboQuantIndex.search` and `IdMapIndex.search` now return
+  their documented `(0, effective_k)`-shaped arrays at any index size,
+  with or without `mask=` / `allowlist=`.
 - **A completed `save()` is durable: the integrations fsync the directory
   the index and side-car were renamed into (#350).** `os.replace`
   publishes a name by updating the *directory*, so fsyncing the two temp

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -622,32 +622,52 @@ fn block_parallel_mask_allows_fewer_than_k() {
     }
 }
 
-/// #349: an empty query batch must not panic. The bug was
-/// `(n_threads * 4).div_ceil(n_quads)` with `n_quads == 0`, and it only
-/// fired once the index was large enough to take the parallel batched
-/// path (bisected to n = 8161), so every small-index test missed it.
+/// #349: an empty query batch must not panic. The divisor is
+/// `(n_threads * 4).div_ceil(n_quads)` in `n_block_ranges`, fed by
+/// `n_quads = nq.div_ceil(QBS)`, which is zero for `nq == 0`.
 ///
-/// The expression was removed incidentally by the masked-search
-/// range-stride rewrite (#295), which means the fix shipped with no test.
-/// This pins it: an empty batch is a routine input and must return an
-/// empty result at any index size, on both index types.
+/// The filtered forms reach that division too, and on aarch64 they are
+/// the only forms that do at all: the x86 dispatch marks a masked search
+/// serial, so `n_block_ranges` returns before dividing, while the aarch64
+/// dispatch passes `serial = false` for masked and unmasked alike. So
+/// pinning the unmasked form alone would leave the masked one covered on
+/// exactly one target.
+///
+/// Runs on an explicit multi-thread pool: `n_threads == 1` short-circuits
+/// ahead of the division, which would make every assertion here vacuous
+/// on a single-core runner.
 #[test]
 fn empty_query_batch_is_not_a_panic_at_any_index_size() {
     let dim = 64;
+    let pool = rayon::ThreadPoolBuilder::new().num_threads(8).build().unwrap();
     for &n in &[16usize, 8160, 8161, 9000] {
         let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
         idx.add_2d(&gaussian_normalized(n, dim, 0x3490 + n as u64), dim).unwrap();
         idx.prepare();
-        let res = idx.search(&[], 5);
+        let res = pool.install(|| idx.search(&[], 5));
         assert_eq!(res.nq, 0, "n={n}: empty batch must report nq = 0");
         assert!(res.indices.is_empty(), "n={n}: empty batch returned indices");
+
+        // Same batch through the mask path.
+        let mask = vec![true; n];
+        let masked = pool.install(|| idx.search_with_mask(&[], 5, Some(&mask)));
+        assert_eq!(masked.nq, 0, "n={n}: masked empty batch must report nq = 0");
+        assert!(masked.indices.is_empty(), "n={n}: masked empty batch returned indices");
 
         let mut ids = IdMapIndex::new(dim, 4).unwrap();
         let id_vals: Vec<u64> = (0..n as u64).collect();
         ids.add_with_ids_2d(&gaussian_normalized(n, dim, 0x3491 + n as u64), dim, &id_vals)
             .unwrap();
         ids.prepare();
-        let (scores, out_ids) = ids.search(&[], 5);
+        let (scores, out_ids) = pool.install(|| ids.search(&[], 5));
         assert!(scores.is_empty() && out_ids.is_empty(), "n={n}: id-map empty batch");
+
+        let allow: Vec<u64> = id_vals.iter().copied().take(3).collect();
+        let (scores, out_ids) =
+            pool.install(|| ids.search_with_allowlist(&[], 5, Some(&allow)).unwrap());
+        assert!(
+            scores.is_empty() && out_ids.is_empty(),
+            "n={n}: id-map empty batch with an allowlist"
+        );
     }
 }

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -626,9 +626,9 @@ fn block_parallel_mask_allows_fewer_than_k() {
 /// `(n_threads * 4).div_ceil(n_quads)` in `n_block_ranges`, fed by
 /// `n_quads = nq.div_ceil(QBS)`, which is zero for `nq == 0`.
 ///
-/// The filtered forms reach that division too, and on aarch64 they are
-/// the only forms that do at all: the x86 dispatch marks a masked search
-/// serial, so `n_block_ranges` returns before dividing, while the aarch64
+/// The filtered forms reach that division too, but only on aarch64: the
+/// x86 dispatch marks a masked search serial, so `n_block_ranges`
+/// returns before dividing, while the aarch64
 /// dispatch passes `serial = false` for masked and unmasked alike. So
 /// pinning the unmasked form alone would leave the masked one covered on
 /// exactly one target.


### PR DESCRIPTION
Closes #349

## The finding: the code fix is already on `main`

I reproduced first, and the first thing the reproduction established is that the panic is **already fixed** at `origin/main` (8649664). The issue's repro, run against a wheel built from this branch:

```
turbovec 0.8.0 .../venv349/lib/python3.11/site-packages/turbovec/__init__.py
n=8160 OK (0, 5)
n=8161 OK (0, 5)
n=9000 OK (0, 5)
```

`97cba51` ("fix: empty query batch panicked with divide-by-zero") and `60c6114` landed the `.max(1)` clamp at both batch dispatches. What did **not** land was the CHANGELOG entry the release notes need, or coverage of the filtered forms. That is what this PR is.

## What was broken, and how I know

The divisor is `n_block_ranges` at `turbovec/src/search.rs:137`:

```rust
(n_threads * 4)
    .div_ceil(n_quads)      // n_quads == 0 when nq == 0
```

fed from the two batch dispatches by `n_quads = nq.div_ceil(QBS)` (aarch64, `search.rs:1816`) and `nq.div_ceil(NQ_BATCH)` (x86, `search.rs:2095`). Both now end in `.max(1)`.

Removing the aarch64 clamp locally and running the existing `#349` tests names the expression exactly:

```
thread 'empty_query_batch_is_not_a_panic_at_any_index_size' panicked at turbovec/src/search.rs:137:10:
attempt to divide by zero
test empty_query_batch_is_not_a_panic_at_any_index_size ... FAILED
```

```
attempt to divide by zero
test search_with_zero_queries_is_a_no_op_not_a_panic ... FAILED
```

**Why 8161.** Nothing about the divisor is size-dependent — with the clamp removed, an empty batch on an 8-thread pool panics at *every* index size I tried, `n = 1` included (per-case `catch_unwind` sweep, quoted below). The threshold is the Python binding's pool routing. `with_pool_if(nq > 1 || single_query_parallelizes(inner.len()))` — for `nq == 0` the first term is false, so the batch runs in the multi-threaded fork-safe pool only when `single_query_parallelizes(len)` holds; outside it, `pin_global_pool_sentinel()` pins the extension's global rayon pool to one thread and `n_block_ranges` returns before dividing. `single_query_parallelizes` is `n.div_ceil(32) >= SINGLE_QUERY_PARALLEL_MIN_BLOCKS`, and at `97cba51^` that constant was **256**: `8160.div_ceil(32) == 255` (safe), `8161.div_ceil(32) == 256` (panics). That is the reported bisect exactly. The constant is 1024 today (#336), so the same routing boundary would now sit at 32737 — the clamp makes it moot either way.

## Deciding what an empty batch should do

Return empty results, not a `SearchError`. Below the routing threshold it already returned `(0, k)`-shaped output, so erroring would be a new breaking behaviour introduced by a bug fix; and `SearchError`'s existing variants are all malformed-input conditions (ragged buffer, non-finite coordinate, mask length, unknown id), which an empty batch is not — it is a routine input (a filter that matched nothing, an empty request page). The clamp keeps that: the tile loop is empty at `nq == 0` regardless of `n_quads`, so the merge yields the same empty result.

## Sibling edge cases on the same divisor

Swept with `catch_unwind` on an 8-thread pool over `n ∈ {0, 1, 16, 8160, 8161, 9000, 40000}` × both index types × `{nq=0, nq=1, nq=64}` × `{k=0, k=5}` × `{no mask, all-true mask, all-false mask, allowlist, empty allowlist}`. **With the clamp in place every one of the 91 cases (7 sizes x 13 shapes) is OK.** With the aarch64 clamp removed, at `n = 8161`:

```
n=8161 nq=0 k=5: PANIC
n=8161 nq=0 k=0: OK
n=8161 nq=1 k=0: OK
n=8161 nq=1 k=5: OK
n=8161 nq=0 mask=all: PANIC
n=8161 nq=0 mask=none: OK
n=8161 nq=1 mask=none: OK
n=8161 nq=64 k=1: OK
idmap n=8161 nq=0 k=5: PANIC
idmap n=8161 nq=0 k=0: OK
idmap n=8161 nq=1 k=0: OK
idmap n=8161 nq=0 allowlist: PANIC
idmap n=8161 nq=0 allowlist-empty: OK
```

So `nq == 0` reaches the divisor through the mask path and the id-map allowlist path too — same expression, in scope — while `k = 0`, an all-false mask, an empty allowlist and an empty index all return before it (`search()` returns early once `k.min(n_allowed) == 0`, and an empty allowlist is `SearchError::AllowlistEmpty`). No sibling panics through a *different* expression; nothing to file separately.

## Discriminating evidence for the tests added here

The two `PANIC` rows above — `mask=all` and `idmap … allowlist` — are the forms this PR adds to `empty_query_batch_is_not_a_panic_at_any_index_size`. With the clamp restored the test passes:

```
test empty_query_batch_is_not_a_panic_at_any_index_size ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 21 filtered out
```

and with `nq.div_ceil(QBS).max(1)` reverted to `nq.div_ceil(QBS)` it fails with `attempt to divide by zero` at `search.rs:137:10` (output quoted above).

The masked form is worth its own coverage rather than being redundant with the unmasked one: the x86 dispatch passes `serial_required(mask.is_some(), …)` into `n_block_ranges`, so a masked search returns at the `serial` guard and never reaches the division, while the aarch64 dispatch passes a literal `false`. A regression on the masked path would therefore be aarch64-only, and nothing pinned it. *(That asymmetry is read from the source; this machine is arm64, so the x86 half is read-not-run.)*

The test now also runs on an explicit 8-thread pool. It previously relied on the ambient rayon pool being multi-threaded — true on my machine, which is why it discriminates above, but on a single-core runner `n_threads == 1` short-circuits ahead of the division and every assertion in it would have been vacuous.

## Also corrected

The test's doc comment claimed the bug "only fired once the index was large enough to take the parallel batched path (bisected to n = 8161)" and that the expression "was removed incidentally by the masked-search range-stride rewrite (#295)". Neither survives the evidence: the expression is live at `search.rs:137`, and with the clamp removed an empty batch panics at *any* index size — 8161 is a Python-binding routing threshold, not a property of the core. Rewritten to what I measured.

## Platform note

arm64 machine. Everything run here exercises the aarch64 dispatch (`search.rs:1816`). The x86 dispatch (`search.rs:2095`) carries the identical `.max(1)` clamp and shares `n_block_ranges`; that conclusion is read-not-run.

## Deliberately left out

- **No Python-level regression test.** The binding introduces no divisor of its own — its one `nq` division, `scores.len() / nq` at `turbovec-python/src/lib.rs:1208`, is already inside the `else` of an `if nq == 0`. I verified the Python surface by building a wheel from this branch and running the issue's repro (output at the top); the core test pins the divisor without depending on a routing constant that has already moved once.
- **The issue's second and third findings.** The `bool`-byte UB is already fixed on `main` (`turbovec-python/src/lib.rs:99`, CHANGELOG under the Python surface), and the "masks are invalidated by any mutation, not just length-changing ones" doc note is a separate docs change — out of scope for a divide-by-zero fix.
- **No CI change.** If you want one, the natural follow-up is a job that runs the Rust test suite under `RAYON_NUM_THREADS=1` *and* a multi-thread setting; this whole class of bug is invisible at one thread. Filing that is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
