### PR TITLE
ci: review on Opus 5, and fix the unsound checkout ternary

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -98,7 +98,10 @@ jobs:
           # have no PR context, so name the head ref explicitly — otherwise the
           # agent would read source and CLAUDE.md from the default branch while
           # reviewing a different diff.
-          ref: ${{ github.event_name == 'pull_request' && '' || format('refs/pull/{0}/head', steps.guard.outputs.pr) }}
+          # Written so the truthy branch is the non-empty one: `A && '' || B`
+          # is unsound in GitHub expressions, because `''` is falsy and the `||`
+          # then yields B on *both* paths (zizmor: unsound-ternary).
+          ref: ${{ github.event_name != 'pull_request' && format('refs/pull/{0}/head', steps.guard.outputs.pr) || '' }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -139,8 +142,11 @@ jobs:
           # having: the plugin's own instructions tell agents to judge from the
           # diff, so without this the validators never execute anything. Drop
           # these two lines if you would rather keep reviews fast and cheap.
+          # `--model` sets the orchestrator only; the plugin picks its own model
+          # per subagent (haiku for the skip check, sonnet for CLAUDE.md
+          # compliance, opus for the bug hunters and validators) — leave that to it.
           claude_args: |
-            --model claude-fable-5
+            --model claude-opus-5
             --max-turns 100
             --allowedTools "Bash,Edit,Write,Read,Grep,Glob,LS,WebSearch,WebFetch,Task,TodoWrite"
             --append-system-prompt "You are reviewing, not authoring: do not edit files, commit, or push. When validating a candidate issue you MAY build and run the test suite (cargo build / cargo test -p turbovec) to confirm or refute it — prefer executed evidence over reasoning about the diff. Never run linters or formatters (clippy, rustfmt, or any lint task): CI runs those separately, and anything a linter would catch must not be reported here."

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -94,14 +94,14 @@ jobs:
       - if: steps.guard.outputs.ok == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # `pull_request` already checks out the PR; the other two triggers
-          # have no PR context, so name the head ref explicitly — otherwise the
-          # agent would read source and CLAUDE.md from the default branch while
-          # reviewing a different diff.
-          # Written so the truthy branch is the non-empty one: `A && '' || B`
-          # is unsound in GitHub expressions, because `''` is falsy and the `||`
-          # then yields B on *both* paths (zizmor: unsound-ternary).
-          ref: ${{ github.event_name != 'pull_request' && format('refs/pull/{0}/head', steps.guard.outputs.pr) || '' }}
+          # Always the PR head, on every trigger. `@review` and workflow_dispatch
+          # carry no PR context, so the ref has to be named explicitly there or
+          # the agent would read source and CLAUDE.md from the default branch
+          # while reviewing a different diff. Naming it unconditionally also
+          # keeps `pull_request` on the head rather than checkout's default merge
+          # ref, so all three paths review the same tree — the code the author
+          # actually wrote, matching the diff the plugin fetches via `gh pr diff`.
+          ref: refs/pull/${{ steps.guard.outputs.pr }}/head
           fetch-depth: 1
           persist-credentials: false
 


### PR DESCRIPTION
Two changes to `pr-review.yml`.

## Opus 5

Switches the review orchestrator from `claude-fable-5` to `claude-opus-5`. This is the **top-level model only** — the `code-review` plugin picks its own model per subagent (haiku for the skip check, sonnet for CLAUDE.md compliance, opus for the bug hunters and validators), and that stays its call.

## Unconditional PR-head checkout (fixes the red audit on main)

The checkout ref was a pseudo-ternary that `zizmor` flags as `unsound-ternary`, and it has left `security-audit` red on `main` since #435:

```
ref: ${{ github.event_name == 'pull_request' && '' || format(...) }}
```

`A && '' || B` does not work as a ternary in GitHub expressions — the empty string is falsy, so the `||` fires on **both** paths.

Rather than rewrite the expression correctly, this drops it. The guard step already resolves the PR number on all three trigger paths, so one unconditional ref covers everything:

```yaml
ref: refs/pull/${{ steps.guard.outputs.pr }}/head
```

No expression, so there is nothing for the audit to flag — soundness by construction rather than by getting operator precedence right.

It also removes a silent behavioral fork. Previously `pull_request` fell through to `actions/checkout`'s default **merge** ref while `@review` and `workflow_dispatch` used the **head** ref, so the same PR was reviewed against a different tree depending on how the review was triggered.

Head ref is the right target for a reviewer: the plugin takes its diff from `gh pr diff` (`base...head`), so checking out the head means the tree and the diff describe the same thing. A merge-ref checkout would show the agent file content that is not in the diff it was handed — the exact setup that manufactures false positives. It is also deterministic, where the merge ref shifts as `main` moves. Semantic conflicts with `main` are left to CI, which already tests the merge result.

## Note

This PR is the first live exercise of `pr-review.yml` — it fires on `opened`. The plugin skips PRs it judges trivial, so it may post nothing; that still confirms the plugin installs, authenticates, and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)