### PR TITLE
feat: make the PR review a required merge gate

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -375,31 +375,36 @@ jobs:
           # A fork head is skipped on purpose, but "skipped" cannot mean
           # "merge freely" — it means a maintainer has to review it by hand
           # and use their branch-protection bypass.
+          # Three states, and only three, on every surface a person reads:
+          # "Passed review" green, "Failed review" red, "Review required" red.
+          # The internal verdict stays GO/NO-GO because that is what the agent
+          # is asked to write and what the checks above decide between — but
+          # none of that vocabulary reaches the PR.
           if [ "$FORK" != "true" ]; then
             state=failure
-            verdict="NO-GO"
-            reason="fork PR — a maintainer must review this by hand"
+            label="Review required"
+            reason="a maintainer must review this fork by hand"
           elif [ "$VERDICT" = "GO" ]; then
             state=success
-            verdict="GO"
+            label="Passed review"
             reason="${REASON:-no blocking findings}"
           else
             state=failure
-            verdict="NO-GO"
+            label="Failed review"
             reason="${REASON:-the review did not reach a verdict}"
           fi
 
           gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
             -f state="$state" -f context="Agent code review" -f target_url="$RUN" \
-            -f description="$verdict: $reason" --silent
+            -f description="$label — $reason" --silent
 
           # Say it on the PR as well. The status alone is a one-line row in a
           # collapsed check list; a no-go needs to say what to do next, and the
           # instruction deliberately never spells the trigger token literally.
           if [ "$state" = success ]; then
-            body="✅ **Agent code review: GO** — $reason. ([run]($RUN))"
+            body="✅ **Passed review** — $reason. ([run]($RUN))"
           else
-            body="🚫 **Agent code review: NO-GO** — $reason. Merging is blocked until a review of the current head returns GO: address the findings, then re-run it by commenting `/review` on this PR. Note that pushing a new commit clears the verdict, so the last push always needs its own review. ([run]($RUN))"
+            body="🚫 **$label** — $reason. Merging is blocked until the current head passes review: address the findings, then re-run it by commenting `/review` on this PR. Note that pushing a new commit needs its own review, so the last push always does too. ([run]($RUN))"
           fi
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$body"
 
@@ -454,4 +459,4 @@ jobs:
           fi
           gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
             -f state=failure -f context="Agent code review" -f target_url="$RUN" \
-            -f description="NO-GO: no review on this commit — comment /review" --silent
+            -f description="Review required — no review on this commit" --silent

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -28,7 +28,10 @@ name: PR Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    # opened / ready_for_review start a review. synchronize and reopened do
+    # not — they only stamp the new commit red (see the `stamp` job), which is
+    # what keeps a push from silently inheriting the previous commit's verdict.
+    types: [opened, ready_for_review, synchronize, reopened]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -42,8 +45,13 @@ permissions: {}
 # One review per PR at a time; a queued run waits rather than racing. Load
 # bearing for the gate too: concurrent runs on one PR would post competing
 # `Agent code review` statuses to the same SHA, last writer winning arbitrarily.
+#
+# The `stamp` job gets its own group. It shares the workflow with the reviewer,
+# and a workflow-level group is per-run, so without the suffix a push landing
+# mid-review would sit queued behind a 45-minute review before going red —
+# leaving the unreviewed commit looking merely pending for the whole window.
 concurrency:
-  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
+  group: pr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}-${{ (github.event_name == 'pull_request' && contains(fromJSON('["synchronize", "reopened"]'), github.event.action)) && 'stamp' || 'review' }}
   cancel-in-progress: false
 
 jobs:
@@ -68,6 +76,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
+       contains(fromJSON('["opened", "ready_for_review"]'), github.event.action) &&
        github.event.pull_request.head.repo.full_name == github.repository &&
        github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' &&
@@ -393,3 +402,56 @@ jobs:
             body="🚫 **Agent code review: NO-GO** — $reason. Merging is blocked until a review of the current head returns GO: address the findings, then re-run it by commenting `/review` on this PR. Note that pushing a new commit clears the verdict, so the last push always needs its own review. ([run]($RUN))"
           fi
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$body"
+
+          # Fail the job on a no-go, after the status and comment are safely
+          # posted. The commit status is what branch protection enforces, so
+          # this is not what blocks the merge — it is here so the run is red
+          # wherever runs are read (the Actions tab, run-failure notifications)
+          # rather than green next to a red check.
+          [ "$state" = success ]
+
+  # A commit nobody has reviewed must read as blocked, not as pending. Branch
+  # protection already refuses to merge a SHA carrying no `Agent code review`
+  # status, but GitHub renders a missing required check as "Expected — waiting
+  # for status to be reported", which looks like something still in flight
+  # rather than a decision that has been made. This job stamps the verdict red
+  # the moment an unreviewed commit appears, so "not reviewed" and "reviewed
+  # and rejected" look the same to anyone glancing at the PR — both are no-go.
+  #
+  # It deliberately does NOT start a review: reviewing every push multiplies
+  # subscription load, which is the trade this workflow has already made.
+  # Clearing the red is one `/review` comment.
+  #
+  # No secrets are used here, and it never runs the project's code — so unlike
+  # the review job it is cheap enough to fire on every push.
+  stamp:
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(fromJSON('["synchronize", "reopened"]'), github.event.action) &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    steps:
+      - name: Mark the new commit unreviewed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Never overwrite a verdict the commit already carries. A push
+          # produces a new SHA that cannot have one, but `synchronize` also
+          # fires when the base branch moves, and `reopened` fires on a SHA
+          # that may well have been reviewed already — clobbering a GO on
+          # either would send the author back for a second review of a tree
+          # nobody has touched.
+          n=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/status" \
+                --jq '[.statuses[] | select(.context == "Agent code review")] | length')
+          if [ "$n" -gt 0 ]; then
+            echo "$SHA already carries a verdict — leaving it alone."
+            exit 0
+          fi
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state=failure -f context="Agent code review" -f target_url="$RUN" \
+            -f description="NO-GO: no review on this commit — comment /review" --silent

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -316,6 +316,15 @@ jobs:
               | jq -s "[.[][] | select((.created_at // .submitted_at) > \"$SINCE\"
                                        and .user.login == \"$bot\") $2] | length"
           }
+          sample() {
+            inline=$(mine "pulls/$PR/comments" "")
+            reviews=$(mine "pulls/$PR/reviews" "")
+            issues=$(mine "issues/$PR/comments" "")
+            rejects=$(mine "pulls/$PR/reviews" "| select(.state == \"CHANGES_REQUESTED\")")
+            total=$((inline + reviews + issues))
+            echo "$1 — inline:$inline reviews:$reviews issues:$issues changes-requested:$rejects"
+          }
+
           # Poll, do not sample once. The action's step can return before the
           # comment it just posted is readable back — observed at 3 seconds,
           # which was long enough to make a clean review look silent and fail
@@ -323,15 +332,23 @@ jobs:
           # one verdict that must never be reached by racing the API, so it
           # is only declared after the lag has had time to settle.
           for attempt in 1 2 3 4 5 6; do
-            inline=$(mine "pulls/$PR/comments" "")
-            reviews=$(mine "pulls/$PR/reviews" "")
-            issues=$(mine "issues/$PR/comments" "")
-            rejects=$(mine "pulls/$PR/reviews" "| select(.state == \"CHANGES_REQUESTED\")")
-            total=$((inline + reviews + issues))
-            echo "attempt $attempt — inline:$inline reviews:$reviews issues:$issues changes-requested:$rejects"
+            sample "attempt $attempt"
             [ "$total" -gt 0 ] && break
             [ "$attempt" -lt 6 ] && sleep 10
           done
+
+          # The four counts come from three endpoints with no read-after-write
+          # coherence between them, and the loop breaks on their SUM — so the
+          # surface that ends the wait is not necessarily the one carrying the
+          # findings. A review posted as N inline comments can present as
+          # reviews=1, inline=0 for a second or so: enough to break, skip both
+          # findings checks, and let the agent's own GO publish a green status
+          # over N validated defects. Re-read once the lag has passed, so the
+          # counts the findings checks act on are never the racing sample.
+          if [ "$total" -gt 0 ]; then
+            sleep 10
+            sample "settled"
+          fi
 
           if [ "$total" -eq 0 ]; then
             decide "NO-GO" "the review posted nothing, so this PR is unreviewed (see #451)"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -404,8 +404,12 @@ jobs:
           if [ "$state" = success ]; then
             body="✅ **Passed review** — $reason. ([run]($RUN))"
           else
-            body="🚫 **$label** — $reason. Merging is blocked until the current head passes review: address the findings, then re-run it by commenting `/review` on this PR. Note that pushing a new commit needs its own review, so the last push always does too. ([run]($RUN))"
+            body="🚫 **$label** — $reason. Merging is blocked until the current head passes review: address the findings, then re-run it by commenting \`/review\` on this PR. Note that pushing a new commit needs its own review, so the last push always does too. ([run]($RUN))"
           fi
+          # Backticks in $body must stay escaped: this is a double-quoted
+          # bash string, so an unescaped `x` runs x as a command. That killed
+          # the step at the assignment under `set -e`, before this line, and
+          # the no-go comment silently stopped being posted.
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$body"
 
           # Fail the job on a no-go, after the status and comment are safely

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -177,7 +177,14 @@ jobs:
       # a comment left by an earlier round cannot be mistaken for this one's.
       - id: review_started
         if: steps.guard.outputs.ok == 'true'
-        run: echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+        run: |
+          # Clear any verdict file before the review can read one. RUNNER_TEMP
+          # is fresh per job on hosted runners, so this is belt-and-braces
+          # there — it matters if this ever runs on a self-hosted runner that
+          # reuses the workspace, where a previous job's verdict would
+          # otherwise be waiting for this one.
+          rm -f "$RUNNER_TEMP/.review-verdict.json"
+          echo "at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - id: review
         if: steps.guard.outputs.ok == 'true'
@@ -365,12 +372,21 @@ jobs:
           fi
 
           # RUNNER_TEMP, never GITHUB_WORKSPACE. The workspace holds the
-          # checked-out PR head, so a verdict file read from there could have
-          # been committed to the branch rather than written by this run —
-          # and this step cannot tell the two apart. A branch carrying
-          # {"verdict":"GO"} would then pass the gate on a silent run, which
-          # is precisely the unreviewed-head merge the gate exists to stop.
-          # RUNNER_TEMP is outside the checkout, so the branch cannot seed it.
+          # checked-out PR head, so a verdict file read from there would be
+          # indistinguishable from one committed to the branch: a branch
+          # carrying {"verdict":"GO"} would pass the gate on a silent run,
+          # which is precisely the unreviewed-head merge this exists to stop.
+          # RUNNER_TEMP is outside the checkout and is cleared before the
+          # review starts, so a committed verdict file is never read.
+          #
+          # It is not a sandbox. The review is authorised to `cargo build` the
+          # branch, which executes its build scripts in this job with
+          # RUNNER_TEMP set and writable, so a branch that deliberately
+          # targets this path can still write it. That is not the weakest
+          # link and not a new privilege — the review step already exports
+          # CLAUDE_BOT_TOKEN to every child process, so such a build script
+          # could post the success status directly and skip the file entirely.
+          # Anyone tightening this should start with the token, not the path.
           f="$RUNNER_TEMP/.review-verdict.json"
           if [ ! -f "$f" ]; then
             decide "NO-GO" "the review recorded no verdict"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -199,8 +199,12 @@ jobs:
           # per subagent (haiku for the skip check, sonnet for CLAUDE.md
           # compliance, opus for the bug hunters and validators) — leave that to it.
           #
-          # The verdict file is the agent's half of the merge gate. The step
-          # after this one cross-checks it against what was actually posted and
+          # The verdict file is the agent's half of the merge gate. It is
+          # written to RUNNER_TEMP rather than the workspace so that the branch
+          # under review cannot pre-commit its own verdict — see the step
+          # below, which reads it from the same place for the same reason.
+          # The step after this one cross-checks it against what was actually
+          # posted and
           # takes the stricter of the two, so a GO written over a wall of
           # findings does not open the gate — but a missing file still closes
           # it, which is why the instruction says so in those terms.
@@ -208,7 +212,7 @@ jobs:
             --model claude-opus-5
             --max-turns 100
             --allowedTools "Bash,Edit,Write,Read,Grep,Glob,LS,WebSearch,WebFetch,Task,TodoWrite"
-            --append-system-prompt "You are reviewing, not authoring: do not edit files, commit, or push. When validating a candidate issue you MAY build and run the test suite (cargo build / cargo test -p turbovec) to confirm or refute it — prefer executed evidence over reasoning about the diff. Never run linters or formatters (clippy, rustfmt, or any lint task): CI runs those separately, and anything a linter would catch must not be reported here. Finally, you MUST write your verdict to \$GITHUB_WORKSPACE/.review-verdict.json as {\"verdict\": \"GO\" or \"NO-GO\", \"summary\": \"one sentence, under 100 characters\"}. NO-GO if you posted any finding you validated as a real defect; GO only if you found nothing worth blocking on. This file is the merge gate: writing no file blocks the merge, so write it even if the review found nothing."
+            --append-system-prompt "You are reviewing, not authoring: do not edit files, commit, or push. When validating a candidate issue you MAY build and run the test suite (cargo build / cargo test -p turbovec) to confirm or refute it — prefer executed evidence over reasoning about the diff. Never run linters or formatters (clippy, rustfmt, or any lint task): CI runs those separately, and anything a linter would catch must not be reported here. Finally, you MUST write your verdict to \$RUNNER_TEMP/.review-verdict.json as {\"verdict\": \"GO\" or \"NO-GO\", \"summary\": \"one sentence, under 100 characters\"}. NO-GO if you posted any finding you validated as a real defect; GO only if you found nothing worth blocking on. This file is the merge gate: writing no file blocks the merge, so write it even if the review found nothing."
 
       # The action reports `is_error: true` without ever surfacing the reason —
       # every claude.yml failure so far has been an opaque 1-turn rejection.
@@ -319,7 +323,14 @@ jobs:
             decide "NO-GO" "the reviewer requested changes"
           fi
 
-          f="$GITHUB_WORKSPACE/.review-verdict.json"
+          # RUNNER_TEMP, never GITHUB_WORKSPACE. The workspace holds the
+          # checked-out PR head, so a verdict file read from there could have
+          # been committed to the branch rather than written by this run —
+          # and this step cannot tell the two apart. A branch carrying
+          # {"verdict":"GO"} would then pass the gate on a silent run, which
+          # is precisely the unreviewed-head merge the gate exists to stop.
+          # RUNNER_TEMP is outside the checkout, so the branch cannot seed it.
+          f="$RUNNER_TEMP/.review-verdict.json"
           if [ ! -f "$f" ]; then
             decide "NO-GO" "the review recorded no verdict"
           fi
@@ -379,6 +390,6 @@ jobs:
           if [ "$state" = success ]; then
             body="✅ **Agent code review: GO** — $reason. ([run]($RUN))"
           else
-            body="🚫 **Agent code review: NO-GO** — $reason. Merging is blocked until a review of the current head returns GO: address the findings, then re-run the review by commenting the review command on this PR. Note that pushing a new commit clears the verdict, so the last push always needs its own review. ([run]($RUN))"
+            body="🚫 **Agent code review: NO-GO** — $reason. Merging is blocked until a review of the current head returns GO: address the findings, then re-run it by commenting `/review` on this PR. Note that pushing a new commit clears the verdict, so the last push always needs its own review. ([run]($RUN))"
           fi
           gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$body"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -70,9 +70,13 @@ jobs:
     # claude.yml does it: logins can be renamed or reclaimed). Its comments
     # are PAT-authored, so they DO fire `issue_comment`. The verdict comment
     # this job posts is written with GITHUB_TOKEN precisely so it cannot fire
-    # `issue_comment` at all, and its body avoids the literal trigger token as
-    # a second line of defence — a reworded body must not be able to start a
-    # review whose own verdict comment starts another.
+    # `issue_comment` at all: GitHub does not create workflow runs from
+    # GITHUB_TOKEN events. That is the whole of the protection for that
+    # comment — its body does spell `/review` literally, and the trigger is a
+    # substring match, so switching that step to CLAUDE_BOT_TOKEN would make
+    # it self-triggering. Note also that the actor-id guard above is not a
+    # backstop there: it pins the PAT account, while that comment is authored
+    # by github-actions[bot]. Keep the token as it is.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
@@ -427,8 +431,11 @@ jobs:
             -f description="$label — $reason" --silent
 
           # Say it on the PR as well. The status alone is a one-line row in a
-          # collapsed check list; a no-go needs to say what to do next, and the
-          # instruction deliberately never spells the trigger token literally.
+          # collapsed check list, and a failure needs to say what to do next —
+          # so this spells `/review` literally rather than describing it. That
+          # is safe only because this step posts as GITHUB_TOKEN, whose events
+          # never start workflow runs; posting it as the PAT would turn every
+          # failed review into a trigger for the next one.
           if [ "$state" = success ]; then
             body="✅ **Passed review** — $reason. ([run]($RUN))"
           else

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -316,13 +316,24 @@ jobs:
               | jq -s "[.[][] | select((.created_at // .submitted_at) > \"$SINCE\"
                                        and .user.login == \"$bot\") $2] | length"
           }
-          inline=$(mine "pulls/$PR/comments" "")
-          reviews=$(mine "pulls/$PR/reviews" "")
-          issues=$(mine "issues/$PR/comments" "")
-          rejects=$(mine "pulls/$PR/reviews" "| select(.state == \"CHANGES_REQUESTED\")")
-          echo "posted since $SINCE — inline:$inline reviews:$reviews issues:$issues changes-requested:$rejects"
+          # Poll, do not sample once. The action's step can return before the
+          # comment it just posted is readable back — observed at 3 seconds,
+          # which was long enough to make a clean review look silent and fail
+          # the gate on a PR that had in fact been reviewed. Silence is the
+          # one verdict that must never be reached by racing the API, so it
+          # is only declared after the lag has had time to settle.
+          for attempt in 1 2 3 4 5 6; do
+            inline=$(mine "pulls/$PR/comments" "")
+            reviews=$(mine "pulls/$PR/reviews" "")
+            issues=$(mine "issues/$PR/comments" "")
+            rejects=$(mine "pulls/$PR/reviews" "| select(.state == \"CHANGES_REQUESTED\")")
+            total=$((inline + reviews + issues))
+            echo "attempt $attempt — inline:$inline reviews:$reviews issues:$issues changes-requested:$rejects"
+            [ "$total" -gt 0 ] && break
+            [ "$attempt" -lt 6 ] && sleep 10
+          done
 
-          if [ $((inline + reviews + issues)) -eq 0 ]; then
+          if [ "$total" -eq 0 ]; then
             decide "NO-GO" "the review posted nothing, so this PR is unreviewed (see #451)"
           fi
           if [ "$inline" -gt 0 ]; then

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,14 +5,23 @@ name: PR Review
 # subagent per candidate issue. Only validated issues get posted as inline
 # comments — unvalidated findings are dropped rather than posted.
 #
-# Advisory, never blocking: this workflow is deliberately NOT in branch
-# protection. The hard gate stays at ci.yml, so a failed or noisy review can
-# never stop a merge.
+# BLOCKING. Every run ends by posting an `Agent code review` commit status on
+# the PR head SHA carrying a go/no-go verdict, and that context is required by
+# branch protection: no-go means the merge button stays disabled. This reverses
+# the workflow's original advisory stance — ci.yml is no longer the only hard
+# gate.
 #
-# Fires automatically when a PR opens or leaves draft, and on demand when a
-# collaborator comments `/review`. Deliberately NOT on `synchronize`: reviewing
-# every push multiplies subscription load, and load correlates with the
-# instant-rejection failures seen in claude.yml.
+# The gate fails closed. A run that errors, posts nothing, or records no
+# verdict is a no-go, because none of those are the same as a clean review
+# (#451: four silent-but-green runs in one day, one of which let a PR merge
+# with its head unreviewed).
+#
+# Statuses are per-commit, so a new push lands on a SHA with no `Agent code
+# review` status and the merge is blocked until the review is re-run on it.
+# That is deliberate, and it is why this still does NOT fire on `synchronize`:
+# auto-reviewing every push multiplies subscription load, and load correlates
+# with the instant-rejection failures seen in claude.yml. The cost of that
+# choice is one manual re-trigger per push — comment `/review` to clear it.
 #
 # `/review` is distinct from claude.yml's `@q-turbovec-bot` so the two
 # workflows never double-fire on the same comment.
@@ -30,7 +39,9 @@ on:
 
 permissions: {}
 
-# One review per PR at a time; a queued run waits rather than racing.
+# One review per PR at a time; a queued run waits rather than racing. Load
+# bearing for the gate too: concurrent runs on one PR would post competing
+# `Agent code review` statuses to the same SHA, last writer winning arbitrarily.
 concurrency:
   group: pr-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
   cancel-in-progress: false
@@ -49,16 +60,11 @@ jobs:
     # The reviewer account is excluded from the mention path by actor id
     # (turbovec-bot = 309383466, pinned numerically for the same reason
     # claude.yml does it: logins can be renamed or reclaimed). Its comments
-    # are PAT-authored, so they DO fire `issue_comment` — and this job posts
-    # a comment of its own when a run produces no output. Without the
-    # exclusion, any wording of that warning containing the trigger token
-    # would start another review run, whose own silence would post warning
-    # #2, and so on unbounded: `SINCE` is re-sampled per run so the previous
-    # warning always predates the window and is never counted, and
-    # `cancel-in-progress: false` serializes the chain rather than breaking
-    # it. The warning body below also avoids the literal token, so the loop
-    # is closed twice over — the body could be reworded by someone who does
-    # not know it is load-bearing, and the actor guard survives that.
+    # are PAT-authored, so they DO fire `issue_comment`. The verdict comment
+    # this job posts is written with GITHUB_TOKEN precisely so it cannot fire
+    # `issue_comment` at all, and its body avoids the literal trigger token as
+    # a second line of defence — a reworded body must not be able to start a
+    # review whose own verdict comment starts another.
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
@@ -81,27 +87,48 @@ jobs:
       pull-requests: write
       issues: write
       actions: read # let the reviewer read CI results on the PR
+      statuses: write # post the `Agent code review` verdict on the head SHA
 
     steps:
-      # Resolve the PR number across all three trigger types, and refuse fork
-      # head branches on the mention and dispatch paths. Runs before any step
-      # that touches a secret, so a fork PR never reaches the agent.
+      # Resolve the PR number and head SHA across all three trigger types, and
+      # detect fork head branches. Runs before any step that touches a secret,
+      # so a fork PR never reaches the agent.
+      #
+      # The SHA is resolved once, here, and every later step posts against it.
+      # Re-resolving at the end would risk stamping a verdict onto a commit
+      # that was pushed while the review was running — i.e. approving code
+      # that was never read.
       - id: guard
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_BOT_TOKEN }}
           PR: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
         run: |
           set -euo pipefail
-          head=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" \
-                   --json headRepository,headRepositoryOwner \
-                   --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name)"')
+          read -r head sha < <(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" \
+                   --json headRepository,headRepositoryOwner,headRefOid \
+                   --jq '"\(.headRepositoryOwner.login)/\(.headRepository.name) \(.headRefOid)"')
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
           if [ "$head" != "$GITHUB_REPOSITORY" ]; then
             echo "PR #$PR head is $head (a fork) — skipping review." >&2
             echo "ok=false" >> "$GITHUB_OUTPUT"
           else
             echo "ok=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # Show the gate as running rather than missing. Without this the PR sits
+      # on "Expected — waiting for status" for the length of the review, which
+      # is indistinguishable from a workflow that never started.
+      - name: Mark gate pending
+        if: steps.guard.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ steps.guard.outputs.sha }}
+          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state=pending -f context="Agent code review" -f target_url="$RUN" \
+            -f description="Review in progress" --silent
 
       # persist-credentials: false — the agent reads PR content it did not
       # author, so no git credential is left in .git/config for it to reuse.
@@ -116,7 +143,11 @@ jobs:
           # keeps `pull_request` on the head rather than checkout's default merge
           # ref, so all three paths review the same tree — the code the author
           # actually wrote, matching the diff the plugin fetches via `gh pr diff`.
-          ref: refs/pull/${{ steps.guard.outputs.pr }}/head
+          #
+          # Pinned to the SHA the guard resolved, not the branch name: the gate
+          # verdict is stamped on that SHA, so the tree reviewed and the tree
+          # judged have to be the same one even if the branch moves mid-run.
+          ref: ${{ steps.guard.outputs.sha }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -167,11 +198,17 @@ jobs:
           # `--model` sets the orchestrator only; the plugin picks its own model
           # per subagent (haiku for the skip check, sonnet for CLAUDE.md
           # compliance, opus for the bug hunters and validators) — leave that to it.
+          #
+          # The verdict file is the agent's half of the merge gate. The step
+          # after this one cross-checks it against what was actually posted and
+          # takes the stricter of the two, so a GO written over a wall of
+          # findings does not open the gate — but a missing file still closes
+          # it, which is why the instruction says so in those terms.
           claude_args: |
             --model claude-opus-5
             --max-turns 100
             --allowedTools "Bash,Edit,Write,Read,Grep,Glob,LS,WebSearch,WebFetch,Task,TodoWrite"
-            --append-system-prompt "You are reviewing, not authoring: do not edit files, commit, or push. When validating a candidate issue you MAY build and run the test suite (cargo build / cargo test -p turbovec) to confirm or refute it — prefer executed evidence over reasoning about the diff. Never run linters or formatters (clippy, rustfmt, or any lint task): CI runs those separately, and anything a linter would catch must not be reported here."
+            --append-system-prompt "You are reviewing, not authoring: do not edit files, commit, or push. When validating a candidate issue you MAY build and run the test suite (cargo build / cargo test -p turbovec) to confirm or refute it — prefer executed evidence over reasoning about the diff. Never run linters or formatters (clippy, rustfmt, or any lint task): CI runs those separately, and anything a linter would catch must not be reported here. Finally, you MUST write your verdict to \$GITHUB_WORKSPACE/.review-verdict.json as {\"verdict\": \"GO\" or \"NO-GO\", \"summary\": \"one sentence, under 100 characters\"}. NO-GO if you posted any finding you validated as a real defect; GO only if you found nothing worth blocking on. This file is the merge gate: writing no file blocks the merge, so write it even if the review found nothing."
 
       # The action reports `is_error: true` without ever surfacing the reason —
       # every claude.yml failure so far has been an opaque 1-turn rejection.
@@ -195,30 +232,47 @@ jobs:
             echo "no execution output at $f"
           fi
 
-      # A run can finish green having posted nothing at all — no issue
-      # comment, no review, no inline comments (#451). On the pull request
-      # that is indistinguishable from "reviewed, found nothing", and since
-      # a clear review is the merge gate, it reads as approval. Four such
-      # runs happened in one day; one PR merged with its head unreviewed
-      # because a re-request produced another silent run.
+      # Decide go/no-go. Four independent ways to reach no-go, checked before
+      # the agent's own verdict is even read, because each one describes a run
+      # whose silence would otherwise read as approval:
       #
-      # Counting all three surfaces is deliberate: the review arrives on a
-      # different one from round to round — a formal review with inline
-      # comments in one round, a plain issue comment in the next — so
-      # checking a single surface would raise false alarms.
-      # `guard.outputs.ok` is required, not just `pr`: a fork PR is skipped
-      # deliberately, and warning that it went unreviewed would be noise
-      # about a decision the workflow made on purpose.
-      - name: Warn if the review posted nothing
-        if: success() && steps.guard.outputs.ok == 'true'
+      #   1. the run did not complete — nothing was reviewed;
+      #   2. it posted nothing at all (#451) — on the PR that is
+      #      indistinguishable from "reviewed, found nothing";
+      #   3. it posted inline findings — the plugin only posts issues its
+      #      validation subagent confirmed, so any inline comment is a
+      #      confirmed defect and blocks;
+      #   4. it submitted a CHANGES_REQUESTED review — same signal, different
+      #      surface. The review lands on a different surface from round to
+      #      round, so both are counted.
+      #
+      # Only then is .review-verdict.json consulted, and only to turn a
+      # findings-free run into a GO. The agent can therefore veto its own
+      # clean review but cannot overrule its own findings.
+      - id: verdict
+        if: always() && steps.guard.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_BOT_TOKEN }}
           PR: ${{ steps.guard.outputs.pr }}
-          RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SINCE: ${{ steps.review_started.outputs.at }}
+          OUTCOME: ${{ steps.review.outcome }}
         run: |
           set -euo pipefail
           repo="$GITHUB_REPOSITORY"
+          # Commit-status descriptions are capped at 140 characters and a
+          # newline would corrupt $GITHUB_OUTPUT, so every reason is flattened
+          # and clipped here rather than at each call site.
+          decide() {
+            echo "verdict=$1" >> "$GITHUB_OUTPUT"
+            echo "reason=$(printf '%s' "$2" | tr '\n' ' ' | cut -c1-120)" >> "$GITHUB_OUTPUT"
+            echo "verdict: $1 — $2"
+            exit 0
+          }
+
+          if [ "$OUTCOME" != "success" ]; then
+            decide "NO-GO" "the review run did not complete, so this PR is unreviewed"
+          fi
+
           # Only the reviewer's own output counts. Counting every comment
           # would let an unrelated human remark posted during the run mask a
           # silent one — which is exactly what happened while testing this.
@@ -231,9 +285,9 @@ jobs:
           # first 30 items and none of the newest. On any PR that has
           # crossed 30 items on the surface the review lands on, the
           # window items are on a later page, the count comes back 0, and
-          # the check posts "unreviewed" about a review that did post.
-          # Exactly inverted, and it gets more likely the more a PR is
-          # iterated on — i.e. on the PRs that are reviewed most.
+          # the gate calls a posted review silent. Exactly inverted, and it
+          # gets more likely the more a PR is iterated on — i.e. on the PRs
+          # that are reviewed most.
           #
           # `--paginate` walks every page and emits one JSON array per
           # page, so `jq -s` collects them into an array of arrays —
@@ -244,29 +298,87 @@ jobs:
           # surfaces carry `created_at`, and an unsubmitted (pending)
           # review has a null `submitted_at`, which fails the comparison
           # — correctly, since it is not visible on the PR either.
-          count_since() {
-            gh api --paginate -X GET "$1" -f per_page=100 \
+          mine() {
+            gh api --paginate -X GET "repos/$repo/$1" -f per_page=100 \
               | jq -s "[.[][] | select((.created_at // .submitted_at) > \"$SINCE\"
-                                       and .user.login == \"$bot\")] | length"
+                                       and .user.login == \"$bot\") $2] | length"
           }
-          n=0
-          n=$(( n + $(count_since "repos/$repo/issues/$PR/comments") ))
-          n=$(( n + $(count_since "repos/$repo/pulls/$PR/reviews") ))
-          n=$(( n + $(count_since "repos/$repo/pulls/$PR/comments") ))
-          echo "items posted by $bot since $SINCE: $n"
-          if [ "$n" -eq 0 ]; then
-            gh pr comment "$PR" --repo "$repo" --body \
-              "⚠️ **Automated review produced no output** — the run finished successfully but posted no comment, review, or inline finding, so this pull request is **unreviewed**. This is not the same as a clean review. Re-request with the review command, and see #451. [View run]($RUN)"
+          inline=$(mine "pulls/$PR/comments" "")
+          reviews=$(mine "pulls/$PR/reviews" "")
+          issues=$(mine "issues/$PR/comments" "")
+          rejects=$(mine "pulls/$PR/reviews" "| select(.state == \"CHANGES_REQUESTED\")")
+          echo "posted since $SINCE — inline:$inline reviews:$reviews issues:$issues changes-requested:$rejects"
+
+          if [ $((inline + reviews + issues)) -eq 0 ]; then
+            decide "NO-GO" "the review posted nothing, so this PR is unreviewed (see #451)"
+          fi
+          if [ "$inline" -gt 0 ]; then
+            decide "NO-GO" "$inline validated finding(s) posted inline"
+          fi
+          if [ "$rejects" -gt 0 ]; then
+            decide "NO-GO" "the reviewer requested changes"
           fi
 
-      # A reaction is too easy to miss. Say plainly on the PR that the review
-      # did not land, so a silent failure never reads as a clean review.
-      - name: Comment on failure
-        if: failure() && steps.guard.outputs.pr != ''
+          f="$GITHUB_WORKSPACE/.review-verdict.json"
+          if [ ! -f "$f" ]; then
+            decide "NO-GO" "the review recorded no verdict"
+          fi
+          v=$(jq -r '.verdict // ""' "$f")
+          s=$(jq -r '.summary // ""' "$f")
+          if [ "$v" = "GO" ]; then
+            decide "GO" "${s:-no blocking findings}"
+          fi
+          decide "NO-GO" "${s:-reviewer returned \"$v\"}"
+
+      # Publish the verdict. Written with GITHUB_TOKEN, not the bot PAT, for
+      # two reasons: a GITHUB_TOKEN comment cannot fire `issue_comment`, so a
+      # no-go comment can never trigger the review that would comment again;
+      # and the status then shows as GitHub Actions rather than as a human
+      # collaborator's judgement.
+      #
+      # `always()`, and with no guard on the verdict step succeeding: if that
+      # step crashed there is no verdict, and a PR with no `Agent code review` status
+      # is blocked by branch protection anyway. This step exists to make the
+      # blocking legible, not to create it.
+      - name: Publish gate verdict
+        if: always() && steps.guard.outputs.sha != ''
         env:
-          GH_TOKEN: ${{ secrets.CLAUDE_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.guard.outputs.pr }}
+          SHA: ${{ steps.guard.outputs.sha }}
+          FORK: ${{ steps.guard.outputs.ok }}
+          VERDICT: ${{ steps.verdict.outputs.verdict }}
+          REASON: ${{ steps.verdict.outputs.reason }}
           RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body \
-            "⚠️ **Automated review did not complete** — no findings were posted, so treat this PR as unreviewed. [View run]($RUN)"
+          set -euo pipefail
+          # A fork head is skipped on purpose, but "skipped" cannot mean
+          # "merge freely" — it means a maintainer has to review it by hand
+          # and use their branch-protection bypass.
+          if [ "$FORK" != "true" ]; then
+            state=failure
+            verdict="NO-GO"
+            reason="fork PR — a maintainer must review this by hand"
+          elif [ "$VERDICT" = "GO" ]; then
+            state=success
+            verdict="GO"
+            reason="${REASON:-no blocking findings}"
+          else
+            state=failure
+            verdict="NO-GO"
+            reason="${REASON:-the review did not reach a verdict}"
+          fi
+
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$SHA" \
+            -f state="$state" -f context="Agent code review" -f target_url="$RUN" \
+            -f description="$verdict: $reason" --silent
+
+          # Say it on the PR as well. The status alone is a one-line row in a
+          # collapsed check list; a no-go needs to say what to do next, and the
+          # instruction deliberately never spells the trigger token literally.
+          if [ "$state" = success ]; then
+            body="✅ **Agent code review: GO** — $reason. ([run]($RUN))"
+          else
+            body="🚫 **Agent code review: NO-GO** — $reason. Merging is blocked until a review of the current head returns GO: address the findings, then re-run the review by commenting the review command on this PR. Note that pushing a new commit clears the verdict, so the last push always needs its own review. ([run]($RUN))"
+          fi
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body "$body"


### PR DESCRIPTION
Makes `pr-review.yml` blocking, per request: every run now produces a final go/no-go and a no-go blocks the merge.

## How the verdict reaches branch protection

The job posts a **`Agent code review` commit status on the PR head SHA**. A commit status is used rather than the job's own check run because `/review` runs are triggered by `issue_comment`, whose check runs attach to the default branch rather than to the PR head — a re-review would never have updated the required check.

## What makes it a no-go

Fail-closed, checked in order, before the agent's own verdict is read:

1. the review run did not complete;
2. it posted nothing at all — green-but-silent (#451) is indistinguishable from "reviewed, found nothing" on the PR, and that is how one PR merged with its head unreviewed;
3. any finding posted inline — the plugin only posts issues its validation subagent confirmed, so an inline comment *is* a confirmed defect;
4. a `CHANGES_REQUESTED` review — same signal, different surface.

Only a run that posted something and found nothing consults `.review-verdict.json`, which the agent writes. So the agent can veto its own clean review, but cannot GO its way past its own findings, and a missing file blocks.

Fork heads are still skipped, but skipping now posts a *failing* status instead of nothing — a maintainer reviews by hand and uses their bypass.

## Re-review on push

Statuses are per-commit, so a new push lands on a SHA with no verdict and merging is blocked until the review is re-run on it. `synchronize` is still deliberately not a trigger: auto-reviewing every push multiplies subscription load, and load correlates with the instant-rejection failures seen in `claude.yml`. The cost is one `/review` comment per push.

## Verification

- Verdict logic exercised against synthetic API payloads across 10 cases (run-failed, silent run, stale-items-only, inline findings, changes-requested, missing verdict file, malformed verdict file, clean+GO, agent veto, issue-comment-only) — each returns the intended verdict.
- Every `run:` body passes `bash -n`; the guard step's `gh pr view` jq template and `read` parsing were run against a real PR.
- This PR exercises the new workflow on itself.

## Not done here — needs your call

The `Agent code review` context is **not yet in branch protection**, so nothing is blocked yet. Adding it to ruleset `16741117` ("main - PR required, admin can self-merge") is a one-call change I can make once this merges. Doing it before then would block every PR on a status no workflow posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)