### PR TITLE
docs(#351): record the measured MSRV floor; findings 1 and 2 already fixed

### DIFF
--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -2,6 +2,11 @@
 name = "turbovec-python"
 version = "0.8.0"
 edition = "2021"
+# Kept in lockstep with turbovec's `rust-version` — the `msrv` leg in ci.yml
+# fails if the two manifests disagree. The rationale for the number, and why
+# an aarch64 build makes it look over-declared, is recorded in
+# `turbovec/Cargo.toml`. pyo3 and numpy declare 1.83, so this crate's own
+# dependencies do not raise the floor; the AVX-512 kernels in turbovec do.
 rust-version = "1.89"
 
 [lib]

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -2,6 +2,28 @@
 name = "turbovec"
 version = "0.9.0"
 edition = "2021"
+# 1.89 is a floor the code actually needs, not a rounded-up default, and it has
+# now been reported as over-declared twice (#351). The AVX-512 search kernel is
+# what sets it: `search.rs` gates functions on `target_feature(enable =
+# "avx512f" / "avx512bw")` and `search.rs`/`rotation.rs` call `_mm512_*`
+# intrinsics, all of which were unstable (`stdarch_x86_avx512`) until 1.89 —
+# and two changed signature at stabilization (`_mm512_loadu_si512` takes
+# `*const i32`, `_mm512_i32gather_ps` a `*const u8` base).
+#
+# Measured with `cargo check -p turbovec --target x86_64-unknown-linux-gnu
+# --locked --all-targets`: 1.83 -> 153 errors, 1.88 -> 151 errors, 1.89 ->
+# Finished. So 1.89 is the exact minimum; the next release down does not build.
+#
+# Checking this on an aarch64 host proves nothing, and that is where both
+# over-declaration reports came from: those kernels sit behind
+# `#[cfg(target_arch = "x86_64")]` and are never compiled on ARM, so
+# `cargo +1.83 check -p turbovec --locked --all-targets` finishes cleanly there
+# while the same check for x86_64 fails 153 times. Pass `--target
+# x86_64-unknown-linux-gnu` explicitly before concluding anything about this
+# number. The `msrv` leg in ci.yml builds the declared toolchain on
+# ubuntu-latest, so it catches an *under*-declaration; nothing checks the
+# release below, which is why an over-declaration would have to be found by
+# hand.
 rust-version = "1.89"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 license = "MIT"


### PR DESCRIPTION
Refs #351 — deliberately not `Closes`: this PR settles the three findings in the issue title, but #351 also carries findings 4–7 (rustdoc under `-D warnings`, the statrs dependency tree, `IdMapIndex::search`'s bare tuple, the thin downstream smoke test), which are untouched here.

## What I found

I re-checked all three title findings against `main` (`fc67831`) by execution, from a **separate cargo project that path-deps the crate** — the `cargo add turbovec` lens the issue was written through. Two are already fixed and the third does not hold.

### 1. `SearchResults` derives nothing — ALREADY FIXED (#403)

`turbovec/src/lib.rs:419` is `#[derive(Debug, Clone, PartialEq)]`, with a documented rationale for omitting `Eq`/`Hash` on a float-carrying type. The downstream probe compiles the exact shape the issue said was impossible:

```rust
#[derive(Debug, Clone, PartialEq)]
struct Downstream { cached: SearchResults }
fn assert_traits<T: std::fmt::Debug + Clone + PartialEq>() {}
assert_traits::<SearchResults>();   // compiles
assert_eq!(d.clone(), d);           // passes
```

`SearchResults` is also `Send + Sync`. Nothing to do.

### 2. No non-panicking `search` — ALREADY FIXED (#403, #412)

`try_search` (`lib.rs:1243`) and `try_search_with_mask` (`lib.rs:1332`) exist, and `IdMapIndex::search_with_allowlist` (`id_map.rs:525`) returns `Result`. The panicking forms now delegate to the checked ones and re-panic on the error's `Display`, so the two cannot diverge in what they detect. Every condition the issue named comes back as `Err` from the probe:

```
finding2 ragged        -> Err(query buffer length 65 not a multiple of dim 64)
finding2 nonfin        -> Err(invalid query value at query 0, coord 3: NaN (must be finite and |value| < 1e16 ...))
finding2 huge          -> Err(invalid query value at query 0, coord 7: 1000000000000000000000000000000 (must be finite and |value| < 1e16 ...))
finding2 mask          -> Err(mask length 3 does not match index size 256)
finding2 unknown       -> Err(id 999 in allowlist is not present in index)
finding2 idmap-ragged  -> Err(query buffer length 65 not a multiple of dim 64)
```

`SearchError` is `Debug + Clone + PartialEq` and boxes as `dyn Error + Send + Sync + 'static`. Nothing to do.

### 3. MSRV over-declared by 9 releases — DOES NOT HOLD; 1.89 is the exact floor

This is the only item this PR touches, and it is a documentation change, because the number is already right.

Measured with `cargo check -p turbovec --locked --all-targets`. The 1.83 and 1.88 runs carry `--ignore-rust-version` because cargo otherwise refuses on the manifest check alone; every error below is emitted by rustc after that gate, not by cargo:

| toolchain | `--target x86_64-unknown-linux-gnu` | native aarch64 |
|---|---|---|
| 1.83 | **153 errors** | Finished |
| 1.88 | **151 errors** | — |
| 1.89 | Finished | Finished |

So 1.89 is not rounded up: the release immediately below it does not compile. The errors are `E0658 use of unstable library feature 'stdarch_x86_avx512'`, `E0658 the target feature 'avx512bw' is currently unstable` (`search.rs:603`), and two signature changes at stabilization:

```
error[E0308]: mismatched types
   --> turbovec/src/rotation.rs:449:38
449 | let idx = _mm512_loadu_si512(perm.as_ptr().add(i) as *const __m512i);
    = note: expected raw pointer `*const i32`
```

**Why the claim was made twice:** those kernels are all inside `#[cfg(target_arch = "x86_64")]`, so an aarch64 host never compiles them — `cargo +1.83 check -p turbovec --locked --all-targets` genuinely finishes there. Both reports in #351 were arm64 checks. `--ignore-rust-version` was a red herring: it suppresses cargo's manifest check, not the compiler, and a crate that truly needs 1.89 still fails under it.

**The change:** the rationale existed only in a `ci.yml` comment, which does not mention the architecture trap and is not where anyone looks when they read `rust-version = "1.89"`. This PR puts the measurement beside the number in `turbovec/Cargo.toml`, and a pointer to it in `turbovec-python/Cargo.toml` (which the `msrv` CI leg requires to match). The manifests are already commented in this style — see the `rand_chacha` and `statrs` pins.

I verified the two floors the issue offered as alternatives rather than repeating them: the locked `pyo3 0.29.0` and `numpy 0.29.0` both declare `rust-version = "1.83"`, so the Python crate's own dependencies do not set the floor either.

## Left to the maintainer

Nothing about the MSRV number itself — it is correct, so there is no support commitment to weigh. One observation recorded in the comment but **not acted on**, since it is CI infrastructure and a separate concern from this issue:

- The `msrv` leg (`ci.yml:234`) installs the *declared* toolchain and builds with it. That catches an under-declaration. It cannot catch an over-declaration, which needs a check that the release *below* the declared one fails. The issue's version of this claim is right; the correction in the issue's own comment thread ("it *would* have caught a genuine over-declaration") is not. Whether that leg is worth adding is a maintainer call and is deliberately not in this PR.

## Test plan

No test ships with this PR, and that is deliberate rather than an omission: the diff is comment-only in two manifests, so there is no runtime behaviour a test could discriminate on, and a test that passed identically before and after would be noise. Findings 1 and 2 already have their tests, landed with #403/#412.

What was run instead:

- `cargo check -p turbovec --target x86_64-unknown-linux-gnu --locked --all-targets` at 1.83 / 1.88 / 1.89 — the table above. This is the discriminating evidence for the only claim the diff makes: change `1.89` to `1.88` and the build fails 151 times.
- The same check natively on aarch64 at 1.83 — Finished, which is the trap the comment documents.
- A downstream path-dep probe crate exercising findings 1 and 2, output quoted above.
- `python3 .github/scripts/changelog_gate.py --base origin/main --head HEAD` → `No substantive changes to shipped surface; no changelog entry required.` The gate ignores comment lines in `Cargo.toml` (`_HASH_COMMENT`), and there is no user-visible change to describe, so no `CHANGELOG.md` entry was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
