### PR TITLE
docs: record that target-cpu=x86-64-v2 does not change any encoded byte (#439)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -18,5 +18,37 @@
 #
 # ARM / aarch64 builds are unaffected — they use their own default
 # codegen target.
+#
+# This file is not published with the crate, so a downstream
+# `cargo add turbovec` build compiles *without* this flag while every
+# in-repo build — including the one that froze the `GOLDEN` constants in
+# `turbovec/tests/encode_fingerprint.rs` — compiles with it. That
+# difference was measured rather than assumed (#439), because if it
+# moved any encoded byte those goldens would pin something no user's
+# build produces:
+#
+#   GitHub Actions `ubuntu-latest` (`uname -m` -> x86_64), rustup
+#   `stable-x86_64-unknown-linux-gnu`, one commit, `cargo clean` between
+#   arms. `cargo run --release --locked -p turbovec --example
+#   encode_hash` was run twice — once with this file in place, once with
+#   it moved aside — and all 48 hashes (8 (dim, bit_width) cells x the
+#   boundaries / centroids / calibration / codes / scales / file
+#   columns) were identical in the two arms, and equal to `GOLDEN`.
+#   `cargo build -v` confirmed the arms really differed: 52 rustc
+#   invocations carried `-C target-cpu=x86-64-v2` in the first arm
+#   (including `--crate-name turbovec` and `--crate-name encode_hash`)
+#   and none did in the second.
+#
+# So this flag is a performance setting only, and in-repo and downstream
+# builds write identical encoded bytes. That is a measurement of the
+# current code, not a guarantee about future code: a change that made
+# encoding sensitive to instruction selection would invalidate it, and
+# nothing in CI re-runs the comparison.
+#
+# Footgun found while measuring: `CARGO_BUILD_RUSTFLAGS=""` does **not**
+# override the `rustflags` below — the flag was still on all 52 rustc
+# invocations under it. `target.<cfg>.rustflags` has to be removed, not
+# emptied from the environment, or a build you believe is unflagged
+# is not.
 [target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-cpu=x86-64-v2"]


### PR DESCRIPTION
Closes #439.

`.cargo/config.toml` sets `-C target-cpu=x86-64-v2` for in-repo `x86_64` builds. That file is not published with the crate, so a downstream `cargo add turbovec` build compiles **without** it. #439 asked whether that difference reaches the encode path — which would matter because `turbovec/tests/encode_fingerprint.rs` pins absolute `GOLDEN` hashes that were frozen by in-repo builds, i.e. *with* the flag. If the flag moved any encoded byte, those goldens would describe something no user's build produces, and the cross-OS agreement leg would be comparing three in-repo builds that all share the flag — self-consistent, and still not reality.

**It does not.** No code or test change here; the goldens were already correct. The only change is a comment recording the measurement next to the flag, so the next reader does not have to re-derive it.

## The measurement

This cannot be settled on arm64, where `target-cpu=x86-64-v2` is meaningless, so it ran on a GitHub Actions `ubuntu-latest` runner via a temporary workflow (**removed before this PR**; nothing in this diff adds a CI leg). `uname -m` → `x86_64`, toolchain `stable-x86_64-unknown-linux-gnu`, one commit, `cargo clean` between arms:

- **arm A** — repo as-is, then `cargo run --release --locked -p turbovec --example encode_hash`
- **arm B** — `.cargo/config.toml` moved aside, same command

Full log: run [30624126662](https://github.com/RyanCodrai/turbovec/actions/runs/30624126662), job `91135299910` (both tables and both `cargo build -v` logs are printed there and uploaded as an artifact).

### The arms really did differ

A comparison that silently applies the same flags twice reports "no difference" and proves nothing, so `cargo build -v` checked it, and the job was written to hard-fail on either violation:

- arm A: **52** rustc invocations carried `-C target-cpu=x86-64-v2`, including `--crate-name turbovec` and `--crate-name encode_hash` (that line ends `…libturbovec-84fc7b9faef88a45.rlib -C target-cpu=x86-64-v2`)
- arm B: **0** occurrences; the `encode_hash` line ends `…libturbovec-f3e4f8d29579b64d.rlib`. The differing `libturbovec` metadata hash (`f3e4f8d2…` vs `84fc7b9f…`) confirms a genuinely separate compilation rather than a reused artifact.

A probe step first established that the obvious alternative method would have produced a **false negative**: under `CARGO_BUILD_RUSTFLAGS=""` the flag was still on all 52 invocations. `target.<cfg>.rustflags` is not overridden by emptying the environment variable — the file has to be removed. That footgun is recorded in the comment too, because anyone re-running this check is likely to reach for the env var first.

### Result

<details>
<summary>WITH <code>-C target-cpu=x86-64-v2</code> (in-repo)</summary>

```
dim=200 bits=2 boundaries=4fb0378dc1d86d75 centroids=d43ff8712da19915 calibration=d8954c04d5e32446 codes=51ac5b5fbac6015c scales=ce80807762595093 file=137431c3add9674c
dim=600 bits=3 boundaries=dbf9f4cb38e0530d centroids=a0f02ffec44b5951 calibration=316048f03777b58a codes=45fb17ac805e46cc scales=b243f721db7dd1b2 file=5e6354595068485e
dim=768 bits=4 boundaries=27273d875c560161 centroids=09704dad5b65a00d calibration=6184f0f5fa718399 codes=710f98173ad7adf4 scales=9e91401ca53d0e56 file=ad08bf26820cc759
dim=1000 bits=4 boundaries=dc246fa18e79015d centroids=a632bd47c9e9628d calibration=61ca5a892223c472 codes=66b01c252d992e2f scales=701dc14d71a883e8 file=76f8ca3dc628094d
dim=1024 bits=3 boundaries=d9eeefae66c34fd1 centroids=fcf5342e5aefb105 calibration=4535808217e71fd1 codes=08de3afa38a7811f scales=995c29a6a7552d50 file=3d583d1804f887f1
dim=1536 bits=2 boundaries=b1a97993603c7dcd centroids=1348c9ae60bbdc3d calibration=634e4556860350de codes=e08d570fb5d95def scales=5c196d53c48adb99 file=6d782eb0a2206256
dim=1536 bits=4 boundaries=05f7a92f87aba9a1 centroids=84f2c25cecbf6761 calibration=258d63b4ed365a8b codes=6ea28fd7af0b94ea scales=90a0225c11099389 file=73373deb1ffdc8c3
dim=3072 bits=4 boundaries=9a1b3dca8251faad centroids=6a56a1738e12e62d calibration=b2d6299eaeeaf100 codes=759066303c3fbad1 scales=1364e4f49709a1f6 file=6910e8598ad1badf
```
</details>

<details>
<summary>WITHOUT the flag (downstream default)</summary>

```
dim=200 bits=2 boundaries=4fb0378dc1d86d75 centroids=d43ff8712da19915 calibration=d8954c04d5e32446 codes=51ac5b5fbac6015c scales=ce80807762595093 file=137431c3add9674c
dim=600 bits=3 boundaries=dbf9f4cb38e0530d centroids=a0f02ffec44b5951 calibration=316048f03777b58a codes=45fb17ac805e46cc scales=b243f721db7dd1b2 file=5e6354595068485e
dim=768 bits=4 boundaries=27273d875c560161 centroids=09704dad5b65a00d calibration=6184f0f5fa718399 codes=710f98173ad7adf4 scales=9e91401ca53d0e56 file=ad08bf26820cc759
dim=1000 bits=4 boundaries=dc246fa18e79015d centroids=a632bd47c9e9628d calibration=61ca5a892223c472 codes=66b01c252d992e2f scales=701dc14d71a883e8 file=76f8ca3dc628094d
dim=1024 bits=3 boundaries=d9eeefae66c34fd1 centroids=fcf5342e5aefb105 calibration=4535808217e71fd1 codes=08de3afa38a7811f scales=995c29a6a7552d50 file=3d583d1804f887f1
dim=1536 bits=2 boundaries=b1a97993603c7dcd centroids=1348c9ae60bbdc3d calibration=634e4556860350de codes=e08d570fb5d95def scales=5c196d53c48adb99 file=6d782eb0a2206256
dim=1536 bits=4 boundaries=05f7a92f87aba9a1 centroids=84f2c25cecbf6761 calibration=258d63b4ed365a8b codes=6ea28fd7af0b94ea scales=90a0225c11099389 file=73373deb1ffdc8c3
dim=3072 bits=4 boundaries=9a1b3dca8251faad centroids=6a56a1738e12e62d calibration=b2d6299eaeeaf100 codes=759066303c3fbad1 scales=1364e4f49709a1f6 file=6910e8598ad1badf
```
</details>

`diff -u` between the two is empty. All 48 hashes — 8 `(dim, bit_width)` cells × the `boundaries` / `centroids` / `calibration` / `codes` / `scales` / `file` columns — match, and every row equals the corresponding `GOLDEN` literal in `turbovec/tests/encode_fingerprint.rs`.

So the flag is a performance setting only, and in-repo and downstream builds write identical encoded bytes.

## Scope of the claim

Stated in the comment as well, because it is the part that is easy to overread: this is a measurement of the current code on one runner, not a guarantee about future code. A change that made encoding sensitive to instruction selection would invalidate it, and nothing in CI re-runs the comparison.

## Follow-up, deliberately not in this PR

A permanent CI leg that fingerprints once with and once without `.cargo/config.toml` would turn the above from a one-time observation into a standing check — the same upgrade `encode_fingerprint.rs` already makes over the cross-OS leg. Per repo convention that is regression-prevention infrastructure and ships separately from the finding; I have not opened it. It costs a second release build of the crate on every run, which is the trade-off worth deciding on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
