### PR TITLE
test(#352): anchor the weak-block (B=8) regime at every bit width, not just 2-bit

### DIFF
--- a/turbovec/tests/common/fingerprint.rs
+++ b/turbovec/tests/common/fingerprint.rs
@@ -32,9 +32,20 @@ use turbovec::TurboQuantIndex;
 /// rotation has and the Beta parameters the codebook is fit against:
 /// `8·odd` dims collapse to a B=8 Hadamard block, powers of two use one
 /// full-width block, and the two production dims sit in between.
+///
+/// The `8·odd` (B=8) regime is covered at *every* supported bit width,
+/// not just one. It is the regime the rotation mixes least (#309), and
+/// nothing about it is shared across bit widths downstream of the
+/// rotation: the Lloyd-Max codebook is fit per `(bits, dim)`, the TQ+
+/// calibration is fit against that codebook, and the packed layout gets
+/// one bit-plane per bit. A drift confined to a weak-block dim at 3 or 4
+/// bits was previously anchored by nothing — dims 768/1024/1536/3072 all
+/// have B >= 256, and the one B=8 cell was 2-bit only (#352).
 pub const CELLS: &[(usize, usize)] = &[
     (200, 2),   // 8·25  -> B = 8, low dim (loosest Beta asymptotics)
+    (600, 3),   // 8·75  -> B = 8 at the odd bit width
     (768, 4),   // 256·3 -> B = 256
+    (1000, 4),  // 8·125 -> B = 8 at 4 bits, the dim rotation.rs names
     (1024, 3),  // pure power of two -> B = 1024, odd bit width
     (1536, 2),  // 512·3 -> B = 512
     (1536, 4),

--- a/turbovec/tests/encode_fingerprint.rs
+++ b/turbovec/tests/encode_fingerprint.rs
@@ -42,13 +42,16 @@
 //!
 //! # These values are architecture-stable, and that is checked, not assumed
 //!
-//! Every column below was produced by all three CI operating systems —
+//! This test is part of `cargo test -p turbovec --release`, which CI's
+//! `Rust (<os>)` leg runs on all three operating systems —
 //! `ubuntu-latest` (x86_64), `macos-14` (aarch64) and `windows-latest`
-//! (x86_64) — byte-for-byte identically, in the `Encode fingerprint` run
-//! for the commit these constants were frozen at. The cross-OS leg
-//! remains in CI and keeps doing its own job; this test adds the
-//! absolute anchor it cannot provide. Nothing here is an arm64-local
-//! observation.
+//! (x86_64). So every column below is asserted byte-for-byte on all
+//! three on every run: a row that is not architecture-stable cannot go
+//! green, whichever machine it was frozen on. That is a standing check,
+//! not a one-time observation, and it is what makes these constants
+//! something other than an arm64-local artifact. The separate cross-OS
+//! `Encode fingerprint` leg remains in CI and keeps doing its own job —
+//! reporting *which stage* diverged when platforms disagree.
 //!
 //! # Regenerating (only for a deliberate, decided format change)
 //!
@@ -75,7 +78,9 @@ use fingerprint::Fingerprint;
 #[rustfmt::skip]
 const GOLDEN: &[(usize, usize, u64, u64, u64, u64, u64, u64)] = &[
     (200, 2, 0x4fb0378dc1d86d75, 0xd43ff8712da19915, 0xd8954c04d5e32446, 0x51ac5b5fbac6015c, 0xce80807762595093, 0x137431c3add9674c),
+    (600, 3, 0xdbf9f4cb38e0530d, 0xa0f02ffec44b5951, 0x316048f03777b58a, 0x45fb17ac805e46cc, 0xb243f721db7dd1b2, 0x5e6354595068485e),
     (768, 4, 0x27273d875c560161, 0x09704dad5b65a00d, 0x6184f0f5fa718399, 0x710f98173ad7adf4, 0x9e91401ca53d0e56, 0xad08bf26820cc759),
+    (1000, 4, 0xdc246fa18e79015d, 0xa632bd47c9e9628d, 0x61ca5a892223c472, 0x66b01c252d992e2f, 0x701dc14d71a883e8, 0x76f8ca3dc628094d),
     (1024, 3, 0xd9eeefae66c34fd1, 0xfcf5342e5aefb105, 0x4535808217e71fd1, 0x08de3afa38a7811f, 0x995c29a6a7552d50, 0x3d583d1804f887f1),
     (1536, 2, 0xb1a97993603c7dcd, 0x1348c9ae60bbdc3d, 0x634e4556860350de, 0xe08d570fb5d95def, 0x5c196d53c48adb99, 0x6d782eb0a2206256),
     (1536, 4, 0x05f7a92f87aba9a1, 0x84f2c25cecbf6761, 0x258d63b4ed365a8b, 0x6ea28fd7af0b94ea, 0x90a0225c11099389, 0x73373deb1ffdc8c3),
@@ -146,9 +151,18 @@ fn refreeze_requested() -> bool {
 
 #[test]
 fn encode_fingerprint_is_frozen() {
-    let refreeze = refreeze_requested();
-    if refreeze {
+    // A re-freeze prints one row per *cell*, not per existing golden, and
+    // does so before the divergence check below. Both halves matter: the
+    // point of a re-freeze is often that the cell list just changed, and
+    // iterating `GOLDEN` (or asserting the two agree first) would make a
+    // newly added cell unfreezable — the regeneration path would refuse
+    // to run until someone hand-wrote the row it exists to generate.
+    if refreeze_requested() {
         println!("// paste into GOLDEN in tests/encode_fingerprint.rs");
+        for &(dim, bits) in fingerprint::CELLS {
+            println!("{}", fingerprint::fingerprint(dim, bits).golden_literal(dim, bits));
+        }
+        return;
     }
 
     // The cells the goldens cover must be exactly the cells the example
@@ -164,10 +178,6 @@ fn encode_fingerprint_is_frozen() {
 
     for &(dim, bits, boundaries, centroids, calibration, codes, scales, file) in GOLDEN {
         let got = fingerprint::fingerprint(dim, bits);
-        if refreeze {
-            println!("{}", got.golden_literal(dim, bits));
-            continue;
-        }
         let want = Fingerprint { boundaries, centroids, calibration, codes, scales, file };
         // Report *all* differing columns across *all* cells rather than
         // panicking on the first: which columns moved together is the


### PR DESCRIPTION
Closes #352

## What was already covered

#406 landed the absolute anchor this issue asked for, and per your narrowing comment the only remaining scope was the `8·odd` gap. Re-verified against `main` before touching anything — `cargo test -p turbovec --release --test encode_fingerprint` → 4 passed, all six columns frozen across six cells.

## The gap this closes

`8·odd` dims collapse to a B=8 Hadamard block — the regime the rotation mixes least (#309, `rotation.rs:91`). It was anchored at exactly one point: dim 200, 2-bit. The other five cells are dims 768/1024/1536/3072, all B >= 256.

Nothing downstream of the rotation is shared across bit widths: the Lloyd-Max codebook is fit per `(bits, dim)`, the TQ+ calibration against that codebook, and the packed layout gets one bit-plane per bit. So a drift confined to a weak-block dim at 3 or 4 bits had nothing absolute to fail against.

Adds two cells: `(600, 3)` = 8·75 and `(1000, 4)` = 8·125 — the latter the dim `rotation.rs:91` names as the canonical weak-block case. **Every existing golden row came back byte-identical**, which is itself the check that the shared fixture was not disturbed.

## Discrimination

Perturbed the weak-block scale by one ulp — `inv_sqrt_block` when `block == 8`, the class of retuned constant the anchor exists to catch:

```
  dim=200  bits=2 calibration: got 47aa2523284976a3, want d8954c04d5e32446
  dim=200  bits=2 scales:      got b84ff4c2f3d5cf75, want ce80807762595093
  dim=200  bits=2 file:        got 32ed5acdb4790fbf, want 137431c3add9674c
  dim=600  bits=3 calibration: got 27c2c217f864989b, want 316048f03777b58a
  dim=600  bits=3 scales:      got 6e8dd498dd696e96, want b243f721db7dd1b2
  dim=600  bits=3 file:        got 298b27673366c19b, want 5e6354595068485e
  dim=1000 bits=4 calibration: got b5dc782b3c1d5a5a, want 61ca5a892223c472
  dim=1000 bits=4 codes:       got 1a065bce81d9ebe0, want 66b01c252d992e2f
  dim=1000 bits=4 scales:      got 5ac490d2517444bd, want 701dc14d71a883e8
  dim=1000 bits=4 file:        got 83565c57358ea623, want 76f8ca3dc628094d
```

Exactly the three B=8 cells; 768/1024/1536/3072 untouched. The interesting line is what did *not* move: at 200/2 and 600/3 the `codes` column is unchanged — the 2-bit boundaries are coarse enough to absorb the perturbation — while at 1000/4 the finer boundaries flip codes. **The pre-existing 2-bit cell alone could not have shown a weak-block change reaching the packed codes.** Restored: 4 passed.

## Two things found on the way

1. **The re-freeze path could not freeze a new cell.** It iterated `GOLDEN` and ran *after* the `GOLDEN == CELLS` equality assert, so adding a cell made `TURBOVEC_REFREEZE=1` abort on that assert — refusing to run for exactly the case it exists to serve. Reproduced verbatim before fixing:

   ```
   assertion `left == right` failed: GOLDEN and the fingerprint CELLS have diverged
     left: [(200, 2), (768, 4), ...]
    right: [(200, 2), (600, 3), (768, 4), ...]
   ```

   It now iterates `CELLS` and returns before the assert. The assert itself is unchanged for normal runs.

2. **A module-doc claim was a one-time observation stated as a standing fact** — that every column had been produced identically by all three CI OSes "in the `Encode fingerprint` run for the commit these constants were frozen at". Verified the stronger and permanent version instead: this test is part of `cargo test -p turbovec --release --locked`, which `ci.yml:19-45` runs on ubuntu-latest, macos-14 and windows-latest. Every column is therefore asserted byte-for-byte on all three on every run, so a row that is not architecture-stable cannot go green whichever machine froze it. Doc updated to say that.

## Verification

- `cargo test -p turbovec --release --locked` → 26 suites, all ok (0 failed)
- `cargo run --release -p turbovec --example encode_hash` → prints the 8 rows, matching `GOLDEN` exactly
- The two new rows are arm64-frozen; this PR's `Rust (ubuntu-latest)` and `Rust (windows-latest)` legs are what confirm them, and will fail here if either is not architecture-stable.

No changelog entry: the gate scopes to `turbovec/src/**` and friends, and CONTRIBUTING.md:51-52 puts tests out of scope entirely.

## Follow-ups, deliberately not bundled

- A CI leg that runs the ulp-perturbation discrimination check automatically, so the anchor cannot rot into a tautology.
- Issue #352's gap 3 (`apply_scaled_into`) is closed at `rotation.rs:1255-1288`; gaps 1/2/4/5 by #406. Nothing else from the issue remains open as far as I can tell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
