### PR TITLE
fix(#360): don't run the core's durability warning under the index read guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1293,6 +1293,23 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A `warnings` handler that touches the index it is saving no longer
+  deadlocks `write()` (#360).** The core's post-commit durability warning
+  (#365) is emitted from inside `write_with_durability`, so it ran
+  `warnings.warn` — and through it a user-replaceable `showwarning`, a
+  `logging.captureWarnings` handler or `sys.unraisablehook` — while the
+  binding still held the index read guard. A handler that called `add`,
+  `remove` or `swap_remove` on that same index asked for the write lock
+  from under a live read guard and blocked forever, wedging the pool
+  thread that emitted the warning; the save never returned. The message is
+  now queued while the guard is live and delivered by the saving thread
+  once the guard is gone, so the handler runs with no lock held. Delivery
+  is unchanged otherwise: same text, same `RuntimeWarning` category, same
+  order relative to the warm-up warning (durability first), and a filter
+  that raises still goes to `sys.unraisablehook` rather than failing an
+  already-committed save. The warm-up serialization warning had the same
+  defect and was fixed earlier; this was the remaining path.
+
 - **`search()` on an empty query batch no longer raises `PanicException`
   (#349).** `ix.search(np.zeros((0, dim), np.float32), k)` reached a
   divide-by-zero in the core's block-range tiling (see the Rust entry),

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -747,12 +747,17 @@ impl TurboQuantIndex {
         // separate probe could also report a state another thread has
         // already moved on from. Warn once back under the GIL (#354).
         let (state, len, result) = py.detach(|| {
+            // The post-commit fsync can warn (#365) from inside the pool,
+            // with this guard still held — queue it rather than let it run
+            // a user `showwarning` that could re-enter the index (#360).
+            let _defer = DeferCoreWarnings::new();
             let guard = lock_read(&self.inner);
             let state = guard.calibration_state();
             let len = guard.len();
             let result = with_pool(|| guard.write_with_durability(path, durability));
             (state, len, result)
         });
+        flush_core_warnings(py);
         warn_if_warming_up(py, &self.warmup_warned, state, len);
         result?
             // `load_err` names the path and narrows a missing directory to
@@ -1271,12 +1276,17 @@ impl IdMapIndex {
         // separate probe could also report a state another thread has
         // already moved on from. Warn once back under the GIL (#354).
         let (state, len, result) = py.detach(|| {
+            // See `TurboQuantIndex::write`: the core's post-commit
+            // durability warning must not run user Python under this
+            // guard (#360, #365).
+            let _defer = DeferCoreWarnings::new();
             let guard = lock_read(&self.inner);
             let state = guard.calibration_state();
             let len = guard.len();
             let result = with_pool(|| guard.write_with_durability(path, durability));
             (state, len, result)
         });
+        flush_core_warnings(py);
         warn_if_warming_up(py, &self.warmup_warned, state, len);
         result?
             // `load_err` names the path and narrows a missing directory to
@@ -1814,20 +1824,91 @@ fn init_rayon_pool(py: Python<'_>) -> PyResult<()> {
 /// `logging.captureWarnings(True)`, and visible to `pytest.warns`, none
 /// of which a bare `eprintln!` from a library can be.
 ///
-/// Attaching to the GIL here is safe from any thread: the core emits
-/// this while a save holds the index read lock, and this file's lock
+/// Attaching to the GIL here is safe from any thread: this file's lock
 /// discipline (see the note above `TurboQuantIndex`) is that the index
 /// lock is only ever *waited on* with the GIL released, so no thread can
 /// be holding the GIL while blocked on the lock we hold.
+///
+/// What is *not* safe is delivering while the save still holds the read
+/// guard, which is exactly when the core emits this: `warnings.warn`
+/// dispatches through the filter chain into a user-replaceable
+/// `showwarning`, and a handler that touches the same index asks for the
+/// write lock while the save read-holds it — an unconditional deadlock,
+/// the same defect the warm-up warning had (#360). So while a save is in
+/// flight the message is queued and [`flush_core_warnings`] delivers it
+/// once the guard is gone. Outside a save (no deferral open) there is no
+/// guard to wait on and the message goes straight out.
 fn emit_core_warning(message: &str) {
-    Python::attach(|py| {
-        // A filter that turns the warning into an error is the caller's
-        // business — it must not corrupt an already-committed save, and
-        // there is no `PyResult` to return it through from here.
-        if let Err(e) = emit_runtime_warning(py, message) {
-            e.write_unraisable(py, None);
-        }
-    });
+    if CORE_WARNINGS_DEFERRED.load(std::sync::atomic::Ordering::Acquire) > 0 {
+        pending_core_warnings().push(message.to_owned());
+        return;
+    }
+    Python::attach(|py| deliver_core_warning(py, message));
+}
+
+/// Emit one queued core message, routing a filter-raised error to
+/// `sys.unraisablehook`: turning it into an exception is the caller's
+/// business — it must not corrupt an already-committed save, and there is
+/// no `PyResult` to return it through from here.
+fn deliver_core_warning(py: Python<'_>, message: &str) {
+    if let Err(e) = emit_runtime_warning(py, message) {
+        e.write_unraisable(py, None);
+    }
+}
+
+/// Core messages emitted while a save held the index read lock, waiting
+/// for [`flush_core_warnings`].
+static PENDING_CORE_WARNINGS: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+
+/// Number of [`DeferCoreWarnings`] regions currently open, across all
+/// threads. A count rather than a flag because saves run concurrently.
+static CORE_WARNINGS_DEFERRED: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// The pending queue, recovering from poisoning for the same reason
+/// [`lock_read`] does: a panic that escaped an earlier warning must not
+/// turn every later save into a panic.
+fn pending_core_warnings() -> std::sync::MutexGuard<'static, Vec<String>> {
+    PENDING_CORE_WARNINGS
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// While alive, [`emit_core_warning`] queues instead of delivering. Held
+/// across the whole detached section of a save — that is, for exactly as
+/// long as the index read guard exists.
+struct DeferCoreWarnings;
+
+impl DeferCoreWarnings {
+    fn new() -> Self {
+        CORE_WARNINGS_DEFERRED.fetch_add(1, std::sync::atomic::Ordering::Release);
+        Self
+    }
+}
+
+impl Drop for DeferCoreWarnings {
+    fn drop(&mut self) {
+        CORE_WARNINGS_DEFERRED.fetch_sub(1, std::sync::atomic::Ordering::Release);
+    }
+}
+
+/// Deliver everything [`emit_core_warning`] queued, from a caller that
+/// holds no index guard. Called by every save that opened a deferral,
+/// before it warns about warm-up, which keeps the order a save's two
+/// warnings arrive in (durability first, then warm-up).
+///
+/// Nothing can be stranded in the queue: the only producer is the
+/// post-commit fsync inside `write_with_durability`, which runs inside
+/// the `with_pool` call the saving thread is blocked on, so a queued
+/// message is always pushed before that save's own flush. Concurrent
+/// saves share one queue, so a message can be delivered on a different
+/// save's thread than the one that produced it — it names its own path,
+/// and both saves flush, so it is delivered exactly once either way.
+fn flush_core_warnings(py: Python<'_>) {
+    let queued = std::mem::take(&mut *pending_core_warnings());
+    for message in queued {
+        deliver_core_warning(py, &message);
+    }
 }
 
 /// Number of stack frames [`emit_runtime_warning`] is willing to walk out

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -436,9 +436,34 @@ print("RESULT: PASS")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
-def test_durability_warning_handler_may_reenter_the_index():
+def test_durability_warning_handler_may_reenter_the_index(tmp_path):
     import subprocess
     import sys
+
+    # Decide whether this environment can provoke the warning at all
+    # *before* launching the payload, using the same probe as the sibling
+    # test above: strip read permission and check that reading is really
+    # refused. Under root it is not, the core's `File::open(dir)` succeeds,
+    # and no durability warning is ever emitted.
+    #
+    # This discriminator is environmental and runs in the parent, so it
+    # cannot absorb a failure of the payload's own assertions. Grepping the
+    # child's stderr for "AssertionError" could — and did: a build that
+    # queues the durability warning and never flushes it fails
+    # `assert any("power loss" in s for s in seen)`, which that grep turned
+    # into a skip, i.e. a green CI run for a broken queue.
+    probe = tmp_path / "no-read"
+    probe.mkdir()
+    os.chmod(probe, 0o300)
+    try:
+        try:
+            os.listdir(probe)
+        except PermissionError:
+            pass
+        else:
+            pytest.skip("directory mode not enforced (running as root?)")
+    finally:
+        os.chmod(probe, 0o700)
 
     try:
         proc = subprocess.run(
@@ -453,8 +478,7 @@ def test_durability_warning_handler_may_reenter_the_index():
             "while the save held the index read lock, so the handler's add "
             "blocked forever on the write lock (#360)"
         )
-    if "running as root" in proc.stderr or "AssertionError" in proc.stderr:
-        # An unenforced directory mode means no warning fired at all;
-        # the sibling test above skips for the same reason.
-        pytest.skip(f"directory mode not enforced:\n{proc.stderr}")
+    assert proc.returncode == 0, (
+        f"payload exited {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
     assert "RESULT: PASS" in proc.stdout, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"

--- a/turbovec-python/tests/test_index.py
+++ b/turbovec-python/tests/test_index.py
@@ -385,3 +385,76 @@ def test_durability_shortfall_surfaces_as_a_runtime_warning(tmp_path):
         assert path.exists(), "the rename committed, so the file must be there"
     finally:
         os.chmod(d, 0o700)
+
+
+# That durability warning is emitted by the core from *inside*
+# `write_with_durability`, i.e. while the binding still holds the index
+# read guard — and it reaches Python through a user-replaceable
+# `showwarning`. A handler that touches the same index then asks for the
+# write lock while the save read-holds it: deadlock, the same defect the
+# warm-up warning had (#360, whose fix left this path unguarded). Runs in
+# a fresh interpreter under a hard timeout — a regression would otherwise
+# hang pytest itself, and it wedges the *pool* thread that emits the
+# warning, so it cannot be unwound in-process.
+_REENTRANT_DURABILITY_HANDLER = r'''
+import os
+import stat
+import sys
+import tempfile
+import warnings
+
+import numpy as np
+import turbovec
+
+DIM = 32
+rng = np.random.default_rng(0)
+idx = turbovec.TurboQuantIndex(DIM, 4)
+idx.add(rng.standard_normal((10, DIM), dtype=np.float32))
+extra = rng.standard_normal((5, DIM), dtype=np.float32)
+
+seen = []
+
+
+def showwarning(message, category, filename, lineno, file=None, line=None):
+    seen.append(str(message))
+    idx.add(extra)          # re-enters the index the save is holding
+
+
+d = tempfile.mkdtemp()
+warnings.simplefilter("always")
+warnings.showwarning = showwarning
+os.chmod(d, stat.S_IWUSR | stat.S_IXUSR)   # writable+traversable, not readable
+try:
+    idx.write(os.path.join(d, "index.tv"), durable=True)
+finally:
+    os.chmod(d, 0o700)
+
+assert any("power loss" in s for s in seen), seen
+assert len(idx) == 20, len(idx)             # 10 + 2 handlers x 5
+print("RESULT: PASS")
+'''
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
+def test_durability_warning_handler_may_reenter_the_index():
+    import subprocess
+    import sys
+
+    try:
+        proc = subprocess.run(
+            [sys.executable, "-c", _REENTRANT_DURABILITY_HANDLER],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            "the durability-shortfall warning DEADLOCKED: it ran user Python "
+            "while the save held the index read lock, so the handler's add "
+            "blocked forever on the write lock (#360)"
+        )
+    if "running as root" in proc.stderr or "AssertionError" in proc.stderr:
+        # An unenforced directory mode means no warning fired at all;
+        # the sibling test above skips for the same reason.
+        pytest.skip(f"directory mode not enforced:\n{proc.stderr}")
+    assert "RESULT: PASS" in proc.stdout, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"


### PR DESCRIPTION
Refs #360 — deliberately **not** `Closes`. #360's item 3 has an `ignore` half this PR leaves out of scope (a save under `warnings.simplefilter("ignore")` still consumes that index's warm-up latch, so the next genuinely-important warming-up save is silent). That remaining half is tracked in #434, labelled `needs-human-decision` because it is the policy question #416 deferred. Merging this must not auto-close a half-live issue.

## Scope first: the two items in the title are already fixed on `main`

Re-audited `origin/main` (9f13bb3) before touching anything, and verified by execution rather than by reading. `warn_if_warming_up` (`turbovec-python/src/lib.rs:375`) has exactly four call sites — `TurboQuantIndex.write` `:756`, `TurboQuantIndex.to_bytes` `:804`, `IdMapIndex.write` `:1280`, `IdMapIndex.to_bytes` `:1330` — and all four already read:

```rust
let (state, len, result) = py.detach(|| {
    let guard = lock_read(&self.inner);
    let state = guard.calibration_state();
    let len = guard.len();
    let result = with_pool(|| guard.write_with_durability(path, durability));
    (state, len, result)
});
warn_if_warming_up(py, &self.warmup_warned, state, len);
```

The guard dies with the closure, so the warn runs with no lock held (item 1); the `lock_read` is inside `py.detach` (item 2, the #289 class); the probe shares the serialization's acquisition, so there is no separate probe to race (item 4); and the latch is a per-index field stored only on a warn that returned (item 3's `error` half). Measured, all four save paths let a `showwarning` that re-enters the same index run to completion:

```
TurboQuantIndex.to_bytes           RETURNED  reentered=['RuntimeWarning']
TurboQuantIndex.write              RETURNED  reentered=['RuntimeWarning']
IdMapIndex.to_bytes                RETURNED  reentered=['RuntimeWarning']
IdMapIndex.write                   RETURNED  reentered=['RuntimeWarning']
RESULT: all four returned
```

So this PR does not re-fix those. It fixes the one place the same defect is **still live**, which the issue's call-site list did not include.

## What was broken

`emit_core_warning` (`lib.rs:1822`) routes the core crate's non-fatal diagnostics into `warnings`. Its only producer is `sync_parent_dir_after_commit` (`turbovec/src/io.rs:1229`), the post-commit parent-directory fsync inside `write_with_durability` — which the binding calls **inside** the `py.detach` closure, with the index read guard live. So `Python::attach` → `warnings.warn` → the filter chain → a user-replaceable `showwarning` all ran under the guard. A handler that calls `add` / `remove` / `swap_remove` on that same index requests the write lock from under a live read guard: unconditional deadlock, and the save never returns.

The doc comment on `emit_core_warning` argued this was safe, but it only argued the *lock-ordering* half ("no thread can be holding the GIL while blocked on the lock we hold"), which is the #289 class. It did not cover re-entrancy, and it named the hazardous condition itself: "the core emits this while a save holds the index read lock".

### Reproduction (on `main`, before the fix)

Timed — the save runs on a worker thread joined with a 20 s timeout, so a deadlock reports `HUNG` instead of hanging the run. The parent directory is chmodded `0o300` (writable + traversable, not readable) so the post-rename `File::open(dir)` fails and the shortfall warning fires; that is the same recipe `turbovec/tests/io_hardening.rs:545` already uses.

```
inert handler    : returned  box={'ok': True}  warnings seen=['/var/folders/.../tmpbgg60ygl',
                                                              'serializing an index that holds only 10 vectors: ...']
reentrant handler: HUNG (>20.0s) -- DEADLOCK; warnings seen=['/var/folders/.../tmpp9xifnih']
RESULT: DEADLOCK OBSERVED
```

The inert handler shows both warnings arriving normally; only the re-entrant one wedges, and it wedges on the *first* (durability) warning. Also measured: the durability warning is delivered on a **different** thread from the caller (a pool worker inside `with_pool`), while the warm-up warning is delivered on the caller's thread — which is why the fix cannot be a thread-local on the calling thread.

## The fix, and why this shape

Same shape the warm-up warning already uses — do the lock-holding work, drop the guard, *then* run the Python hook — adapted to the fact that the message originates on a pool thread deep inside the core call:

- `DeferCoreWarnings`, an RAII region opened inside the `py.detach` closure of both `write` methods, i.e. for exactly as long as the read guard exists. While any region is open, `emit_core_warning` pushes the message onto `PENDING_CORE_WARNINGS` instead of attaching the GIL.
- `flush_core_warnings(py)` runs right after `py.detach` returns — guard gone, GIL held — and before `warn_if_warming_up`, which preserves the observed arrival order (durability first, then warm-up).
- Outside any region there is no guard to wait on, so the message is delivered inline exactly as before.

Nothing can be stranded in the queue: the only producer runs inside the `with_pool` call the saving thread is blocked on, so every queued message is pushed before that save's own flush. Concurrent saves share one queue, so a message can be delivered on a different save's thread than the one that produced it — it names its own path, both saves flush, and it is delivered exactly once either way. That trade-off is written into the code comment rather than left implicit.

An `AtomicUsize` region count rather than a flag, because saves run concurrently; the queue mutex recovers from poisoning for the same reason `lock_read` does.

## Discriminating evidence

New test: `turbovec-python/tests/test_index.py::test_durability_warning_handler_may_reenter_the_index`. It runs the re-entrant handler in a fresh interpreter under a 60 s `subprocess.run` timeout — a regression fails the test rather than hanging pytest, which matters here because the wedged thread is a pool thread that cannot be unwound in-process. It also asserts the payload's returncode, that the warning actually fired (`"power loss" in seen`), and that both handler invocations landed (`len(idx) == 20`).

Its only skip is an **environmental probe in the parent**, borrowed from the sibling test at `:373`: chmod a directory `0o300` and confirm `os.listdir` really raises `PermissionError`. That runs before the subprocess launches, so it covers the unenforced-directory-mode case (root) by construction and structurally cannot absorb a failure of the payload's own assertions. A build that emits no warning therefore **fails**; it does not skip.

That distinction was not academic. An earlier revision of this test grepped the child's stderr for `"AssertionError"` and skipped on a hit — but the payload's assertions are uncaught in a `python -c`, so a genuinely broken build printed `AssertionError` and was swallowed into a skip, which CI treats as success. Demonstrated with a real product regression rather than a test mutation: **both `flush_core_warnings` calls disabled, both `DeferCoreWarnings` regions left intact** — the exact strand the new queue makes possible, where the durability message is queued and never delivered.

Old test, strand build — green in CI:

```
SKIPPED [1] tests/test_index.py:459: directory mode not enforced:
AssertionError: ['serializing an index that holds only 10 vectors: ...']
1 skipped, 42 deselected in 0.20s
```

Repaired test, byte-identical strand build (`sha256 1c728e47836b…`):

```
E       AssertionError: payload exited 1
E         stderr:
E         AssertionError: ['serializing an index that holds only 10 vectors: ...']
1 failed, 42 deselected in 0.20s
```

The deadlock arm was re-confirmed against the repaired test on a **full** revert of `lib.rs` to `origin/main`, so the blind spot was closed without opening another one — `subprocess.TimeoutExpired` is still raised out of `subprocess.run` before any assertion runs:

```
E           Failed: the durability-shortfall warning DEADLOCKED: ...
1 failed, 42 deselected in 60.12s (0:01:00)
```

**With the fix:**

```
2 passed, 41 deselected, 1 warning in 0.30s
```

**With the fix reverted** (both `DeferCoreWarnings` regions and both `flush_core_warnings` calls removed, rebuilt, reinstalled):

```
E           Failed: the durability-shortfall warning DEADLOCKED: it ran user Python
            while the save held the index read lock, so the handler's add blocked
            forever on the write lock (#360)

1 failed, 42 deselected in 60.38s (0:01:00)
```

It fails by timing out, as designed, rather than hanging. Restoring the fix rebuilt a byte-identical extension (`sha256 cb35d603b86f…`, same as the pre-revert build).

Also verified on the fixed build, because the CHANGELOG entry claims them:

- Both warnings still delivered, in the original order: `['/var/folders/.../tmp…', 'serializing an index that holds only 10 vectors: …']`.
- Under `simplefilter("error")` the save still completes (`write returned normally: True`, `file exists: True`) and both raised warnings go to `sys.unraisablehook` (`unraisable count: 2`) — unchanged behaviour for an already-committed save.
- Full Python suite: `305 passed, 151 skipped` (the skips are the integration frameworks, which are not installed in the verification venv).

### How the binding was verified

The stale-binding trap fired once and was caught: the shared scratchpad already contained a `venv/`, and `python3.12 -m venv venv` over it produced a half-3.11/half-3.12 environment whose `pip` installed into `lib/python3.12/site-packages` while its `python` imported an **old** turbovec from `lib/python3.11/site-packages`. Every measurement above was redone in a uniquely-named fresh venv, with `maturin build --release` plus `pip install --no-cache-dir --force-reinstall --no-deps` of the wheel, no `maturin develop`, no source-redirecting `.pth`, and the loaded package path plus `sys.version` printed by every script. The installed `.so` was additionally checked by string signature (`serializing an index`, present only in the current source) and by sha256 across the revert/restore cycle.

## Out of scope, deliberately

- **The `ignore` half of item 3.** A serialization under `simplefilter("ignore")` still consumes that index's latch. `warnings.warn` returns `None` whether the chain delivered or dropped the warning, so this needs a delivery signal the stdlib does not expose; the alternatives are policy changes (drop the latch and accept a flood, or leave `warnings` for a channel where delivery is observable), which #416 explicitly left for a maintainer decision. Untouched here, and now tracked separately as **#434** (`needs-human-decision`) — which is why this PR says `Refs #360`, not `Closes #360`. Reproduced on this build:

```
ignore-half, warns after a suppressed save: []      <- latch burned while suppressed
error-half,  warns after an errored save: [...]     <- fixed
```
- **`to_bytes` on either class.** It never touches the filesystem, so it cannot reach the only core-warning producer today. Deferring there would be speculative; if a future core diagnostic is added to the serialization path, it needs the same region.
- **The calibration bug at the bottom of #360's body** (drain-to-zero then a large add losing TQ+): reported fixed by #416, not re-verified here.
- **Regression-prevention infrastructure.** A CI check that flags `Python::attach` / `warnings.warn` reachable from inside a `lock_read` region would have caught both this and the original #360, and is worth its own issue — but it is not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

