### PR TITLE
ci: /summary accepts a paragraph and/or word count

### DIFF
--- a/.claude/skills/summarize/SKILL.md
+++ b/.claude/skills/summarize/SKILL.md
@@ -7,7 +7,9 @@ description: Write a short, plain-English summary of whatever it's attached to �
 
 Summarize whatever this is attached to — the issue, pull request, or diff.
 
-- One or two short paragraphs. No headers, no bullet points.
+- One or two short paragraphs by default. If a specific length was asked
+  for — a paragraph count, a word count, or both — that wins; everything
+  below still applies. No headers, no bullet points either way.
 - Plain English, simple enough for a non-expert. Say what it does and why
   it matters; skip the implementation and format details.
 - Direct and matter-of-fact. No hype, no marketing language.

--- a/.github/workflows/summarize-command.yml
+++ b/.github/workflows/summarize-command.yml
@@ -59,6 +59,47 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # Optional length overrides: `/summary para 3`, `/summary words 150`,
+      # or both in either order. Anything else after `/summary` is ignored,
+      # so the bare command keeps working exactly as before.
+      #
+      # The comment body arrives through `env`, never interpolated into the
+      # script. A comment body is a template-injection sink even behind the
+      # owner-id guard, and zizmor gates this workflow on that rule.
+      #
+      # Both counts are range-checked rather than passed through: an
+      # out-of-range or malformed number falls back to the default instead
+      # of asking the model for 900 paragraphs.
+      - name: Parse requested length
+        id: length
+        env:
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          num() {
+            printf '%s' "$BODY" \
+              | grep -oiE "\\b$1[[:space:]]+[0-9]{1,4}\\b" \
+              | head -1 | grep -oE '[0-9]+' || true
+          }
+          paras=$(num 'para(graph)?s?')
+          words=$(num 'words?')
+
+          out=""
+          if [ -n "$paras" ] && [ "$paras" -ge 1 ] && [ "$paras" -le 10 ]; then
+            if [ "$paras" -eq 1 ]; then
+              out="Write exactly one paragraph."
+            else
+              out="Write exactly $paras paragraphs."
+            fi
+          fi
+          if [ -n "$words" ] && [ "$words" -ge 10 ] && [ "$words" -le 2000 ]; then
+            out="${out:+$out }Keep it to roughly $words words."
+          fi
+          [ -n "$out" ] || out="Use the skill's default length."
+
+          echo "instruction=$out" >> "$GITHUB_OUTPUT"
+          echo "requested: $out"
+
       - name: Summarize and comment
         uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         env:
@@ -82,7 +123,11 @@ jobs:
             2. Write the summary by following the /summarize skill
                (.claude/skills/summarize/SKILL.md), which covers issues and
                pull requests alike.
-            3. Post it with `gh pr comment N --body ...` on a pull request,
+            3. Length: ${{ steps.length.outputs.instruction }}
+               This came from the command itself, so it overrides the
+               skill's default length. Everything else in the skill — plain
+               English, no headers or bullets, no hype — still applies.
+            4. Post it with `gh pr comment N --body ...` on a pull request,
                or `gh issue comment N --body ...` on an issue.
 
             Read-only otherwise: do not push commits, edit files, or touch


### PR DESCRIPTION
## What this adds

```
/summary                      # unchanged — skill default
/summary para 3               # exactly 3 paragraphs
/summary words 150            # roughly 150 words
/summary para 2 words 120     # both, either order
```

`para`, `paras`, `paragraph`, `paragraphs` and `word`, `words` are all accepted.

## How

A `Parse requested length` step turns the command into one sentence, which the prompt passes to the agent as step 3. `.claude/skills/summarize/SKILL.md` now says an explicit length wins over its "one or two short paragraphs" default — without that the two instructions contradict each other and the model silently picks one.

## Two deliberate choices

**Range-checked, not passed through.** 1-10 paragraphs, 10-2000 words. Anything outside that, non-numeric, or absent falls back to the default. A typo should produce a normal summary, not a request for 900 paragraphs.

**The comment body never touches the script.** It arrives via `env: BODY`, and the script reads `$BODY`. A comment body is a template-injection sink even behind the owner-id guard, and zizmor gates this workflow on exactly that rule.

## Verified

Parser run against 15 inputs, all correct:

| input | result |
|---|---|
| `/summary` | default |
| `/summary para 3` / `paras 3` / `paragraphs 5` | 3 / 3 / 5 paragraphs |
| `/summary paragraph 1` | "exactly one paragraph" (not "1 paragraphs") |
| `/summary words 150` / `word 80` | roughly 150 / 80 words |
| `/summary para 2 words 120` | both |
| `/summary words 120 para 2` | both — order independent |
| `para 0`, `para 99`, `words 5`, `words 99999` | default (out of range) |
| `para abc`, `make it comparable` | default (no match) |

Also confirmed: `yaml.safe_load` parses the workflow, the body is passed via `env` only, and the step ordering puts parsing before the agent step.

Not executable locally — the Actions expression and webhook path can only be confirmed by running it. The real test is `/summary para 3` on an issue once this lands.

## Note

Touches `.github/workflows/**`, so the zizmor audit runs. No `actions/checkout`, permissions or existing `run:` lines changed; the one new `run:` follows the env-not-interpolation rule the audit enforces.