### PR TITLE
chore(ci): rename the agent trigger phrase to @tq-bot

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -15,22 +15,22 @@ permissions: {}
 jobs:
   claude:
     # Only the repo owner and the turbovec-bot machine account may invoke
-    # @q-turbovec-bot — the OAuth token spends subscription usage, and this
-    # workflow runs project code (cargo build/test) on trigger, so this guard
-    # is load-bearing for security. Pinned to immutable numeric actor IDs
+    # @tq-bot — the OAuth token spends subscription usage, and this workflow
+    # runs project code (cargo build/test) on trigger, so this guard is
+    # load-bearing for security. Pinned to immutable numeric actor IDs
     # (RyanCodrai = 10856497, turbovec-bot = 309383466) rather than logins,
     # which can be renamed/reclaimed. turbovec-bot is allowed so a Claude run
-    # can @q-turbovec-bot-mention follow-up work (e.g. request a review of its
-    # own PR) and spawn a fresh agent; its PAT-authored comments do fire this
-    # workflow, so keep the agent instructed to mention @q-turbovec-bot at
-    # most once per run to bound chained invocations.
+    # can @tq-bot-mention follow-up work (e.g. request a review of its own PR)
+    # and spawn a fresh agent; its PAT-authored comments do fire this workflow,
+    # so keep the agent instructed to mention @tq-bot at most once per run to
+    # bound chained invocations.
     if: |
       contains(fromJSON('["10856497", "309383466"]'), github.actor_id) &&
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@q-turbovec-bot')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@q-turbovec-bot')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@q-turbovec-bot')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@q-turbovec-bot') || contains(github.event.issue.title, '@q-turbovec-bot')))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@tq-bot')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@tq-bot')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@tq-bot')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@tq-bot') || contains(github.event.issue.title, '@tq-bot')))
       )
     runs-on: ubuntu-latest
     # Write scopes so Claude can push branches, open PRs, and comment —
@@ -90,7 +90,7 @@ jobs:
           github_token: ${{ secrets.CLAUDE_BOT_TOKEN }}
           # The action's own mention-detection defaults to "@claude"; keep it
           # in sync with the actor-guard trigger above.
-          trigger_phrase: "@q-turbovec-bot"
+          trigger_phrase: "@tq-bot"
           # Full local-parity toolset: arbitrary shell (build/test/gh/etc.),
           # file edits, and web access. Safe because this workflow is
           # owner-only (see the actor guard above) — do NOT widen the guard


### PR DESCRIPTION
Renames the agent's mention trigger from `@q-turbovec-bot` to `@tq-bot`.

`.github/workflows/claude.yml` is the only file that referenced the old
phrase — 8 occurrences: the `trigger_phrase` input, the four actor-guard
`contains()` conditions, and three comments. The surrounding comment
paragraph is re-wrapped to fit the shorter name; no other lines change.

Nothing about who may invoke the agent changes. The guard still pins the
immutable actor IDs, and the bot still posts under the identity behind
`CLAUDE_BOT_TOKEN`. Only the string you type to summon it is different.

`@tq-bot` is now the machine account's own login (user id 309383466 — the
same id already pinned in the actor allowlist), so the trigger phrase and
the bot's identity finally agree, and mentioning it links to a real
profile rather than to nothing.

One consequence worth noting: `@tq-bot` is short enough to appear
incidentally in a comment body and fire the workflow. The actor guard
keeps that owner-only, so the cost is a wasted run rather than an
escalation.

Follow-up, not included here: several comments in `claude.yml` and
`summarize-command.yml` still describe the account by its old
`turbovec-bot` login. Worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
