### PR TITLE
Declared llama-index-core>=0.11 floor is not supported: raise to 0.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,7 +403,7 @@ jobs:
           python -m pip install dist/*.whl
           python -m pip install \
             "langchain-core>=0.3" \
-            "llama-index-core>=0.11" \
+            "llama-index-core>=0.12.1" \
             "haystack-ai>=2.0" \
             "agno>=2.0"
 
@@ -480,20 +480,16 @@ jobs:
       - name: Integration suites against the floors
         shell: bash
         run: |
-          # One deselection, not a suite exclusion. Turning this leg on for the
-          # first time immediately found that the declared
-          # `llama-index-core>=0.11` floor is not actually supported: at
-          # 0.11.0 the field is spelled `metadata_seperator` (the upstream
-          # typo), so the node round-trip test fails. That is a real bug in
-          # the declaration, filed as #386, and fixing it is a user-visible
-          # packaging change that belongs in its own PR — not something to
-          # paper over here. Deselecting the single failing test keeps the
-          # other 380-odd assertions gating the floor. Remove this line when
-          # #386 lands. (`-k` rather than `--deselect`: pytest resolves
-          # --deselect node ids against its rootdir, which is turbovec-python
-          # here, so the repo-root-relative path silently matches nothing.)
+          # No deselections: every test in these four suites gates the floors.
+          # This leg previously skipped
+          # test_query_returns_node_with_full_field_fidelity, because the
+          # declared `llama-index-core>=0.11` floor was not actually
+          # supported — at 0.11.0 the field is spelled `metadata_seperator`
+          # (the upstream typo) and `metadata_separator` does not exist, so
+          # the value is dropped by pydantic at construction. The floor is now
+          # 0.12.1, the first release where `TextNode.metadata_separator` is a
+          # real field, and the test passes unmodified (#386).
           pytest -v -ra \
-            -k "not test_query_returns_node_with_full_field_fidelity" \
             turbovec-python/tests/test_haystack.py \
             turbovec-python/tests/test_agno.py \
             turbovec-python/tests/test_langchain.py \

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -94,7 +94,7 @@ jobs:
           {
             echo "numpy>=1.20"
             echo "langchain-core>=0.3"
-            echo "llama-index-core>=0.11"
+            echo "llama-index-core>=0.12.1"
             echo "haystack-ai>=2.23.0"
             echo "agno>=2.5.4"
           } > "${RUNNER_TEMP}/extras-requirements.txt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1163,6 +1163,25 @@ appears under each surface it touches.
 
 #### Changed
 
+- **`llama-index` extra now requires `llama-index-core>=0.12.1`, raised
+  from `>=0.11` (#386).** The declared floor was never supported. Until
+  0.12.1 the field is spelled `metadata_seperator` — the upstream typo —
+  and `TextNode.metadata_separator` does not exist, so pydantic silently
+  discards the value at construction: on 0.11.0,
+  `TextNode(text='t', metadata_separator='|SEP|').metadata_seperator` is
+  `'\n'`, the default, and reading `.metadata_separator` raises
+  `AttributeError`. That happens with no vector store in the call path at
+  all, so the full-node fidelity `TurboQuantVectorStore` promises could
+  not hold at the advertised floor and nothing in turbovec could bridge
+  it. 0.12.1 is the first release where `metadata_separator` is a real
+  `TextNode` field; the integration suite is green there (95 passed, 3
+  skipped) and fails at 0.12.0 and below. The three remaining skips are
+  optional filter operators (`FilterOperator.TEXT_MATCH_INSENSITIVE`,
+  `FilterCondition.NOT`) that upstream adds in 0.12.6 and that the store
+  already degrades gracefully without — they are not fidelity failures,
+  which is why the floor is 0.12.1 and not 0.12.6. Users pinned below
+  0.12.1 must upgrade `llama-index-core`; no turbovec API changed.
+
 - **LangChain / LlamaIndex / Agno async methods no longer block the event
   loop, and `asyncio.wait_for` now works on them (#342).** The `a*` /
   `async_*` methods ran their index work inline on the loop thread, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1175,12 +1175,18 @@ appears under each surface it touches.
   not hold at the advertised floor and nothing in turbovec could bridge
   it. 0.12.1 is the first release where `metadata_separator` is a real
   `TextNode` field; the integration suite is green there (95 passed, 3
-  skipped) and fails at 0.12.0 and below. The three remaining skips are
-  optional filter operators (`FilterOperator.TEXT_MATCH_INSENSITIVE`,
-  `FilterCondition.NOT`) that upstream adds in 0.12.6 and that the store
-  already degrades gracefully without — they are not fidelity failures,
-  which is why the floor is 0.12.1 and not 0.12.6. Users pinned below
-  0.12.1 must upgrade `llama-index-core`; no turbovec API changed.
+  skipped) and fails at 0.12.0 and below. Two of the three remaining
+  skips are optional filter operators
+  (`FilterOperator.TEXT_MATCH_INSENSITIVE`, `FilterCondition.NOT`) that
+  upstream adds in 0.12.6 and that the store already degrades gracefully
+  without — they are not fidelity failures, which is why the floor is
+  0.12.1 and not 0.12.6. The third,
+  `test_failed_persist_preserves_previous_store`, is unrelated to the
+  floor choice and is not cleared by 0.12.6 either: below roughly 0.12.40
+  upstream json-serializes node content eagerly inside
+  `node_to_metadata_dict`, so `add()` raises before the mid-persist
+  failure that test provokes can be reached. Users pinned below 0.12.1
+  must upgrade `llama-index-core`; no turbovec API changed.
 
 - **LangChain / LlamaIndex / Agno async methods no longer block the event
   loop, and `asyncio.wait_for` now works on them (#342).** The `a*` /

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -52,7 +52,7 @@ Issues = "https://github.com/RyanCodrai/turbovec/issues"
 
 [project.optional-dependencies]
 langchain = ["langchain-core>=0.3"]
-llama-index = ["llama-index-core>=0.11"]
+llama-index = ["llama-index-core>=0.12.1"]
 haystack = ["haystack-ai>=2.23.0"]
 agno = ["agno>=2.5.4"]
 


### PR DESCRIPTION
Closes #386

`turbovec-python/pyproject.toml` declared `llama-index-core>=0.11`. That floor
does not work. This raises it to `>=0.12.1`, the lowest version measured to
genuinely work.

## The failure at the declared floor

`llama-index-core==0.11.0`, Python 3.11.12, against the release wheel
(`--force-reinstall --no-deps`; `_turbovec.abi3.so` sha256
`a13e930b8bdddec4859fc36c77ae8046771611dabaf91875da3f4e372ffd19ab`):

```
FAILED turbovec-python/tests/test_llama_index.py::test_query_returns_node_with_full_field_fidelity
1 failed, 94 passed, 3 skipped, 19 warnings in 1.36s
```

One field: `metadata_separator`. In goes `"|SEP|"`, out comes `"\n"`. Note the
repr of the node that came back — the value is not corrupted in transit, it is
the *default*:

```
>       assert returned.metadata_separator == "|SEP|"
self = TextNode(id_='node-rich-1', ..., metadata_template='<<{key}::{value}>>', metadata_seperator='\n')
item = 'metadata_separator'
E   AttributeError: 'TextNode' object has no attribute 'metadata_separator'
```

## turbovec is not in the call path

This is the load-bearing evidence. No store, no round-trip — just upstream:

```python
from llama_index.core.schema import TextNode
n = TextNode(text='t', metadata_separator='|SEP|')
```

At 0.11.0:

```
  metadata_seperator (typo field) = '\n'
  model_dump has metadata_separator? False
  getattr metadata_separator -> AttributeError: 'TextNode' object has no attribute 'metadata_separator'
```

`TextNode.model_fields` at 0.11.0 has `metadata_seperator` and not
`metadata_separator`, so pydantic discards the unknown kwarg at `__init__`.
The value is gone before any turbovec code runs.

## The boundary, measured

Upstream `llama_index/core/schema.py`, counts of each spelling, by downloading
each wheel:

| version | `metadata_separator` | `metadata_seperator` |
|---|---|---|
| 0.11.0  | 0 | 2 |
| 0.11.23 | 0 | 2 |
| 0.12.0  | 0 | 2 |
| **0.12.1** | **2** | 2 |
| 0.12.2  | 2 | 2 |
| 0.12.3  | 2 | 2 |
| 0.12.6  | 2 | 3 |
| 0.12.10 | 2 | 3 |
| 0.12.20 | 2 | 3 |
| 0.13.0  | 2 | 3 |
| 0.14.0  | 2 | 3 |

The typo never disappears, but from 0.12.1 it survives only on a separate
legacy class — upstream's own comment at `schema.py:597` says *"we keep the
field with the typo 'seperator' to maintain backward compatibility"*. The live
`TextNode` gets `metadata_separator: str = Field(...)` at line 300.

Confirmed at runtime:

```
--- 0.12.0 ---                        --- 0.12.1 ---
metadata_separator in model_fields: False   metadata_separator in model_fields: True
round-trip-free construct -> '<ABSENT>'     round-trip-free construct -> '|SEP|'
```

And by the suite that actually matters:

- `0.11.0` — `1 failed, 94 passed, 3 skipped`
- `0.12.0` — same failure
- **`0.12.1` — `95 passed, 3 skipped, 19 warnings in 1.01s`**

## Why 0.12.1 and not the 0.12.6 the issue guessed

The issue proposed 0.12.6 because two tests in the file already carry
`>= 0.12.6` skip markers. Those are a different thing:
`FilterOperator.TEXT_MATCH_INSENSITIVE` and `FilterCondition.NOT` are optional
filter operators upstream adds in 0.12.6, and the store already degrades
gracefully without them — there is a dedicated test at
`test_llama_index.py:866` that simulates an old llama-index with an
`OldFilterOperator` enum, and it passes. They skip, they do not fail, and they
are not the fidelity contract. Declaring 0.12.6 would exclude 0.12.1 through
0.12.5, five releases I measured to work.

## Why raise the floor rather than alias the field

There is nothing to alias. The value is discarded by pydantic at
`TextNode.__init__`, before turbovec sees the node. An alias in turbovec could
only run at write time, by which point the caller's node already holds `'\n'`
— the information does not exist to preserve. Bridging would require
monkeypatching upstream's `TextNode` to add the field, i.e. turbovec silently
mutating a framework class its users share with every other llama-index
consumer. And reads would still be wrong regardless: `.metadata_separator`
raises `AttributeError` at 0.11.0, so user code written against the documented
attribute cannot run there whatever turbovec stores.

Reinforcing it: the store never enumerates node fields. It delegates to
upstream's `node_to_metadata_dict` / `metadata_dict_to_node`
(`python/turbovec/llama_index.py:59-60, 348, 548`), so there is no
turbovec-side serializer that could be taught the other spelling.

## Changes

1. `turbovec-python/pyproject.toml:55` — `>=0.11` → `>=0.12.1`. The defect.
2. `.github/workflows/ci.yml:406` — the main integration-extras install also
   said `>=0.11`; raised so the declaration and what CI installs agree.
3. `.github/workflows/ci.yml:485` — removed the floors leg's
   `-k "not test_query_returns_node_with_full_field_fidelity"` deselection.
   Its own comment said *"Remove this line when #386 lands"*; leaving it would
   ship the fix ungated by the one leg that exercises it.

`.github/scripts/dep_floors.py` needed no change — it derives pins from
pyproject, and now emits `llama-index-core==0.12.1`.

4. `.github/workflows/supply-chain.yml:97` — the informational extras audit
   mirrors pyproject's extras (its own comment says so, and the other four
   entries match exactly), so leaving it at `>=0.11` would have made that
   comment false. Raised to `>=0.12.1`. **Found by review** — my original
   repo-wide grep for version constraints was malformed and missed it.

All four constraint sites now agree at `>=0.12.1`. `docs/`, `README.md` and
`turbovec-python/README.md` make no llama-index version claim, so there is
nothing to keep consistent there.

CHANGELOG entry added under `[Unreleased]` → `turbovec — Python package` →
`Changed` (`turbovec-python/pyproject.toml` is gated surface per
`changelog_gate.py:71`).

## Will the floors leg pass

Yes. The four floors co-resolve with no conflict (`pip install --dry-run`):
`Would install ... agno-2.5.4 ... haystack-ai-2.23.0 ... langchain-core-0.3.0
... llama-index-core-0.12.1 ... pydantic-2.9.2`. The suite at 0.12.1 is
`95 passed, 3 skipped`, and all three are `SKIPPED`, not failures. Two of the
three are the optional filter operators above; the third,
`test_failed_persist_preserves_previous_store`, is unrelated to the floor
choice and is not cleared by 0.12.6 either — below roughly 0.12.40 upstream
json-serializes node content eagerly in `node_to_metadata_dict`, so `add()`
raises before the mid-persist failure it provokes can be reached.

## No runtime test was added, deliberately

This fix has zero runtime behaviour — it is a manifest constraint, and no code
path changed. Any runtime assertion I could add would re-test what
`test_query_returns_node_with_full_field_fidelity` already asserts and would
pass identically with or without the fix, which is a vacuous test.

The discriminating evidence is the install boundary itself: at `>=0.11` pip
accepts `llama-index-core==0.11.0` and the suite fails; at `>=0.12.1` the
resolver refuses that install. The floors leg now runs exactly that experiment
on every PR, since `dep_floors.py` derives `==0.12.1` from the manifest —
revert the one-line manifest change and the leg goes back to installing 0.11.0
and failing.

## Follow-up, not bundled

The floors leg tests the floor but asserts weakly in one respect: it installs
the derived `==` pins and runs the suites, so it catches a floor that *fails*,
but it would not catch a floor that is merely *lower than necessary* (a
needlessly conservative floor resolves and passes). Worth a separate issue if
wanted; per repo convention regression-prevention infra ships separately from
the fix, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
