### PR TITLE
fix: retry ERROR_ACCESS_DENIED, not just ERROR_SHARING_VIOLATION, on Windows renames (#415)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,14 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **`rename_atomic` retries `ERROR_ACCESS_DENIED` as well as
+  `ERROR_SHARING_VIOLATION` on Windows (#415).** The Rust writer had the
+  same too-narrow whitelist as the Python one: a rename onto a
+  destination another writer is concurrently replacing fails with
+  winerror 5 while that destination is delete-pending, not winerror 32,
+  so the retry never fired for it. The two writers implement one protocol
+  against one on-disk format and now recognise the same transient set.
+
 - **An empty query batch no longer panics with a divide-by-zero (#349).**
   The batch dispatch splits the block axis into
   `(n_threads * 4).div_ceil(n_quads)` ranges, where
@@ -1292,6 +1300,24 @@ appears under each surface it touches.
   succeeded and yielded an empty module. It now raises `ImportError`.
 
 #### Fixed
+
+- **Concurrent saves to one path no longer intermittently raise
+  `PermissionError` on Windows (#415).** `atomic_save` retried the
+  `os.replace` that publishes each artifact, but only for
+  `ERROR_SHARING_VIOLATION` (winerror 32). Replacing a destination leaves
+  the file it supersedes *delete-pending* until its last handle closes,
+  and every rename against a delete-pending file fails with
+  `ERROR_ACCESS_DENIED` (winerror 5) instead — so two threads saving to
+  one path raced through a window the retry did not cover, and the save
+  failed with `PermissionError(13, 'Access is denied')`. Both codes are
+  transient and now retried; permanent failures (a read-only destination,
+  a directory in the way, a missing privilege) still surface on the first
+  attempt. Completes #316, which made concurrent same-path saves
+  non-corrupting but left them able to raise. The temp-file cleanup in
+  the same function is now genuinely best-effort as documented: it
+  swallowed only `FileNotFoundError`, so an antivirus or indexer holding
+  a freshly-written temp could turn a save that had already landed on
+  disk into an error — while never masking the save's own exception.
 
 - **A `warnings` handler that touches the index it is saving no longer
   deadlocks `write()` (#360).** The core's post-commit durability warning

--- a/docs/integrations/agno.md
+++ b/docs/integrations/agno.md
@@ -174,6 +174,7 @@ What the contract does *not* cover:
 - **No cross-call atomicity.** A caller-side check-then-act sequence (`id_exists` then `delete_by_id`) can interleave with other writers. Batch writes are not atomic with respect to readers: a search overlapping an `upsert` can briefly see both the old and new generation of a `content_hash`.
 - **`save` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a save.
 - **The embedder and reranker are invoked outside the store's lock** and must be thread-safe themselves.
+- **Two stores writing to the same path is safe.** Concurrent `save` calls to one destination from several threads each publish atomically and the last writer wins; a caller never sees a torn file, and never an error caused only by the other writer. Which writer wins is not defined.
 - **Multi-process access is not supported.**
 
 ## Known limitations

--- a/docs/integrations/haystack.md
+++ b/docs/integrations/haystack.md
@@ -194,6 +194,7 @@ What the contract does *not* cover:
 - **No cross-call atomicity.** A caller-side check-then-act sequence (`count_documents` then `filter_documents`) can interleave with other writers. Batch writes are not atomic with respect to readers: a retrieval overlapping an `OVERWRITE` write can briefly see a document id under both its old and new entry.
 - **`save_to_disk` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a save.
 - **`to_dict` / `from_dict` and the executor lifecycle** are assumed single-threaded.
+- **Two stores writing to the same path is safe.** Concurrent `save_to_disk` calls to one destination from several threads each publish atomically and the last writer wins; a caller never sees a torn file, and never an error caused only by the other writer. Which writer wins is not defined.
 - **Multi-process access is not supported.**
 
 ## Known limitations

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -188,6 +188,7 @@ What the contract does *not* cover:
 - **No cross-call atomicity.** A caller-side check-then-act sequence (`get_by_ids` then `delete`, a count then a search) can interleave with other writers. Batch writes are not atomic with respect to readers: a search overlapping an upsert can briefly see a document id under both its old and new entry.
 - **`dump` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a dump.
 - **The embedder is invoked outside the store's lock** and must be thread-safe itself.
+- **Two stores writing to the same path is safe.** Concurrent `dump` calls to one destination from several threads each publish atomically and the last writer wins; a caller never sees a torn file, and never an error caused only by the other writer. Which writer wins is not defined.
 - **Multi-process access is not supported.**
 
 ## Known limitations

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -253,6 +253,7 @@ What the contract does *not* cover:
 
 - **No cross-call atomicity.** A caller-side check-then-act sequence (`get_nodes` then `delete_nodes`) can interleave with other writers. Batch writes are not atomic with respect to readers: a query overlapping a re-`add` of an existing `node_id` can briefly see that id under both its old and new entry.
 - **`persist` serializes with writes** (so it always snapshots a consistent store); reads may proceed during a persist.
+- **Two stores writing to the same path is safe.** Concurrent `persist` calls to one destination from several threads each publish atomically and the last writer wins; a caller never sees a torn file, and never an error caused only by the other writer. Which writer wins is not defined.
 - **Multi-process access is not supported.**
 
 ## Known limitations

--- a/turbovec-python/python/turbovec/_persist.py
+++ b/turbovec-python/python/turbovec/_persist.py
@@ -64,29 +64,78 @@ def _tmp_path(path: str) -> str:
     return os.path.join(directory, base + suffix)
 
 
-def _replace_atomic(src: str, dst: str) -> None:
-    """``os.replace`` with a short retry on Windows sharing violations.
+# Win32 status codes a rename/unlink can return transiently while some
+# other party holds the file open, all of which surface as
+# ``PermissionError(13, ...)``:
+#
+# * 32 ERROR_SHARING_VIOLATION — another handle lacks FILE_SHARE_DELETE.
+# * 5 ERROR_ACCESS_DENIED — the target is in the *delete-pending* state.
+#   Windows leaves a file in that state between the last handle being
+#   marked delete-on-close and the last handle actually closing; every
+#   open, rename or unlink against it fails with ACCESS_DENIED rather
+#   than SHARING_VIOLATION. Replacing a destination puts it there, so
+#   two concurrent saves to one path race through it (#415), as does an
+#   antivirus or indexer that opened the file to scan it.
+#
+# Both clear on their own within microseconds. Codes outside this set
+# (a read-only destination, a directory in the way, a missing privilege)
+# are permanent and must surface immediately.
+_WINDOWS_TRANSIENT_WINERRORS = frozenset((5, 32))
 
-    On Windows the rename fails with ERROR_SHARING_VIOLATION (winerror 32)
-    while any other handle to the destination lacks FILE_SHARE_DELETE —
-    CPython's own ``open()`` qualifies, as do antivirus and indexer scans.
-    The Rust writer already retries (``rename_atomic``); the Python side
-    needs the same posture or the integrations still hit #313 (#355).
+_RETRY_ATTEMPTS = 10
+
+# Read once, as a module-local flag rather than an ``os.name`` test at
+# the call site: it is the seam that lets the tests drive this
+# Windows-only path from any platform. Patching ``os.name`` itself would
+# not do — ``pathlib`` reads it to choose its flavour, so a test that set
+# it would hand out WindowsPath objects to everything else running.
+_IS_WINDOWS = os.name == "nt"
+
+
+def _with_windows_retry(op):
+    """Run ``op``, retrying the transient Windows sharing failures above.
+
+    A no-op wrapper off Windows, where rename and unlink are defined
+    against open files and none of these conditions exist. The Rust
+    writer takes the same posture (``rename_atomic`` in
+    ``turbovec/src/io.rs``). Backoff doubles from 1ms to a 64ms cap, so
+    a genuinely permanent failure still raises after ~0.3s.
     """
-    if os.name != "nt":
-        os.replace(src, dst)
-        return
+    if not _IS_WINDOWS:
+        return op()
     delay = 0.001
-    for _ in range(10):
+    for attempt in range(_RETRY_ATTEMPTS):
         try:
-            os.replace(src, dst)
-            return
-        except OSError as exc:  # pragma: no cover - Windows-only path
-            if getattr(exc, "winerror", None) != 32:
+            return op()
+        except OSError as exc:
+            if (
+                attempt == _RETRY_ATTEMPTS - 1
+                or getattr(exc, "winerror", None) not in _WINDOWS_TRANSIENT_WINERRORS
+            ):
                 raise
             time.sleep(delay)
             delay = min(delay * 2, 0.064)
-    os.replace(src, dst)
+
+
+def _replace_atomic(src: str, dst: str) -> None:
+    """``os.replace`` with a short retry on transient Windows failures."""
+    _with_windows_retry(lambda: os.replace(src, dst))
+
+
+def _unlink_best_effort(path: str) -> None:
+    """Remove ``path``, never raising.
+
+    This runs in ``atomic_save``'s ``finally``, where any raise would
+    either mask the real failure or turn an already-completed save into
+    an error the caller cannot act on — the temp is by then a stray file,
+    not a correctness problem. It still retries the transient Windows
+    codes first, so the ordinary case removes the temp rather than
+    leaving it behind.
+    """
+    try:
+        _with_windows_retry(lambda: os.unlink(path))
+    except OSError:
+        pass
 
 
 def _fsync_dir(directory: str) -> None:
@@ -310,7 +359,11 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
        rename publishes a name in the *directory*, so without that fsync
        a crash after a successful return could still lose it (#350). A failure or crash before
        the first replace leaves a previous store at these paths intact.
-    3. On failure the temp files are removed (best effort).
+       Concurrent saves to one path are safe: temp names are unique per
+       save, and each replace retries the transient Windows failures a
+       competing save's replace briefly induces (#415).
+    3. The temp files are removed on the way out (best effort — cleanup
+       never raises over the save's own outcome).
 
     The one remaining non-atomic window is between the two ``replace``
     calls (and the directory fsync that follows them): a hard crash
@@ -368,10 +421,7 @@ def atomic_save(index, index_path, payload: Any, sidecar_path) -> None:
             _fsync_dir(directory)
     finally:
         for tmp in (index_tmp, sidecar_tmp):
-            try:
-                os.unlink(tmp)
-            except FileNotFoundError:
-                pass
+            _unlink_best_effort(tmp)
 
 
 def check_persisted_handles(

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -151,14 +151,23 @@ def _win_oserror(winerror, strerror="Access is denied"):
     return exc
 
 
-def test_win_oserror_helper_reproduces_the_reported_repr():
-    # The CI repr in #415 was `PermissionError(13, 'Access is denied')`.
-    # OSError.args is the (errno, strerror) pair on every platform, so
-    # the winerror never appears in the repr — which is exactly why that
-    # log could not distinguish ERROR_ACCESS_DENIED (5) from
-    # ERROR_SHARING_VIOLATION (32) by eye. The strerror is what pins it:
-    # 'Access is denied' is the text of 5, and 32 reads differently.
-    assert repr(_win_oserror(5)) == "PermissionError(13, 'Access is denied')"
+def test_win_oserror_helper_carries_the_reported_fields():
+    # The CI repr in #415 was `PermissionError(13, 'Access is denied')`,
+    # with no winerror in it — which is why that log could not tell
+    # ERROR_ACCESS_DENIED (5) from ERROR_SHARING_VIOLATION (32) by eye.
+    # The strerror is what pins it: 'Access is denied' is the text
+    # FormatMessage gives for 5, and 32 reads quite differently.
+    #
+    # Do not assert on the repr itself. An OSError *raised by Windows*
+    # carries args as the (errno, strerror) pair, but one constructed
+    # explicitly from four arguments keeps all four, so the fixture's
+    # repr matches the reported one only off Windows. The fields the
+    # retry actually consults are the same on both.
+    exc = _win_oserror(5)
+    assert isinstance(exc, OSError)
+    assert exc.args[0] == 13
+    assert exc.args[1] == "Access is denied"
+    assert getattr(exc, "winerror", None) == 5
 
 
 @pytest.fixture
@@ -247,12 +256,15 @@ def test_with_windows_retry_gives_up_after_the_attempt_budget(as_windows):
     assert max(delays) == 0.064
 
 
-def test_with_windows_retry_does_not_retry_off_windows():
+def test_with_windows_retry_does_not_retry_off_windows(monkeypatch):
     # POSIX rename and unlink are defined against open files, so none of
     # these conditions exist there: a failure is real and immediate.
+    # Patch the flag rather than asserting it, so the POSIX branch is
+    # covered on every platform — including the Windows CI leg, where
+    # reading the real flag would make this assert its own negation.
     from turbovec import _persist
 
-    assert not _persist._IS_WINDOWS, "this test asserts the POSIX branch"
+    monkeypatch.setattr(_persist, "_IS_WINDOWS", False)
     calls = []
 
     def always_fails():
@@ -288,9 +300,18 @@ def test_replace_atomic_routes_through_the_retry(tmp_path, as_windows):
     assert not src.exists()
 
 
+@pytest.mark.skipif(os.name == "nt", reason="POSIX directory permissions")
 def test_unlink_best_effort_swallows_a_real_permission_error(tmp_path):
     # Not simulated: a file inside a directory with the write bit off
     # genuinely cannot be unlinked. Cleanup must absorb that.
+    #
+    # POSIX-only, and skipped rather than adapted: on Windows `chmod`
+    # only toggles FILE_ATTRIBUTE_READONLY, which is ignored on
+    # directories (deletion is governed by ACLs), so the unlink would
+    # simply succeed. The suite's other chmod-based tests carry the same
+    # guard. The Windows equivalent of this scenario is covered by
+    # `test_atomic_save_cleanup_failure_does_not_fail_a_completed_save`,
+    # which injects the failure instead of provoking it.
     from turbovec import _persist
 
     victim = tmp_path / "locked" / "temp"

--- a/turbovec-python/tests/test_persist.py
+++ b/turbovec-python/tests/test_persist.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from unittest import mock
 
 import pytest
 
@@ -78,6 +79,7 @@ def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
     # mismatched index/side-car pair on disk).
     import json
     import threading
+    import traceback
 
     import numpy as np
 
@@ -103,8 +105,15 @@ def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
             barrier.wait()
             for _ in range(25):
                 atomic_save(index, index_path, payload, sidecar_path)
-        except Exception as e:  # noqa: BLE001 — recorded for the assert
-            errors.append(e)
+        except Exception:  # noqa: BLE001 — recorded for the assert
+            # Keep the *traceback*, not just the exception object. When
+            # this failed intermittently on Windows CI (#415) the log
+            # held only `PermissionError(13, 'Access is denied')`, which
+            # named neither the failing call nor the winerror behind it
+            # — two different raise sites in atomic_save produce that
+            # identical repr. The frame is what makes a rare failure
+            # actionable from a CI log alone.
+            errors.append(traceback.format_exc())
 
     threads = [threading.Thread(target=save_loop, args=s) for s in stores]
     for t in threads:
@@ -112,7 +121,7 @@ def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
     for t in threads:
         t.join()
 
-    assert not errors, f"concurrent saves raised: {errors!r}"
+    assert not errors, "concurrent saves raised:\n" + "\n".join(errors)
     # Each artifact must individually be a complete write from one of
     # the two stores — never interleaved bytes.
     loaded = IdMapIndex.load(str(index_path))
@@ -122,6 +131,245 @@ def test_atomic_save_concurrent_same_process_does_not_corrupt(tmp_path):
     # No temp strays.
     strays = [p.name for p in tmp_path.iterdir() if ".tmp." in p.name]
     assert strays == []
+
+
+def _win_oserror(winerror, strerror="Access is denied"):
+    """An OSError shaped like the one Windows raises for ``winerror``.
+
+    On Windows, build the real thing — the four-argument OSError form
+    sets the ``winerror`` attribute and maps to the matching subclass.
+    Off Windows there is no such attribute, so fabricate it. That
+    fabrication is the *only* simulated part of these tests: the retry
+    helper reads ``winerror`` with ``getattr``, so a hand-built exception
+    drives the real control flow, which is otherwise unreachable from a
+    POSIX machine.
+    """
+    if os.name == "nt":  # pragma: no cover - Windows-only path
+        return OSError(13, strerror, None, winerror)
+    exc = PermissionError(13, strerror)
+    exc.winerror = winerror
+    return exc
+
+
+def test_win_oserror_helper_reproduces_the_reported_repr():
+    # The CI repr in #415 was `PermissionError(13, 'Access is denied')`.
+    # OSError.args is the (errno, strerror) pair on every platform, so
+    # the winerror never appears in the repr — which is exactly why that
+    # log could not distinguish ERROR_ACCESS_DENIED (5) from
+    # ERROR_SHARING_VIOLATION (32) by eye. The strerror is what pins it:
+    # 'Access is denied' is the text of 5, and 32 reads differently.
+    assert repr(_win_oserror(5)) == "PermissionError(13, 'Access is denied')"
+
+
+@pytest.fixture
+def as_windows(monkeypatch):
+    """Drive the Windows-only retry path from any platform.
+
+    Flips ``_persist``'s own platform flag and neutralizes the backoff
+    sleeps. Deliberately *not* done by patching ``os.name``: pathlib
+    reads that to pick its flavour, so setting it hands WindowsPath
+    objects to everything else running, pytest's own reporting included.
+    """
+    from turbovec import _persist
+
+    monkeypatch.setattr(_persist, "_IS_WINDOWS", True)
+    delays = []
+    monkeypatch.setattr(_persist.time, "sleep", delays.append)
+    return delays
+
+
+@pytest.mark.parametrize("winerror", [5, 32])
+def test_with_windows_retry_retries_transient_failures(as_windows, winerror):
+    # #415: a rename onto a destination another save is concurrently
+    # replacing fails transiently — with ERROR_SHARING_VIOLATION (32)
+    # while a competing handle lacks FILE_SHARE_DELETE, and with
+    # ERROR_ACCESS_DENIED (5) while the superseded destination sits in
+    # the delete-pending state Windows leaves it in until the last handle
+    # closes. Both clear on their own within microseconds. The retry
+    # covered only 32, so the 5 escaped to the caller as a failed save.
+    from turbovec import _persist
+
+    calls = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) < 4:
+            raise _win_oserror(winerror)
+        return "done"
+
+    assert _persist._with_windows_retry(flaky) == "done"
+    assert len(calls) == 4
+
+
+# ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND, ERROR_WRITE_PROTECT,
+# ERROR_DIRECTORY_NOT_SUPPORTED, ERROR_PRIVILEGE_NOT_HELD — none of
+# these clear by waiting.
+@pytest.mark.parametrize("winerror", [2, 3, 19, 267, 1314])
+def test_with_windows_retry_reraises_permanent_failures(as_windows, winerror):
+    # The guard that stops this decaying into retry-everything. A
+    # permanent condition — a read-only destination, a directory in the
+    # way, a missing privilege — must surface on the *first* attempt, not
+    # after a third of a second of pointless sleeping. Widening the
+    # whitelist to a catch-all still raises, so only the call count
+    # catches it; that is what this asserts.
+    from turbovec import _persist
+
+    calls = []
+
+    def always_fails():
+        calls.append(1)
+        raise _win_oserror(winerror, "nope")
+
+    with pytest.raises(OSError):
+        _persist._with_windows_retry(always_fails)
+    assert len(calls) == 1, "a permanent Windows failure must not be retried"
+
+
+def test_with_windows_retry_gives_up_after_the_attempt_budget(as_windows):
+    # A transient code that never clears is a failure, not a hang: the
+    # helper raises the last error after a bounded number of attempts,
+    # with the backoff doubling from 1ms to a 64ms cap.
+    from turbovec import _persist
+
+    delays = as_windows
+    calls = []
+
+    def always_denied():
+        calls.append(1)
+        raise _win_oserror(5)
+
+    with pytest.raises(OSError, match="Access is denied"):
+        _persist._with_windows_retry(always_denied)
+    assert len(calls) == _persist._RETRY_ATTEMPTS
+    # One sleep between attempts, none after the last.
+    assert len(delays) == _persist._RETRY_ATTEMPTS - 1
+    assert delays[:4] == [0.001, 0.002, 0.004, 0.008]
+    assert max(delays) == 0.064
+
+
+def test_with_windows_retry_does_not_retry_off_windows():
+    # POSIX rename and unlink are defined against open files, so none of
+    # these conditions exist there: a failure is real and immediate.
+    from turbovec import _persist
+
+    assert not _persist._IS_WINDOWS, "this test asserts the POSIX branch"
+    calls = []
+
+    def always_fails():
+        calls.append(1)
+        raise PermissionError(13, "Permission denied")
+
+    with pytest.raises(PermissionError):
+        _persist._with_windows_retry(always_fails)
+    assert len(calls) == 1
+
+
+def test_replace_atomic_routes_through_the_retry(tmp_path, as_windows):
+    # Wiring check: _replace_atomic must go through the helper above,
+    # and must still perform a real rename.
+    from turbovec import _persist
+
+    src = tmp_path / "src"
+    src.write_text("payload")
+    dst = tmp_path / "dst"
+    real_replace = os.replace
+    calls = []
+
+    def flaky_replace(a, b):
+        calls.append(1)
+        if len(calls) < 3:
+            raise _win_oserror(5)
+        real_replace(a, b)
+
+    with mock.patch.object(_persist.os, "replace", flaky_replace):
+        _persist._replace_atomic(str(src), str(dst))
+    assert len(calls) == 3
+    assert dst.read_text() == "payload"
+    assert not src.exists()
+
+
+def test_unlink_best_effort_swallows_a_real_permission_error(tmp_path):
+    # Not simulated: a file inside a directory with the write bit off
+    # genuinely cannot be unlinked. Cleanup must absorb that.
+    from turbovec import _persist
+
+    victim = tmp_path / "locked" / "temp"
+    victim.parent.mkdir()
+    victim.write_text("x")
+    victim.parent.chmod(0o500)
+    try:
+        with pytest.raises(PermissionError):
+            os.unlink(str(victim))  # the real failure this absorbs
+        _persist._unlink_best_effort(str(victim))  # must not raise
+    finally:
+        victim.parent.chmod(0o700)
+
+
+def test_atomic_save_cleanup_failure_does_not_fail_a_completed_save(tmp_path):
+    # #415, second raise site. The temp unlink runs in a `finally` and is
+    # documented best-effort, but it only swallowed FileNotFoundError. On
+    # Windows an antivirus or indexer that opened the freshly-created
+    # temp to scan it makes unlink fail with ERROR_ACCESS_DENIED — the
+    # same PermissionError(13, 'Access is denied') — which turned a save
+    # that had already landed on disk into an error the caller could
+    # neither act on nor distinguish from a lost write.
+    import json
+
+    import numpy as np
+
+    from turbovec import IdMapIndex, _persist
+
+    idx = IdMapIndex(dim=8, bit_width=4)
+    idx.add_with_ids(np.eye(8, dtype=np.float32), np.arange(8, dtype=np.uint64))
+    index_path = tmp_path / "index.tvim"
+    sidecar_path = tmp_path / "docstore.json"
+
+    real_unlink = os.unlink
+
+    def denied_unlink(path):
+        # Remove it where it still exists, then fail the way Windows
+        # does. Not short-circuiting on FileNotFoundError matters: by the
+        # time cleanup runs, a successful save has already renamed both
+        # temps away, and swallowing only FileNotFoundError (what this
+        # used to do) would then never see the PermissionError at all.
+        try:
+            real_unlink(path)
+        except FileNotFoundError:
+            pass
+        raise PermissionError(13, "Access is denied")
+
+    with mock.patch.object(_persist.os, "unlink", denied_unlink):
+        _persist.atomic_save(idx, index_path, ["a", "b"], sidecar_path)
+
+    assert len(IdMapIndex.load(str(index_path))) == 8
+    assert json.loads(sidecar_path.read_text()) == ["a", "b"]
+
+
+def test_atomic_save_cleanup_failure_does_not_mask_the_real_error(tmp_path):
+    # The other half: swallowing in the `finally` must not hide why the
+    # save failed. The swallow is scoped to one unlink of one temp path
+    # this call created, so the body's own exception still propagates
+    # unchanged.
+    import numpy as np
+
+    from turbovec import IdMapIndex, _persist
+
+    idx = IdMapIndex(dim=8, bit_width=4)
+    idx.add_with_ids(np.eye(8, dtype=np.float32), np.arange(8, dtype=np.uint64))
+
+    def boom(src, dst):
+        raise RuntimeError("the actual failure")
+
+    def denied_unlink(path):
+        raise PermissionError(13, "Access is denied")
+
+    with mock.patch.object(_persist, "_replace_atomic", boom), mock.patch.object(
+        _persist.os, "unlink", denied_unlink
+    ):
+        with pytest.raises(RuntimeError, match="the actual failure"):
+            _persist.atomic_save(
+                idx, tmp_path / "index.tvim", ["a"], tmp_path / "docstore.json"
+            )
 
 
 def test_tmp_path_fits_name_max_for_long_destinations():

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -1039,19 +1039,43 @@ fn create_tmp(path: &Path) -> io::Result<(File, PathBuf)> {
     Err(last_err.expect("retry loop ran"))
 }
 
-/// Atomically rename `tmp` over `path`. On Windows, `MoveFileExW` fails
-/// with ERROR_SHARING_VIOLATION (os error 32) while any other handle to
-/// the destination lacks FILE_SHARE_DELETE — CPython's `open()` and
-/// antivirus/indexer scans both qualify — so retry briefly with backoff,
-/// the same posture cargo, rustup, and git take (#313).
+/// True for the Win32 status codes a rename can return *transiently*
+/// while another party still holds the destination.
+///
+/// - 32 ERROR_SHARING_VIOLATION: another handle lacks FILE_SHARE_DELETE
+///   — CPython's `open()` and antivirus/indexer scans both qualify
+///   (#313).
+/// - 5 ERROR_ACCESS_DENIED: the destination is *delete-pending*. Windows
+///   leaves a file in that state from the moment its last handle is
+///   marked delete-on-close until that handle actually closes, and every
+///   open, rename or unlink against it fails with ACCESS_DENIED rather
+///   than SHARING_VIOLATION. Replacing a destination puts it there, so
+///   two threads saving to one path race through that window (#415).
+///
+/// Both clear on their own within microseconds. Everything else — a
+/// read-only destination, a directory in the way, a missing privilege —
+/// is permanent and must surface immediately rather than after a third
+/// of a second of pointless sleeping.
+///
+/// Not `cfg(windows)`-gated so the table itself stays testable on every
+/// platform; only its caller is Windows-only.
+#[cfg_attr(not(windows), allow(dead_code))]
+fn is_transient_rename_error(raw_os_error: Option<i32>) -> bool {
+    matches!(raw_os_error, Some(5) | Some(32))
+}
+
+/// Atomically rename `tmp` over `path`, retrying briefly with backoff on
+/// the transient Windows failures above — the same posture cargo,
+/// rustup, and git take (#313), and the same set the Python writer uses
+/// (`turbovec-python/python/turbovec/_persist.py`). The two must stay in
+/// step: they implement one protocol against one on-disk format.
 fn rename_atomic(tmp: &Path, path: &Path) -> io::Result<()> {
     #[cfg(windows)]
     {
-        const ERROR_SHARING_VIOLATION: i32 = 32;
         let mut delay_ms = 1u64;
         for _ in 0..10 {
             match std::fs::rename(tmp, path) {
-                Err(e) if e.raw_os_error() == Some(ERROR_SHARING_VIOLATION) => {
+                Err(e) if is_transient_rename_error(e.raw_os_error()) => {
                     std::thread::sleep(std::time::Duration::from_millis(delay_ms));
                     delay_ms = (delay_ms * 2).min(64);
                 }
@@ -2123,6 +2147,39 @@ fn read_exact_vec_capped<R: Read>(r: &mut R, n: usize, alloc_cap: u64) -> io::Re
         ));
     }
     Ok(buf)
+}
+
+#[cfg(test)]
+mod rename_retry_tests {
+    use super::*;
+
+    // #415. The retry existed but whitelisted only ERROR_SHARING_VIOLATION
+    // (32), so the ERROR_ACCESS_DENIED (5) that a delete-pending
+    // destination returns went straight to the caller as a failed save.
+    // The retry loop itself is `cfg(windows)` and cannot run here; the
+    // decision table it consults is not, so the part that was actually
+    // wrong is checked on every platform.
+    #[test]
+    fn transient_windows_rename_errors_are_retried() {
+        assert!(is_transient_rename_error(Some(5)), "ERROR_ACCESS_DENIED");
+        assert!(
+            is_transient_rename_error(Some(32)),
+            "ERROR_SHARING_VIOLATION"
+        );
+    }
+
+    // The guard against widening this into retry-everything: a permanent
+    // condition must surface on the first attempt.
+    #[test]
+    fn permanent_windows_rename_errors_are_not_retried() {
+        for code in [2, 3, 19, 267, 1314] {
+            assert!(
+                !is_transient_rename_error(Some(code)),
+                "os error {code} is permanent and must not be retried"
+            );
+        }
+        assert!(!is_transient_rename_error(None));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #415.

## Diagnosis: a product bug, and the retry that was already there never fired

The reported failure is `PermissionError(13, 'Access is denied')`. That string identifies the Win32 code without needing a Windows box: `os.replace`/`os.unlink` failures are raised through `PyErr_SetExcFromWindowsErr*`, which builds `strerror` from the **Win32 code via FormatMessage**, not from errno — errno 13's C strerror is `'Permission denied'`, which is not what was printed. `'Access is denied'` is the text of **`ERROR_ACCESS_DENIED` = winerror 5**. `ERROR_SHARING_VIOLATION` = 32 reads `'The process cannot access the file because it is being used by another process'`. The winerror never showed in that repr because an `OSError` *raised by Windows* carries `args` as the `(errno, strerror)` pair, which is why the issue could not tell 5 from 32 by eye. (An earlier revision of this PR over-generalised that to all `OSError`s and asserted an exact repr in a test; the Windows leg falsified it — one constructed explicitly from four arguments keeps all four. Corrected in 6243375.)

The gate on `main` (`_persist.py:85`):

```python
except OSError as exc:  # pragma: no cover - Windows-only path
    if getattr(exc, "winerror", None) != 32:
        raise
```

So the retry machinery — built deliberately for exactly this hazard in #355/#313 — **whitelisted the wrong code and never fired**. This is not "a flake needs a retry"; it is a retry with a too-narrow error set.

**Which handle is open.** No *application* handle is, and that is the point: both threads only write uniquely-named temps and rename, and nothing opens the destination for reading. The handle is the one `MoveFileEx` itself takes on the destination it supersedes — replacing a file opens the old destination with DELETE and marks it delete-on-close, and it stays **delete-pending** until that handle closes. Windows fails every open/rename/unlink against a delete-pending file with `ERROR_ACCESS_DENIED`, *not* `SHARING_VIOLATION`. A second concurrent replace onto the same destination lands in that window. **Read-not-run** — see the honesty section below.

**A second raise site produces the identical repr**, `_persist.py:370-374`:

```python
try:
    os.unlink(tmp)
except FileNotFoundError:
    pass
```

The docstring calls this best-effort, but it only swallowed `FileNotFoundError`. On Windows an antivirus or indexer that opened a freshly-created temp to scan it makes `unlink` fail with `ERROR_ACCESS_DENIED` → the same `PermissionError(13, 'Access is denied')` — and because it is in a `finally`, it could turn a save that **had already landed on disk** into an error the caller can neither act on nor distinguish from a lost write.

Nothing in the CI log could distinguish the two: the test recorded the bare exception object, so no frame ever reached the log. Both are real defects, both are fixed here, and the test now records `traceback.format_exc()` so any recurrence names its frame.

## Test bug or product bug?

**Product.** `atomic_save` is the shared write path behind all four integrations' save methods (`langchain.py:874`, `haystack.py:862`, `llama_index.py:975`, `agno.py:1102`). The test calls it exactly as a caller would; the assertion is not about test-internal state. A user doing the same thing sees the same `PermissionError`.

Concurrent same-path saving is a supported operation. The docs promise "The store is safe for concurrent multi-threaded use" and enumerate their carve-outs — the only one about parallel writers excludes **multi-process**, and nothing excludes two store objects in one process. The lock at `langchain.md:183` is explicitly **per-store**, so two stores on one path never serialize with each other. And the code already says so: the `_TMP_SEQ` comment names this exact scenario, because #316 (`d979ce3`) was spent making it safe and added this very test to pin it. **#415 is the unfinished half of #316** — that fix made concurrent same-path saves non-*corrupting*; it did not make them non-*raising*, because the delete-pending window is a distinct hazard from the temp-name collision.

Docs: one bullet added to the Thread safety section of all four integration docs stating the same-path guarantee explicitly, worded as current behaviour (the change narrative stays in the CHANGELOG). The "Multi-process access is not supported" carve-out is untouched and still true.

## The fix

- `_with_windows_retry(op)` — one helper, used by both raise sites, retrying `{5, 32}` with the existing 1ms→64ms backoff.
- `_unlink_best_effort` — genuinely best-effort. The swallow is scoped to a single `os.unlink` of a temp path this call created, so it cannot hide anything else; the body's own exception still propagates out of the `finally` unchanged (asserted by a test).
- `_IS_WINDOWS` module flag, so the Windows-only branch is reachable from tests. Deliberately **not** done by patching `os.name`: `pathlib` reads that to pick its flavour, and patching it hands `WindowsPath` objects to everything else running — including pytest's own failure reporting, which I hit and backed out of.
- `turbovec/src/io.rs` `rename_atomic` had the identical 32-only blind spot; the predicate is extracted, given the same `{5, 32}` set, and unit-tested.

## Discriminating evidence — all run on macOS/arm64

Verified binding, not an editable install: `maturin build --release` + `pip install --force-reinstall --no-deps`; turbovec 0.8.0, `_turbovec.abi3.so` sha256 `a13e930b8bdddec4…`, CPython 3.9.6.

Baseline: **44 passed** (`tests/test_persist.py`), **320 passed / 150 skipped** (full Python suite — the skips are integration frameworks not installed locally, which CI does install), **2 passed** for the new Rust tests.

Each variant below reverts one thing and re-runs:

| Variant | Result |
|---|---|
| **A** fixed (baseline) | 44 passed |
| **B** whitelist back to 32-only (the `main` gate) | **3 failed** — `…retries_transient_failures[5]`, `…gives_up_after_the_attempt_budget`, `…replace_atomic_routes_through_the_retry` |
| **C** whitelist widened to a **catch-all** | **5 failed** — `…reraises_permanent_failures[2/3/19/267/1314]`, on `assert 10 == 1` |
| **D** cleanup back to `except FileNotFoundError` | **3 failed** — `…unlink_best_effort_swallows_a_real_permission_error`, `…cleanup_failure_does_not_fail_a_completed_save`, `…cleanup_failure_does_not_mask_the_real_error` |

**C is the guard that matters**: a catch-all still *raises*, so only the call count catches it. Same in Rust — flipping `is_transient_rename_error` to `raw_os_error.is_some()` fails `permanent_windows_rename_errors_are_not_retried`.

`test_unlink_best_effort_swallows_a_real_permission_error` is **not simulated**: it chmods a directory to `0o500` and unlinks a file inside it, a real `PermissionError` on this machine.

## What is simulated, and what I could not execute

I am on **macOS/arm64**. I cannot reproduce a Windows-only flake, and I say so rather than claiming a repro.

- **Simulated:** the `winerror` attribute. Off Windows an `OSError` has none, so `_win_oserror` fabricates it; the helper reads it with `getattr`, so the fabricated exception drives the *real* control flow. On Windows the same fixture builds a genuine one via the four-argument `OSError` form. This is the only simulated part.
- **Read-not-run:** that a concurrent `MoveFileEx` is what puts the destination in delete-pending state, and that delete-pending is what returns code 5 here. That mechanism is inference from the error code — it is the documented Windows condition that yields 5 rather than 32 in this position. **The fix does not rest on it:** whatever produced code 5, `main` re-raised it instead of retrying, and that is settled by the strerror alone.
- **Read-not-run:** that the fix removes the flake in practice. It removes the *raise* for both codes; only repeated green Windows runs can confirm the rate.
- **CI's Windows legs are the real oracle for this change** — `Rust (windows-latest)` and `Python (windows-latest)`. I will not treat a green macOS/Linux matrix as evidence here. Note the flake is intermittent (the issue records the same leg passing on a bare re-run), so a single green Windows run is weak evidence; I am reading it as "did not regress", not "proven fixed".

## The mutation gate, and why `[skip mutants]`

The `New code is covered by discriminating tests` gate reported 3 caught and 2 MISSED. Both MISSED mutants are the same line — `io.rs:1078`, the match guard `is_transient_rename_error(e.raw_os_error())`, replaced with `true` and with `false`.

That line sits inside `#[cfg(windows)]`, and `mutants.yml:54` runs the gate on `ubuntu-latest`, where it is **not compiled**. No test on that runner can distinguish either mutant, because neither changes any code that exists in the binary under test. This is the gate's own "genuinely equivalent" case, not a missing assertion.

The part that *can* be covered is covered: `is_transient_rename_error` is deliberately extracted and left un-gated precisely so its decision table is testable everywhere, it has two unit tests that run on every platform, and **the 3 caught mutants are all in it**. Flipping it to `raw_os_error.is_some()` fails `permanent_windows_rename_errors_are_not_retried` — I ran that and restored. So the whitelist this PR changes is mutation-covered; only its Windows-only call site is not, and cannot be from Linux.

[skip mutants]

## Out of scope (named, not bundled)

- **Repo-wide `cargo fmt` drift.** `cargo fmt --check` reports 42 hunks in `io.rs` alone, in code this PR does not touch; `ci.yml:110-117` documents this as deliberate and excludes the check. My added lines are fmt-clean and clippy-clean; I did not reformat anything else.
- **A stress/soak job for this test on Windows** would be the way to turn "did not regress" into a rate measurement. That is CI infrastructure and belongs in its own PR.
- **Multi-process concurrent saves** remain unsupported and unchanged. The delete-pending retry plausibly helps there too; I make no claim I cannot test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
