### PR TITLE
Retain blocked cache after cold writes (relands #323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,6 +421,7 @@ appears under each surface it touches.
   win; ARM keeps the streamed writer, where the same technique regresses).
   Temp files now carry a per-process sequence number so concurrent saves to
   one path cannot interleave.
+- **Faster saves.** New indexes retain blocked cache (#323), thanks @faysou
 - **File format v6 for `.tv` / `.tvim`: the file *is* the search-ready
   index — loads skip the first-search rebuild entirely (#68).** The code
   payload is now stored in the arch-neutral *sequential blocked* layout

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1646,10 +1646,10 @@ impl TurboQuantIndex {
     }
 
     /// The v6 file payload: codes in the arch-neutral sequential blocked
-    /// layout. Cheap when the SIMD-blocked cache is warm (a per-block
-    /// nibble de-interleave on x86, a copy elsewhere); otherwise the full
-    /// O(n·dim) bit-plane repack — the same cost the pre-v6 format paid
-    /// on every load instead of once per write.
+    /// layout. The first cold write retains the native blocked cache so
+    /// later mutations can repair only their affected blocks. Producing
+    /// sequential bytes is a per-block nibble de-interleave on x86 and a
+    /// copy elsewhere.
     pub fn codes_blocked_seq(&self) -> Vec<u8> {
         let Some(dim) = self.dim else {
             return Vec::new();
@@ -1657,10 +1657,11 @@ impl TurboQuantIndex {
         if self.n_vectors == 0 {
             return Vec::new();
         }
-        if let Some(cache) = self.blocked.get() {
-            return pack::native_to_seq(&cache.data);
-        }
-        pack::repack_seq(self.packed(), self.n_vectors, self.bit_width, dim)
+        let cache = self.blocked.get_or_init(|| {
+            let (data, n_blocks) = pack::repack(self.packed(), self.n_vectors, self.bit_width, dim);
+            BlockedCache { data, n_blocks }
+        });
+        pack::native_to_seq(&cache.data)
     }
 
     /// The codebook arrays the v6 file embeds — `(boundaries,
@@ -2595,6 +2596,39 @@ mod scratch_retention_tests {
             0,
             "a buffer no recent add needed was not released",
         );
+    }
+}
+
+#[cfg(test)]
+mod blocked_cache_tests {
+    use super::{pack, TurboQuantIndex};
+
+    fn vectors(n: usize, dim: usize) -> Vec<f32> {
+        let mut state = 1u64;
+        (0..n * dim)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                ((state >> 32) as u32 as f64 / 2_147_483_648.0 - 1.0) as f32
+            })
+            .collect()
+    }
+
+    #[test]
+    fn cold_write_seeds_blocked_cache() {
+        let mut idx = TurboQuantIndex::new(64, 4).unwrap();
+        idx.add(&vectors(65, 64));
+        assert!(idx.blocked.get().is_none());
+
+        let first = idx.to_bytes();
+        let cache = idx.blocked.get().expect("write must retain blocked cache");
+        let dim = idx.dim.expect("constructor sets dim");
+        let (expected, n_blocks) =
+            pack::repack(idx.packed(), idx.n_vectors, idx.bit_width, dim);
+        assert_eq!(cache.data, expected);
+        assert_eq!(cache.n_blocks, n_blocks);
+        assert_eq!(idx.to_bytes(), first);
     }
 }
 

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -294,6 +294,7 @@ fn extract_codes_flat(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: u
 /// arch-neutral form the v6 file format persists: vectors in order inside
 /// each 32-vector block, one code byte per lane. On non-x86 this is also
 /// the layout the search kernel consumes.
+#[cfg_attr(target_arch = "x86_64", allow(dead_code))]
 fn pack_blocked_sequential(
     n: usize,
     n_blocks: usize,
@@ -320,6 +321,7 @@ fn pack_blocked_sequential(
 /// Packed bit-plane rows → sequential blocked layout (the v6 file
 /// payload). Arch-independent and deterministic: identical bytes on every
 /// platform for the same packed codes.
+#[cfg(test)]
 pub(crate) fn repack_seq(packed_codes: &[u8], n_vectors: usize, bits: usize, dim: usize) -> Vec<u8> {
     let (n_blocks, n_byte_groups, blocked_size) = blocked_geometry(n_vectors, bits, dim);
     let codes_flat = extract_codes_flat(packed_codes, n_vectors, bits, dim);


### PR DESCRIPTION
Relands #323 by @faysou, which was merged by mistake before review and
reverted 21 seconds later in #470.

The change is untouched. This branch restores the exact tree from
`ec2c4cd`, verified byte-identical (`git diff ec2c4cd <head>` is empty),
so the diff here is precisely what #323 contained: `turbovec/src/lib.rs`,
`turbovec/src/pack.rs`, and a CHANGELOG entry, +45/-8. Authorship is
preserved on the commit.

The point of this PR is that #323 never actually got the review or the
green CI it was entitled to — its checks were cancelled mid-flight by the
merge (14 cancelled, 2 passed), and it went in with `REVIEW_REQUIRED`
outstanding. Nothing about it was known to be wrong; it simply skipped
the gate. This runs it through properly.

#323 itself cannot be reopened — GitHub locks a merged pull request — so
this is a fresh one in its place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
