### PR TITLE
docs: state that a mask is invalidated by any mutation, not just a length-changing one

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,7 @@ Before the first add, `idx.dim` is `None`, `len(idx)` is `0`, and `search()` ret
 
 `swap_remove(i)` is named to match Rust's [`Vec::swap_remove`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.swap_remove): the last element moves into slot `i`, and the vector is truncated by one. It is **not** a shift — the slots after `i` do not move down by one. Order is not preserved; slot indices of vectors you didn't delete may now point at different vectors than before.
 
-Use [`IdMapIndex`](#idmapindex) if external references have to stay stable across deletes.
+Use [`IdMapIndex`](#idmapindex) if external references have to stay stable across deletes. Search masks are external references too — see [A mask is invalidated by any mutation](#a-mask-is-invalidated-by-any-mutation-not-just-a-length-changing-one).
 
 ### Low-level construction from raw parts (Rust)
 
@@ -166,6 +166,14 @@ scores, slots = idx.search(queries, k=10, mask=mask)
 ```
 
 The output shape is `(nq, min(k, n_allowed))`, where `n_allowed` is the number of *distinct* allowed vectors — unique ids in the allowlist, or `mask.sum()` for a mask — the same shrinking behaviour you already see when `k > len(idx)`. No `-1` / `NaN` padding; pad on the caller side if you need a fixed-width batch.
+
+### A mask is invalidated by any mutation, not just a length-changing one
+
+A mask names slots, and [`swap_remove`](#swap_remove-semantics) renumbers slots — so **any** mutation invalidates a mask, including one that leaves `len(idx)` unchanged. Rebuild the mask after every mutation.
+
+The length check is not what protects you. It catches only a size difference (`ValueError: mask length 100 does not match index size 99`); a `swap_remove(i)` + `add(...)` pair restores the original length while leaving a *different* vector in slot `i`, so a mask built before that pair passes validation and then silently selects a different set of vectors than you intended. Nothing outside the index leaks and no error is raised — the selected set is simply the wrong one.
+
+Allowlists on `IdMapIndex` do not have this failure mode, because they name external ids and the index never renumbers an id. An allowlist entry for an id that has since been removed raises `KeyError` (Rust: `SearchError::UnknownId`) instead of quietly resolving to some other vector. The one way an allowlist entry can come to name a different vector is if you re-add that same id yourself with different data.
 
 Common use cases:
 

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -629,6 +629,15 @@ impl TurboQuantIndex {
     /// `mask`, when given, is a bool array of length `len(self)`. Only slots
     /// with `mask[i] == True` contribute to the returned top-`k`. The
     /// returned result count per query is `min(k, mask.sum())`.
+    ///
+    /// A mask names slots, and `swap_remove` renumbers them, so any
+    /// mutation invalidates a mask — not only one that changes the
+    /// length. The length check is not what protects you: a
+    /// `swap_remove(i)` + `add` pair restores the original length while
+    /// leaving a different vector in slot `i`, so a mask built before
+    /// that pair passes validation and then silently selects a
+    /// different set of vectors than intended. Rebuild the mask after
+    /// every mutation.
     #[pyo3(signature = (queries, k, *, mask=None))]
     fn search<'py>(
         &self,

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1253,6 +1253,15 @@ impl TurboQuantIndex {
     ///
     /// Passing `mask = None` is equivalent to [`Self::search`].
     ///
+    /// A mask names slots, and [`Self::swap_remove`] renumbers them, so
+    /// **any** mutation invalidates a mask — not only one that changes
+    /// the length. The length check below is not what protects you: a
+    /// `swap_remove(i)` + `add` pair restores the original length while
+    /// leaving a different vector in slot `i`, so a mask built before
+    /// that pair passes validation and then silently selects a
+    /// different set of vectors than the caller intended. Rebuild the
+    /// mask after every mutation.
+    ///
     /// # Panics
     ///
     /// - If `mask.len() != self.len()` (when `mask` is `Some`).


### PR DESCRIPTION
Closes #432

## The behaviour, verified before documenting it

Reproduction run against this branch's `main` base (`turbovec` 0.9.0), as a temp integration test (`turbovec/tests/`, not committed). `dim=64`, `bit_width=4`, `n=8`, unit-norm gaussian rows; the caller's intent is "search only slots 0 and 1".

```
LENGTH-MISMATCH CHECK FIRES: mask length 7 does not match index size 8
before mutation, allowed slots {0,1} -> [0, 1]
swap_remove(1) -> previous position of moved vector: 7
len after swap_remove + add: 8
after mutation, SAME mask -> [0, 1]
query = original row 7, mask = {slot 1} -> slot [1] score [0.999535]
query = original row 1, mask = {slot 1} -> slot [1] score [0.018155558]
```

Reading it:

- The length check does fire on a genuine size mismatch (line 1).
- After `swap_remove(1)` + `add(...)`, `len` is back to 8, so the **unmodified** mask passes validation and the search runs (line 5) — no error, no panic.
- Slot 1 now holds what used to be slot 7: querying with original row 7 scores `0.9995` against slot 1, while querying with original row 1 — the vector the caller thought slot 1 named — scores `0.018`. The mask selected a different set of vectors than intended, silently.

So #432 is accurate for masks.

## One correction to the issue: allowlists are not affected

The issue title and wording cover "masks and allowlists". `IdMapIndex` allowlists name external `u64` ids, which are translated to a slot mask inside `search_with_allowlist` at call time, so they do not go stale. Same mutation shape:

```
allowlist before mutation: [100, 101]
len after remove + add: 8
allowlist after mutation: Err(UnknownId(101))
surviving-ids allowlist after mutation: [100, 102]
```

A stale entry is **loud** (`SearchError::UnknownId`, `KeyError` in Python), and entries for surviving ids keep naming the right vectors. The one way an allowlist entry comes to name a different vector is the caller re-adding the same id with different data, which I also checked:

```
before: ids [11] score [1.0069245]
after re-adding id 11: ids [11] score [-0.021840608]
```

The landed wording says all three of those things rather than sweeping allowlists into the mask claim.

## The wording

In `docs/api.md`, under **Filtering**, after the output-shape paragraph:

> ### A mask is invalidated by any mutation, not just a length-changing one
>
> A mask names slots, and [`swap_remove`](#swap_remove-semantics) renumbers slots — so **any** mutation invalidates a mask, including one that leaves `len(idx)` unchanged. Rebuild the mask after every mutation.
>
> The length check is not what protects you. It catches only a size difference (`ValueError: mask length 100 does not match index size 99`); a `swap_remove(i)` + `add(...)` pair restores the original length while leaving a *different* vector in slot `i`, so a mask built before that pair passes validation and then silently selects a different set of vectors than you intended. Nothing outside the index leaks and no error is raised — the selected set is simply the wrong one.
>
> Allowlists on `IdMapIndex` do not have this failure mode, because they name external ids and the index never renumbers an id. An allowlist entry for an id that has since been removed raises `KeyError` (Rust: `SearchError::UnknownId`) instead of quietly resolving to some other vector. The one way an allowlist entry can come to name a different vector is if you re-add that same id yourself with different data.

Plus a one-clause pointer from the existing `### swap_remove semantics` section, so the two places that talk about slot invalidation agree.

Every clause is executed above. The exact `ValueError` text is the one the Python binding raises (`turbovec-python/src/lib.rs:689`, asserted by `turbovec-python/tests/test_filtering.py:96`); the Rust `Display` is the same string (`turbovec/src/error.rs:297`).

## Docstrings — checked, not assumed

The same gap was present in the two docstrings that state the mask length rule, so both got the note:

- `TurboQuantIndex::search_with_mask` (`turbovec/src/lib.rs`) said "`mask` … must have length equal to `Self::len`" and then listed the length panic, which is exactly the reading that misleads.
- The pyo3 `search` docstring (`turbovec-python/src/lib.rs`) said the same for the Python surface.

`search_with_allowlist` (`turbovec/src/id_map.rs`) was **not** touched: it already documents `UnknownId` for ids not currently present, which is the accurate statement of its behaviour, and adding a staleness warning there would be false.

`cargo doc --no-deps -p turbovec` produces no new warnings (the 15 that remain are pre-existing and elsewhere).

## Deliberately left out

- **No behaviour change.** #432 decides this is contract-conformant, and I agree it is — but as a follow-up worth considering: `TurboQuantIndex` could carry a monotonic mutation counter and hand out masks stamped with it, turning the silent-wrong-set case into the same loud error the length mismatch already gives. That is a new API, not a fix to this one, so it is not in this PR.
- **No CHANGELOG entry.** Verified against `CONTRIBUTING.md` rather than taking it on faith: the gate's scope list ends "Tests, benchmarks, examples, docs and workflows are out of scope entirely", and its code-file scope explicitly ignores comments — which is all the two `src` changes here are.

[skip changelog]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
