### PR TITLE
fix: pin statrs to =0.17.1 — its inverse_cdf feeds encoded bytes (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,21 @@ appears under each surface it touches.
 
 #### Changed
 
+- **`statrs` is now an exact version requirement, `=0.17.1` (#346).** It was
+  the caret range `"0.17"`, so any 0.17.x patch release was picked up
+  automatically by a downstream build with no lockfile. `statrs` is not an
+  ordinary dependency here: `Beta::inverse_cdf` sets the TQ+ calibration
+  (`tqplus_shift`/`tqplus_scale`), which is written into the file and
+  multiplies every coordinate before coding. `Beta` does not override
+  `ContinuousCDF::inverse_cdf` in 0.17.1, so it gets the trait default — a
+  fixed 16-step bisection on `[-2, 2]` — and an upstream patch that
+  specialises it, an ordinary improvement to make, would change encoded
+  bytes. Measured: perturbing both `inverse_cdf` results by 3.05e-5 moves
+  the calibration, codes, scales and file hashes of all six
+  `encode_fingerprint` cells. `rand_chacha` is pinned for the same reason;
+  this closes the matching hole. `0.17.1` is what the lockfile already
+  resolved and the newest 0.17.x published, so no build changes version.
+
 - **The #383 below-the-table add gate is pinned structurally, not by wall
   clock (#409, #420).** `deferred_adds_below_the_table_do_not_scale_with_n`
   now asserts that the load-time sorted table is byte-identical after the

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -23,7 +23,17 @@ rand = "0.8"
 # invalidate every index — the same #206 bug class this format break fixed —
 # so the version is frozen and a golden-bytes test guards it.
 rand_chacha = "=0.3.1"
-statrs = "0.17"
+# Pinned to an exact version for the same reason as `rand_chacha` above.
+# `encode::compute_tqplus_calibration` calls `Beta::inverse_cdf`, and `Beta`
+# does not override `ContinuousCDF::inverse_cdf` in 0.17.1 — it gets the trait
+# default in `distribution/mod.rs`, a fixed 16-step bisection on `[-2, 2]`.
+# Its result sets `tqplus_shift`/`tqplus_scale`, which are stored in the file
+# and multiply every coordinate before coding, so a 0.17.x patch release that
+# specialises `inverse_cdf` (or changes that iteration count) would change
+# encoded bytes — a non-breaking-looking upstream change that silently
+# invalidates existing indexes (#346). `tests/encode_fingerprint.rs` pins the
+# resulting bytes; this pin stops the input from moving under it unasked.
+statrs = "=0.17.1"
 
 [features]
 # Debug/test telemetry: count 32-vector blocks short-circuited by the

--- a/turbovec/tests/codebook_determinism.rs
+++ b/turbovec/tests/codebook_determinism.rs
@@ -17,10 +17,15 @@
 //!   changes its special functions by an ulp, or a libm update. The
 //!   fingerprint leg cannot see this: it compares three OSes *within a
 //!   single locked build*, so a drift that moves every platform together
-//!   passes it silently. `rand_chacha` is exact-pinned (`=0.3.1`)
-//!   precisely because the rotation's byte stream is format-frozen;
-//!   `statrs` is a caret range, so this test is the equivalent guard for
-//!   the codebook.
+//!   passes it silently. Both inputs that can move this way are
+//!   exact-pinned for the same reason — `rand_chacha` at `=0.3.1`
+//!   because the rotation's byte stream is format-frozen, `statrs` at
+//!   `=0.17.1` because the codebook and the TQ+ calibration are (#346).
+//!   A pin is not a guard, though: it fixes the version, not the
+//!   values, so it does nothing about a libm update, and it is one
+//!   manifest line that a deliberate bump or a dependency sweep can
+//!   raise. This test is what makes any of those fail loudly for the
+//!   codebook.
 //!
 //! The constants below are not local observations — they are the values
 //! Linux, macOS and Windows independently agreed on in the

--- a/turbovec/tests/encode_fingerprint.rs
+++ b/turbovec/tests/encode_fingerprint.rs
@@ -14,14 +14,19 @@
 //!
 //! Such changes are routine, not exotic:
 //!
-//! * `statrs` is a caret range (`"0.17"`). `Beta` does not override
-//!   `ContinuousCDF::inverse_cdf`, so `encode::fit_calibration` gets the
-//!   trait default — a fixed 16-step bisection on `[-2, 2]`, resolution
-//!   6.1e-5, whose own doc comment calls it "ill-behaved". A patch
+//! * `statrs` decides the TQ+ calibration. `Beta` does not override
+//!   `ContinuousCDF::inverse_cdf`, so `encode::compute_tqplus_calibration`
+//!   gets the trait default — a fixed 16-step bisection on `[-2, 2]`,
+//!   resolution 6.1e-5, whose own doc comment calls it "ill-behaved". A
 //!   release adding a specialised `inverse_cdf` — an obvious upstream
 //!   improvement — moves `tqplus_shift`/`tqplus_scale` by ~5e-4
 //!   relative, which flips ~0.1% of all codes and changes every stored
-//!   scale. Nothing failed (#346).
+//!   scale. Nothing failed (#346). The dependency is now exact-pinned
+//!   (`=0.17.1`), so that upgrade can no longer arrive on its own — but
+//!   the pin only decides *which* version is compiled, not what the
+//!   resulting bytes are, and it is one line that a deliberate bump or a
+//!   routine dependency sweep can raise. This test is what turns such a
+//!   bump into a visible byte change instead of a silent one.
 //! * `NORM_CHAINS` and the frozen combine tree decide the per-vector
 //!   norm. `norm_simd_matches_scalar_bit_exactly` compares SIMD to the
 //!   scalar reference, so a change to the *reference* moves both and


### PR DESCRIPTION
Closes #346.

## What `statrs` actually reaches

Traced, not inherited:

- `turbovec/src/encode.rs:667-672` — `compute_tqplus_calibration` builds
  `Beta::new(a, a)` with `a = (dim - 1) / 2` and calls
  `beta.inverse_cdf(TQPLUS_P_LO)` / `(TQPLUS_P_HI)` (0.05 / 0.95) to get
  `qc_lo`/`qc_hi`, the canonical quantiles the empirical ones are mapped onto.
- Those set the per-coordinate `tqplus_shift` / `tqplus_scale`, which are applied
  to every rotated coordinate before quantization and are serialized into the
  index file.

So `statrs` is on the encoded-byte path, not merely on a metrics path.

`statrs-0.17.1/src/distribution/beta.rs` has no `inverse_cdf` override — only
`impl ContinuousCDF<f64, f64> for Beta`. It therefore uses the trait default at
`distribution/mod.rs:117-144`, which is a fixed `let mut i = 16;` bisection
starting from `[-2, 2]`. Confirmed by reading the vendored 0.17.1 source. A
patch release specialising `Beta::inverse_cdf`, or changing that iteration
count, is an ordinary non-breaking upstream change that would move the value.

**Demonstrated.** I temporarily added `+ 3.05e-5` to both `inverse_cdf` results
in `encode.rs` and re-ran the golden test. Before:

```
running 4 tests
test the_pinned_calibration_is_actually_fitted ... ok
test the_tqplus_fit_threshold_is_exactly_where_it_has_always_been ... ok
test the_recon_table_threshold_does_not_change_encoded_bytes ... ok
test encode_fingerprint_is_frozen ... ok
test result: ok. 4 passed; 0 failed
```

After the perturbation, `encode_fingerprint_is_frozen` fails on the
`calibration`, `codes`, `scales` and `file` columns of **all six** cells, e.g.

```
  dim=1536 bits=4 calibration: got 0dabc1cdd15dc1f3, want 258d63b4ed365a8b
  dim=1536 bits=4 codes:       got 67d0e61374fd1d9c, want 6ea28fd7af0b94ea
  dim=1536 bits=4 scales:      got 0489aa67835e0c97, want 90a0225c11099389
  dim=1536 bits=4 file:        got 890d860a669772a2, want 73373deb1ffdc8c3
```

The perturbation was then reverted; this PR contains no `encode.rs` change.

## Which half of #346 this fixes, and why only that half

The issue offers two fixes. They are not equivalent and only one is still open:

- **(b) "nothing detects it if the bytes do change" — already fixed on `main`.**
  `turbovec/tests/encode_fingerprint.rs` landed since the issue was filed. It
  pins absolute golden hashes for `boundaries, centroids, calibration, codes,
  scales, file` across six `(dim, bits)` cells, with `N = 2000` (above
  `TQPLUS_MIN_SAMPLES`) and an assertion that the calibration actually fitted
  rather than falling back to identity. Its `calibration` diagnosis string names
  #346 explicitly. The failure output quoted above is that machinery working.
  Nothing to add here.

- **(a) "the dependency is a caret range" — still open, and fixed here.**
  `turbovec/Cargo.toml` declared `statrs = "0.17"`. This PR makes it
  `statrs = "=0.17.1"`, matching the existing house style for
  `rand_chacha = "=0.3.1"`, which is pinned for the identical reason (its byte
  stream is baked into every v5-encoded vector). The comment above the pin
  records why.

Detection and prevention are different properties: the golden test tells you
*after* the fact that a rebuild would write different bytes; the pin stops the
input moving unasked in the first place, including for a downstream user who has
no lockfile.

## The pin is a no-op for every build today

- `Cargo.lock` and `examples/downstream-smoke/Cargo.lock` both already resolve
  `statrs 0.17.1`. After the pin, `cargo check --workspace` and
  `cargo check --manifest-path examples/downstream-smoke/Cargo.toml` leave both
  lockfiles byte-identical (`git diff --stat` on each: empty).
- `cargo update --dry-run -p statrs` reports `Locking 0 packages to latest
  compatible versions` — 0.17.1 is the newest published 0.17.x, so the pin is
  not currently holding anything back either.
- No other crate in the tree depends on `statrs`; `turbovec-python` and
  `examples/downstream-smoke` both get it only through `turbovec`, so there is
  no requirement to conflict with.
- The MSRV leg (`ci.yml:261-262`) runs `cargo check --locked`, and the lock is
  unchanged, so its resolution is untouched.

## Tests

No new test. The change is a manifest requirement with no runtime behaviour, so
any test I could write would assert on the manifest text rather than on
behaviour — vacuous. The discriminating evidence is the perturbation experiment
above (which shows the existing golden test does catch this drift class) plus
the before/after resolved version (0.17.1 -> 0.17.1, both lockfiles unchanged).

`cargo test --release -p turbovec --test encode_fingerprint --test
codebook_determinism` passes on this branch: 4 + 2 tests, 0 failures.

## Deliberately out of scope

The issue raises two further points I did not act on, per the repo convention
that regression-prevention infrastructure does not ride along with a fix:

1. **`--locked` downstream smoke.** `ci.yml:52` runs the downstream-smoke crate
   with `--locked` against a tracked `Cargo.lock`, so it does not reproduce a
   real `cargo add turbovec` resolution. Suggested follow-up: a separate,
   possibly non-blocking leg that resolves fresh without the committed lock, so
   upstream drift in *any* dependency surfaces as a signal.
2. **`.cargo/config.toml` `target-cpu=x86-64-v2`** is repo-local and not
   published, so downstream x86 builds use different instruction selection than
   CI ever tests. Separate concern, separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
