### PR TITLE
chore: gitignore .claude/worktrees/ — and verification that #347's workflow findings are already fixed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,10 @@ jobs:
         run: cargo test -p turbovec --release --locked
 
       # Standalone cargo project that path-deps turbovec — exercises the
-      # same link path a downstream `cargo add turbovec` user hits. Since
-      # turbovec 0.10.0 (format v5) the crate has no native/BLAS dependency,
-      # so this must build and run with zero extra setup.
+      # same link path a downstream `cargo add turbovec` user hits. The
+      # crate has no native/BLAS dependency any more (removed with the v5
+      # block-Hadamard rotation, #206 — on `main`, not yet in a tagged
+      # release), so this must build and run with zero extra setup.
       - name: Downstream consumer smoke test
         run: cargo run --release --locked --manifest-path examples/downstream-smoke/Cargo.toml
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@ mutants.out.old/
 evolve/
 evolve_rust/
 dist/
+
+# Per-agent git worktrees created by Claude Code. `.claude/settings.json` is
+# tracked, so `.claude/` itself must stay un-ignored — only the worktrees are
+# excluded. Each one is a full checkout with its own `target/`, so without this
+# a `git add -A` from the repo root would stage thousands of duplicate source
+# files (the `target/` rule above does not help: it is the source trees, not
+# the build output, that get staged).
+.claude/worktrees/

--- a/examples/downstream-smoke/Cargo.toml
+++ b/examples/downstream-smoke/Cargo.toml
@@ -7,8 +7,11 @@ publish = false
 # Standalone crate (NOT a workspace member) that depends on turbovec via
 # a path dep. This exercises the same code path a downstream cargo user
 # hits when they `cargo add turbovec` and write their first program.
-# Since turbovec 0.10.0 the crate has no native/BLAS dependency at all —
-# this smoke test confirms a plain `cargo build` links and runs with zero
+# The crate now has no native/BLAS dependency at all: the v5 block-Hadamard
+# rotation removed the last GEMM and with it OpenBLAS/Accelerate, `faer`,
+# `ndarray` and the `build.rs` link shim (#206). That removal is unreleased —
+# it is on `main` but not in 0.9.0, the last tagged crate release — so this
+# smoke test is what confirms a plain `cargo build` links and runs with zero
 # extra ceremony.
 #
 # Run from this directory: `cargo run --release`.

--- a/examples/downstream-smoke/src/main.rs
+++ b/examples/downstream-smoke/src/main.rs
@@ -1,9 +1,10 @@
 //! Smoke test for the downstream `cargo add turbovec` experience.
 //!
 //! Exercises the public API end-to-end (construct, add, prepare, search,
-//! write, load). Since turbovec 0.10.0 the crate has no native/BLAS
-//! dependency, so this binary links and runs with a plain `cargo build`
-//! and no `extern crate blas_src;` ceremony.
+//! write, load). The crate has no native/BLAS dependency any more (removed
+//! with the v5 block-Hadamard rotation, #206 — on `main`, not yet in a tagged
+//! release), so this binary links and runs with a plain `cargo build` and no
+//! `extern crate blas_src;` ceremony.
 
 use turbovec::TurboQuantIndex;
 


### PR DESCRIPTION
Closes #347.

## TL;DR

**The headline defect in #347 is already fixed** — by #414 (`a3abe75`), merged
earlier today. I re-verified both of the issue's factual claims from scratch
rather than taking that PR's word for it, and both halves hold on current
`main`. So this PR makes no functional workflow change — its only
`.github/workflows/` edit is a comment fix, described below. What it does fix is
the one sub-item of #347 that is genuinely still open: `.claude/worktrees/`
matched no `.gitignore` rule.

## Claim 1 — "the only two checkouts that persist credentials"

True when filed, **false against current `main`**. I enumerated every
`actions/checkout` step in every file under `.github/workflows/`
programmatically (scanning each step block for a `persist-credentials` key), not
by sampling. **20 checkouts, 0 missing the flag:**

| Workflow | Checkout line(s) | `persist-credentials: false`? |
|---|---|---|
| `changelog.yml` | 25 | yes |
| `ci.yml` | 26, 90, 163, 237, 286, 362, 445 | yes (7/7) |
| `claude.yml` | 70 | yes |
| `intake.yml` | 31 | yes |
| `mutants.yml` | 60 | yes |
| `release-crates.yml` | 23 | yes |
| `release-pypi.yml` | 26, 129, 164, 196 | yes (4/4) |
| `security-audit.yml` | 40 | yes |
| `summarize-command.yml` | 50 | yes |
| `supply-chain.yml` | 48, 69 | yes (2/2) |

The issue cites `claude.yml:64-67` and `summarize-command.yml:46-49`; both now
carry the flag at the shifted line numbers above, with an explanatory comment.

### Did those two workflows actually need the token?

Worth confirming, because adding `persist-credentials: false` to a workflow that
pushes would break it. Checked both, and checked the action's source at the
pinned SHA rather than trusting the comment:

- **`summarize-command.yml`** cannot need it: the job is `contents: read`, the
  prompt is explicitly read-only ("do not push commits, edit files"), tools are
  `Bash,Read,Grep,Glob,LS,Skill,TodoWrite` (no `Edit`/`Write`), and the summary
  is posted with `gh pr comment` authenticated by `GH_TOKEN`.
- **`claude.yml`** is the one that needed checking — it has `contents: write`
  and the agent does push branches and open PRs. It does not rely on checkout's
  credential: `claude-code-action` at the pinned SHA
  `be7b93b1907a4abad570368f3c74b6fe3807510b`,
  `src/github/operations/git-config.ts`, explicitly runs
  `git config --unset-all http.<server>/.extraheader` under the comment
  "Remove the authorization header that actions/checkout sets", then supplies
  its own credential derived from the `github_token` input. The credential the
  fix removes was being discarded by the action anyway.

## Claim 2 — "the lint that catches it is non-gating"

`security-audit.yml`'s own comments claim `artipacked` **does** gate; #347 says
it does not. **The workflow comment is correct and the issue is out of date.** I
resolved this by running zizmor, not by reading, using the version the workflow
pins — clean `python3.11 -m venv`, `pip install zizmor==1.28.0`,
`zizmor --version` reporting `1.28.0` — and the workflow's exact command,
`zizmor --offline --persona regular --min-severity low .github/workflows/`:

- **Unmodified `main`:** `No findings to report. Good job! (3 ignored, 20 suppressed)`, **exit 0**.
- **Same tree, `persist-credentials: false` deleted from `claude.yml` only** — reproducing exactly the regression #347 describes:

```
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/claude.yml:70:9
   | _____^ does not set persist-credentials: false
   = note: audit confidence -> Low
24 findings (3 ignored, 20 suppressed, 1 unsafe fixes): 0 informational, 0 low, 1 medium, 0 high
```

**Exit 13.** The step carries no `continue-on-error` — the only remaining
`continue-on-error: true` anywhere in `.github/workflows/` is
`supply-chain.yml:92`, which is a different job. So a credential-persisting
checkout fails the build today. The `--min-severity low` floor does not spare it:
`artipacked` reports at *medium* severity (with Low *confidence*, a separate
axis), well above the floor. `claude.yml` was restored and `git status` confirmed
clean before committing.

Corroborating from real CI, not just locally: `security-audit.yml` has run and
concluded `success` on `main` since the fix landed, most recently at
2026-07-30T21:00Z (`fdf1bf0`, #429).

## What this PR actually changes

Two things: the `.gitignore` entry below, and the `downstream-smoke` comment fix
in the next section (added in review rounds 1 and 2).

One `.gitignore` entry, `.claude/worktrees/`, plus a comment explaining why it
is scoped to the subdirectory. Verified before: `git check-ignore -v
.claude/worktrees/foo` exited 1 (not ignored), and `git status` listed dozens of
untracked worktree directories. Verified after: the path is ignored by the new
rule, and `git check-ignore .claude/settings.json` still exits 1 — the tracked
settings file is deliberately unaffected, which is why the rule is
`.claude/worktrees/` and not `.claude/`.

Each worktree is a full checkout with its own `target/`, so without this a
`git add -A` from the root stages thousands of duplicate source files. The
existing `target/` rule does not help; it is the source trees that get staged.

## The `downstream-smoke` version comment (also #347, fixed here)

#347's last sub-item: `examples/downstream-smoke/Cargo.toml:10` said "Since
turbovec **0.10.0** the crate has no native/BLAS dependency" while
`turbovec/Cargo.toml:3` is `version = "0.9.0"`. There is no 0.10.0.

An earlier revision of this body deferred it to #343. **That was wrong on both
counts**, and it is fixed here instead: #343 is CLOSED (`stateReason:
COMPLETED`, 2026-07-29) and was never a version bump — its title is "Release
safety: nothing checks that the git tag matches the declared version". Once
`Closes #347` fires, no open issue would have tracked this.

The fix is not "change 10 to 9", because the removal did not happen in 0.9.0
either. Established from history, not assumed:

- The BLAS drop landed in **`0cc381c`** (#235, 2026-07-27) — "format v5 —
  block-Hadamard k=2 rotation (deterministic, drops OpenBLAS)". `git log -S`
  over `turbovec/Cargo.toml` shows exactly two touches of the BLAS deps: the
  `build.rs` link shim added in `8790529` (#79) and this removal.
- That is **after** the 0.9.0 release. `v0.9.0` is the newest `v*` tag, dated
  2026-06-10; `git merge-base --is-ancestor 0cc381c v0.9.0` **exits 1**, while
  the same check against `origin/main` **exits 0**.
- `turbovec/Cargo.toml` on `main` still declares `version = "0.9.0"`, and both
  CHANGELOG entries for the removal (the Rust "Removed" bullet and the Python
  "no longer bundles OpenBLAS" bullet, both `#206`) sit under `## [Unreleased]`
  — the next heading is `## turbovec 0.8.0 (Python) + turbovec 0.9.0 (Rust) —
  2026-06-10`.

So the removal is **real but unreleased**, and the comment now says that rather
than naming a version that has never existed. The claim it does make is checked:
`turbovec/build.rs` no longer exists, and `turbovec/Cargo.toml`'s dependencies
are `rayon`, `ordered-float`, `rand`, `rand_chacha`, `statrs` — no `faer`, no
`ndarray`, no BLAS. `cargo build` in `examples/downstream-smoke/` succeeds with
no native toolchain (one pre-existing `deprecated` warning on `loaded.dim()`,
untouched by this PR).

**The same false sentence appeared in three places, not one.** Besides the
manifest it was in `examples/downstream-smoke/src/main.rs:4` (the binary's module
doc) and in `.github/workflows/ci.yml:47-49`, the comment on the very CI step
that invokes this smoke test — so the repo contradicted itself at the two ends of
one step. All three are corrected consistently, none of them naming a version.
That is the whole of the extra diff: three comments, no code.

The two `since = "0.10.0"` strings in `#[deprecated(...)]`
(`turbovec/src/id_map.rs:592`, `turbovec/src/lib.rs:2361`) are deliberately left
alone. Those are forward-looking declarations about the next release, which is
conventional and correct — unlike a past-tense claim that a version already
shipped. A tree-wide `git grep -inE "0\.10\.0|native/BLAS|no native"` after the
fix returns only those two plus the three corrected comments and one
`## [Unreleased]` CHANGELOG line, all of which name no version.

**No CHANGELOG entry.** `CONTRIBUTING.md`'s "The changelog gate" section scopes
the gate to `turbovec/src/**.rs`, `turbovec-python/src/**.rs`, the shipped Python
package and the three manifests, and states "Tests, benchmarks, examples, docs
and workflows are out of scope entirely." Verified against the current file: the
gated paths are `turbovec/src/**.rs`, `turbovec-python/src/**.rs`,
`turbovec-python/python/turbovec/**.py` and the three manifests, and the gate
additionally ignores comments and blank lines even inside those. A `.gitignore`
entry, two comments in `examples/` and one comment in a workflow are outside the
gate twice over.

## Not run / could not verify

- **`security-audit.yml` will run on this PR, and is expected to pass.** It
  triggers on `pull_request` with `paths: [".github/workflows/**"]`, and the
  round-2 `ci.yml` comment fix puts the PR back inside that path filter. That is
  expected, not a problem: `GitHub Actions audit (zizmor)` already ran on an
  earlier SHA of this branch (`8ab9179`) and concluded **success**, every step
  included — so the gating step has been observed green in real CI here, not
  only locally. The round-2 change is a comment inside an existing step and
  touches no `actions/checkout`, no permissions and no `run:` line, so it cannot
  introduce a zizmor finding. I did not wait on the run to confirm.
- **No GitHub Actions run was executed by me.** I cannot demonstrate `claude.yml`
  or `summarize-command.yml` executing end-to-end. `gh run list
  --workflow=claude.yml` shows no non-`skipped` run at all in the last 60
  entries (the actor guard skips the rest), so I have no post-`a3abe75`
  execution to point at. The argument that they still work is source-level: the
  action unsets checkout's header regardless, as quoted above.

## Deliberately out of scope

Remaining #347 sub-items I verified and am *not* changing, so they are not lost:

- **`.github/claude/__pycache__/`** — already a non-issue in the repo.
  `git ls-files .github/claude/` returns nothing (no tracked file), and
  `__pycache__/` is `.gitignore` line 1. It is local disk residue only; removing
  it is a `rm`, not a commit.
- **Stray `=` and `err.log` in the repo root** — untracked, still present in my
  working tree, both 0 bytes. Not added to `.gitignore`: they are one-off shell
  typos, not recurring build artifacts, and an ignore rule would enshrine the
  typo. Suggested follow-up: just delete them.
*(The `downstream-smoke` version comment was previously listed here as deferred
to #343. That deferral was wrong and it is now fixed in this PR — see the
section above.)*

Suggested follow-up spotted while reading all ten workflows, not bundled:
`supply-chain.yml:92` has `continue-on-error: true`, so that step can only warn.
It may well be intentional — I did not investigate what it guards — but it is
now the only non-gating check in the directory, which is worth a deliberate
decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


