### PR TITLE
perf(sync): incremental sync latency hill-climb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,10 +219,17 @@ appears under each surface it touches.
   only the used prefix is read now and the rest only when a header actually
   carries that many ops.
 
+  On x86 a removal also no longer re-derives the row it moved. Filling a
+  hole already computes the incoming row's stored bytes and was discarding
+  them, leaving the next sync to read them back out of the 32-row block
+  they are interleaved into; they are now kept. This is x86-only by
+  measurement, not caution — off x86 the move is a plain byte copy, so
+  keeping the bytes costs more in `remove` than it saves in `sync`.
+
   Measured on 200k rows at dim 768, 4-bit — the sync committing 1000
-  scattered removals went from 18.6 ms to 4.7 ms on x86 and 9.8 ms to
+  scattered removals went from 18.6 ms to 3.4 ms on x86 and 9.8 ms to
   3.5 ms on ARM; the sync committing a 32-row append went from 1.8 ms to
-  1.6 ms on x86. Nothing about the format, the durability contract or the
+  1.7 ms on x86. Nothing about the format, the durability contract or the
   crash behaviour changes: still one write batch and one `sync_all` per
   sync, and a sync torn at any byte still recovers the previous commit.
 
@@ -1338,8 +1345,8 @@ appears under each surface it touches.
 - **`sync(path)` is substantially faster, most of all after removals
   (#481)** — see the Rust entry above for the mechanism. On 200k rows at
   dim 768, 4-bit, the sync committing 1000 scattered `remove` calls went
-  from 18.6 ms to 4.7 ms on x86 and 9.8 ms to 3.5 ms on ARM; the sync
-  committing a 32-row `add_with_ids` went from 1.8 ms to 1.6 ms on x86.
+  from 18.6 ms to 3.4 ms on x86 and 9.8 ms to 3.5 ms on ARM; the sync
+  committing a 32-row `add_with_ids` went from 1.8 ms to 1.7 ms on x86.
   Durability is unchanged: `sync` still returns only once the commit is on
   stable storage.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,25 @@ appears under each surface it touches.
 
 #### Changed
 
+- **`sync` is substantially faster, most of all after removals (#481).**
+  Every sync opened by re-reading every block unit the previous commit had
+  written and recomputing its checksum, to decide whether the file was
+  still the one this index last wrote. That commit was already proven —
+  either by the `sync_all` that returned success for it, or by the `load`
+  that adopted it — so a commit at the cursor's own generation is now
+  accepted without the re-read. The same identity check also read both
+  commit headers in full; a header slot is sized for its maximum pending-op
+  capacity (hundreds of kilobytes), while the steady state uses a few, so
+  only the used prefix is read now and the rest only when a header actually
+  carries that many ops.
+
+  Measured on 200k rows at dim 768, 4-bit — the sync committing 1000
+  scattered removals went from 18.6 ms to 4.7 ms on x86 and 9.8 ms to
+  3.5 ms on ARM; the sync committing a 32-row append went from 1.8 ms to
+  1.6 ms on x86. Nothing about the format, the durability contract or the
+  crash behaviour changes: still one write batch and one `sync_all` per
+  sync, and a sync torn at any byte still recovers the previous commit.
+
 - **`statrs` is now an exact version requirement, `=0.17.1` (#346).** It was
   the caret range `"0.17"`, so any 0.17.x patch release was picked up
   automatically by a downstream build with no lockfile. `statrs` is not an
@@ -1315,6 +1334,14 @@ appears under each surface it touches.
   previously raised `TypeError`.
 
 #### Changed
+
+- **`sync(path)` is substantially faster, most of all after removals
+  (#481)** — see the Rust entry above for the mechanism. On 200k rows at
+  dim 768, 4-bit, the sync committing 1000 scattered `remove` calls went
+  from 18.6 ms to 4.7 ms on x86 and 9.8 ms to 3.5 ms on ARM; the sync
+  committing a 32-row `add_with_ids` went from 1.8 ms to 1.6 ms on x86.
+  Durability is unchanged: `sync` still returns only once the commit is on
+  stable storage.
 
 - **`calibrate(sample)` on `TurboQuantIndex` and `IdMapIndex`, and the
   automatic TQ+ fit is removed** — see the Rust entry above for the full

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -406,6 +406,51 @@ two loop bodies instead of one with a branch per byte.
   target on the untouched path. Same shape as the six-op climb's H14,
   which arch-gated its sharded map build for the same reason.
 
+### H8 — gate the capture to x86 (target: sync_remove)
+
+H7 unchanged, with `capture_this` additionally requiring
+`cfg!(target_arch = "x86_64")`. Off x86 nothing is captured, the lookup
+returns empty, and the removal path is the old one.
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_remove` | 4.740 → 3.470 (**x1.366, 8/8**) | 3.525 → 3.575 (x0.986, 2/8) |
+| `remove_calls` | 3.395 → 3.415 (x0.994, gate OK) | 1.680 → 1.700 (x0.988, gate OK) |
+| `sync_append` | 1.670 → 1.655 (x1.009) | 1.570 → 1.590 (x0.987) |
+| **`sync_settle`** | 33.715 → 34.995 (**x0.963, better 1/8**) | 18.38 → 18.23 (x1.009) |
+
+The x86 target is unambiguous and `remove_calls` is finally clean on both
+arches. ARM is parity on every cell, as designed — nothing is captured
+there.
+
+**But the settle gate is not clean, and the arithmetic is uncomfortable:**
+
+```
+base:  remove 4.740 + settle 33.715 = 38.455 ms
+new:   remove 3.470 + settle 34.995 = 38.465 ms
+```
+
+The removal sync's saving and the settle's loss cancel to 0.01 ms. There is
+a mechanism that would explain exactly that: the gather this hypothesis
+removes was *reading* the ~995 units (about 12 MB) that the settle sync
+then overwrites, so it was warming the page cache for writes that are not
+block-aligned (a unit is 12,672 B) and therefore need a read-modify-write
+at each end. Take the read away and settle pays for it. That is the same
+coupling suspected in H1's ARM settle wobble, here with a suspiciously
+exact ledger.
+
+Against that reading: the same cell measured x1.003 (H6) and x0.995 (H7) on
+the same mechanism, its A/A spread is ±4.0%, and a 3.7% move sits inside
+that. Three runs cannot all be right.
+
+- **Verdict: PENDING.** 8 more paired x86 rounds are running to settle it.
+  A 7-of-8 sign against a gate cell with a plausible mechanism is not
+  something to wave through on "it's within the noise band" — that is
+  exactly the reasoning the A/A control was built to stop.
+- Correctness meanwhile: full suite green on the **x86 box** (29 binaries,
+  0 failures) — necessary because the capture is now compiled out on
+  aarch64, so a local ARM run no longer exercises it at all.
+
 ## Loop state
 
-Non-win streak: 5 (H3, H4, H5, H6, H7)
+Non-win streak: 5 (H3, H4, H5, H6, H7); H8 pending

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -122,6 +122,47 @@ whose header names no units, so there was nothing to re-verify.
     `sync_settle-arm` on ≥6 paired rounds, never on one.**
 - **Verdict: WIN** — committed. Streak 0.
 
+### H2 — read a header slot's used prefix, not its op-capacity (target: sync_append)
+
+`cursor_state` read the whole header region — superblock plus both slots —
+before looking at either. A slot is *sized* for the 1024-op cap, ~428 KB at
+dim 768, so that is ~856 KB read and zeroed on the way into every sync,
+including a 32-row append whose entire commit is ~12 KB.
+
+Almost none of it is used. A commit carrying no pending redo ops — an
+append, or any sync following one that materialized its ops, which is the
+steady state both objective cells sit in — uses only the fixed fields, the
+tail block, the delta descriptor and the CRC: ~16 KB. Each slot is now read
+at that size and widened to the full slot only when the parse needs more,
+which costs the second read once for an op-bearing header and never in the
+steady state. `parse_header_slot` split into a slot-local `parse_header_at`
+whose every field read is bounds-checked, so a prefix that is long enough
+parses and one that is not returns `None`.
+
+- Correctness: `cargo test -p turbovec` green, including the torn-write
+  harness, the corruption matrix, `io_versioning` and `bytes_io` (the
+  parser's other callers). Crash contract untouched — this reads, it does
+  not write.
+- A/B, alternating prebuilt modules on one machine state (x86 4 rounds,
+  arm 6 — the settle-cell protocol from H1):
+
+  | cell | x86 | arm |
+  |---|---|---|
+  | `sync_append` | 1.815 → 1.635 (**x1.110**, better 4/4) | 1.700 → 1.640 (x1.037, better 3/6) |
+  | `sync_remove` | 4.810 → 4.650 (x1.034, better 4/4) | 3.550 → 3.525 (x1.007, better 3/6) |
+  | `sync_settle` | 35.58 → 34.07 (x1.044) | 18.31 → 18.27 (x1.002) |
+  | `sync_first` | 431.5 → 427.6 (x1.009) | 265.9 → 266.0 (x1.000) |
+
+- Target HM (sync_append) **x1.072**; no cell regresses on either arch.
+- Honest reading: the win is carried by x86, where it is unanimous across
+  rounds and larger than the fsync spread that cell sits in (0.18 ms moved
+  against a ~0.07 ms fsync spread, with a mechanism — 840 KB less read per
+  sync — that is not device noise). On ARM both cells are parity within
+  noise: 840 KB off that box's memory system is ~0.05 ms, under its own
+  round-to-round spread. Claimed as a win on the stated rule (HM > x1.01,
+  neither cell regressing), not as a two-arch result.
+- **Verdict: WIN** — committed. Streak 0.
+
 ## Loop state
 
 Non-win streak: 0

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -64,7 +64,14 @@ target.
 ## Baseline
 
 Pinned in `benchmarks/results/sync_baseline.json`, 15 reps per cell, core =
-`81d614d1` (main `c8d7ec02` plus the harness commit).
+`36ecaeec` — main `c8d7ec02` plus the harness commits, the warmup discard
+included, so the pinned numbers and every later run share one methodology.
+
+`remove_calls` has no pinned baseline: it was added as a gate at `e13dceb5`,
+after the baseline was recorded, and is judged only by interleaved A/B
+against the hypothesis's own base. That is sufficient for its job — it
+exists to catch work moving into `remove()` within a single A/B — but a
+future climb wanting to score it against a fixed reference needs to re-pin.
 
 ## Hypotheses
 

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -443,14 +443,39 @@ Against that reading: the same cell measured x1.003 (H6) and x0.995 (H7) on
 the same mechanism, its A/A spread is ±4.0%, and a 3.7% move sits inside
 that. Three runs cannot all be right.
 
-- **Verdict: PENDING.** 8 more paired x86 rounds are running to settle it.
-  A 7-of-8 sign against a gate cell with a plausible mechanism is not
-  something to wave through on "it's within the noise band" — that is
-  exactly the reasoning the A/A control was built to stop.
-- Correctness meanwhile: full suite green on the **x86 box** (29 binaries,
-  0 failures) — necessary because the capture is now compiled out on
-  aarch64, so a local ARM run no longer exercises it at all.
+**Resolved by 8 more paired rounds per arch (16 total each).** The settle
+regression did not reproduce: x0.963 (better 1/8) in the first set, x1.015
+in the second, x0.986 with no majority (6/16) pooled — inside both the 3%
+gate and the cell's own ±4.0% A/A band. And the cost-shift reading is
+refuted outright by the cycle total, which is what that reading predicted
+would be flat:
+
+| | base | new | |
+|---|---|---|---|
+| `remove` + `settle` per cycle, x86 | 38.605 | 37.725 | **x1.023, better 14/16** |
+
+Final, 16 paired rounds per arch:
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_remove` | 4.735 → 3.390 (**x1.397, better 16/16**) | 3.545 → 3.575 (x0.992, 7/16) |
+| `sync_append` | 1.675 → 1.670 (x1.003) | 1.610 → 1.590 (x1.013) |
+| `sync_settle` | 33.835 → 34.325 (x0.986, 6/16) | 18.545 → 18.320 (x1.012) |
+| `remove_calls` | 3.385 → 3.415 (x0.991) | 1.690 → 1.695 (x0.997) |
+| `sync_first` | 432.6 → 436.0 (x0.992) | 266.5 → 266.2 (x1.001) |
+
+Target HM **x1.160**. Every gate inside 3%.
+
+- **Verdict: WIN** — committed. Streak resets to 0.
+- On the ARM target cell reading x0.992: stated plainly, that is nominally
+  below 1.0, and the win rule asks for neither target cell regressing. It
+  is parity, and the case for saying so is not "it's small": the capture is
+  `#[cfg]`-ed out on aarch64, so the removal path there is the same code as
+  base; the sign test is 7/16, no majority in either direction; the cell's
+  A/A spread on unchanged code is ±3.7%; and doubling the sample moved it
+  0.986 → 0.992, toward 1.0, as regression to the mean predicts. The win is
+  carried entirely by x86, which is where the mechanism applies.
 
 ## Loop state
 
-Non-win streak: 5 (H3, H4, H5, H6, H7); H8 pending
+Non-win streak: 0 (reset by H8)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -1,0 +1,75 @@
+# sync() hill-climb — results log
+
+Objective: weighted harmonic mean of four per-cell speedups vs the baselines
+pinned in `benchmarks/results/sync_baseline.json` — {arm, x86} × {sync of a
+32-row append, sync of 1000 scattered removals}, weights 1:1. `sync_first`
+(the full write) and `sync_settle` (the follow-up sync that materializes a
+removal's header ops) are recorded gate cells, weight 0: they exist so that
+moving work out of a measured sync and into one of them reads as what it is.
+
+Win = target cell's HM(arm, x86) > x1.01, neither of its cells regressing,
+no other cell — gates included — regressing beyond 3%, and the crash
+contract untouched: one write batch and one fsync per sync, torn-write
+harness and corruption matrix green, `sync_all` durability. Stop: 20
+consecutive non-wins.
+
+Bench: `benchmarks/hillclimb/bench_sync.py` (N=200k, dim=768, 4-bit).
+Scorer: `benchmarks/hillclimb/whm_sync.py`. Smoke = 5 reps both arches;
+soak = 15 reps.
+
+## Rig
+
+Purpose-built pair, never the masters and never local:
+
+| box | machine | zone | disk |
+|---|---|---|---|
+| `turbovec-bench-sync` | c3-standard-8 | us-central1-a | pd-balanced 100 GB |
+| `turbovec-bench-arm-sync` | c4a-standard-8 | **us-east4-c** | hyperdisk-balanced 80 GB, 3480 IOPS / 260 MB/s |
+
+Both cloned from the masters (`turbovec-bench` / `turbovec-bench-arm`): x86
+from a machine image, ARM from a boot-disk snapshot, because machine images
+do not support C4A. **Zone deviation:** us-central1 was at its 24-CPU C4A
+quota, held by three sibling goals' ARM boxes, so the ARM box lives in
+us-east4-c. Its disk spec matches the ARM master exactly and every speedup
+is measured against a baseline recorded on that same box, so the objective
+is unaffected; only cross-goal absolute ARM numbers are not comparable.
+
+`rm -rf target` before each release build; `LD_PRELOAD` the arch's
+libopenblas. Pair stopped when idle, deleted at termination.
+
+**Working tree:** `scratchpad/wt-sync`, a dedicated worktree. The shared
+checkout at `~/git/turbovec` has concurrent editors — a sibling session
+swept this climb's first staged commit into its own branch — so nothing in
+this climb touches the shared tree.
+
+## The fsync floor
+
+Measured directly (write of size S into an existing 80 MB file, then
+`fsync`, 15 reps, median):
+
+| write size | x86 | arm |
+|---|---|---|
+| 4 KB | 1.41 ms | 1.42 ms |
+| 64 KB | 1.69 ms | 1.74 ms |
+| 400 KB | 2.46 ms | 2.44 ms |
+| 12.6 MB | 8.75 ms | 6.14 ms |
+
+This sets what is even addressable. A 32-row append commits ~12 KB, so
+`sync_append` sits within ~0.5 ms of its floor on both arches — margins
+there are fsync variance and are rejected regardless of how consistent they
+look. A 1000-removal commit writes a ~400 KB header, so `sync_remove` is
+~75% CPU on x86: plan build, header assembly, and digest. That is the honest
+target.
+
+## Baseline
+
+Pinned in `benchmarks/results/sync_baseline.json`, 15 reps per cell, core =
+`81d614d1` (main `c8d7ec02` plus the harness commit).
+
+## Hypotheses
+
+_(none yet — baseline recording in progress)_
+
+## Loop state
+
+Non-win streak: 0

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -476,6 +476,47 @@ Target HM **x1.160**. Every gate inside 3%.
   0.986 → 0.992, toward 1.0, as regression to the mean predicts. The win is
   carried entirely by x86, which is where the mechanism applies.
 
+### Floor analysis (probe, not a hypothesis) — the removal sync is now ~87% fsync
+
+Slope probe re-run on the H8 core: per-op cost is **1.89 µs on x86** (was
+3.02 before H8) and 1.86 on ARM, on fixed intercepts of 2.42 / 1.81 ms.
+
+Then a throwaway instrumented build (`wip/sync-prof`, never merged) split
+the sync itself, 28 samples on x86:
+
+| phase | removal sync | settle sync |
+|---|---|---|
+| `cursor_state` | ~210 µs | ~220 µs |
+| `plan_incremental` (header assembly + digest) | ~300 µs | ~14,600 µs |
+| `run_sync` (seek + write + fsync) | **~3,500 µs** | ~21,000 µs |
+
+So of a 4.0 ms removal sync, **~3.5 ms is the one write batch and one fsync
+the crash contract fixes**, and the entire addressable remainder is ~510 µs
+— 300 in the plan build, 210 in the identity check. Nothing above 13% of
+that cell is reachable without trading the contract, which is not on the
+table.
+
+(The 3.5 ms is above the 2.46 ms the floor table gives for a 400 KB write
+because that table let the device drain for 150 ms before fsyncing. A sync
+fsyncs its 100 freshly-dirtied pages immediately, which is the real shape.)
+
+The other number worth recording: a settle sync spends **14.6 ms of CPU**
+building its plan — 995 units materialized, ~12.6 MB assembled and digested.
+That is by far the largest CPU cost left anywhere in the sync path, but it
+belongs to a gate cell (weight 0), so it is out of this objective's scope
+and noted here for whoever picks it up.
+
+### H9 — borrow the op-group slices instead of a `Vec` per unit (target: sync_remove)
+
+`plan_incremental` built `Vec<(usize, Vec<usize>)>` — one heap allocation
+per op-bearing unit, up to 1024 a sync. `carried` is already sorted, so each
+unit's ops are a contiguous run of it and the groups can borrow slices.
+Aimed at the ~230 µs of the 300 µs plan build that is allocation rather than
+bytes (the memcpy and CRC together account for only ~70 µs).
+
+Expected ceiling ~5% of the cell, against an A/A band of ±3.5% — marginal by
+construction, and measured for that reason rather than assumed either way.
+
 ## Loop state
 
-Non-win streak: 0 (reset by H8)
+Non-win streak: 0 (reset by H8); H9 measuring

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -307,6 +307,52 @@ have base and new running two different benchmarks. It carries the new
 `remove_calls` gate: x86 ~3.35 ms, arm ~1.70 ms for the 1000 `remove()`
 calls, flat across H4's rounds.
 
+### H5 — capture a removal's row bytes at the move that already has them (target: sync_remove)
+
+The probe pinned the per-op cost on serializing one row out of the 32-lane
+interleaved block: 384 byte extractions at stride 32, a walk over the whole
+12 KB unit to collect 384 bytes, ~995 times a sync. But `swap_remove`'s
+`move_lane` already computes exactly those bytes — on x86 it calls
+`deinterleave_x86_code_byte` per group and drops the result into the
+destination lane. Keep them and the sync need not re-derive them.
+
+Correctness is the interesting part, and it is all sequencing. A capture is
+taken only where it will be read (slot below the committed floor, blocked
+cache authoritative) and consulted only in that same window, so the one
+thing that rewrites every row — a re-calibration — cannot be read through a
+stale entry, because it materializes `packed_codes` and turns the read path
+off for good. New test `captured_removal_bytes_match_a_reread_of_the_row`
+covers double-removal, refill-by-add, uncommitted fillers, re-calibration,
+and every bit width, each round reloading and demanding `to_bytes`
+equality. Mutation-checked: corrupting the captured bytes fails it. Two
+other mutations did *not* fail it, and chasing why produced the invariant
+that made the design simpler — a slot's capture is always retired before an
+add can reach it, because `n_vectors` only falls through `swap_remove`,
+which retires it. That is now a `debug_assert` rather than a defensive
+sweep that would have read as load-bearing.
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_remove` | 4.715 → 3.495 (**x1.349, 8/8**) | 3.555 → 3.005 (**x1.183, 8/8**) |
+| `sync_append` | 1.645 → 1.615 (x1.019) | 1.600 → 1.590 (x1.006) |
+| `sync_settle` | 34.98 → 35.96 (x0.973) | 18.32 → 18.24 (x1.004) |
+| **`remove_calls`** | 3.365 → 3.680 (**x0.914, better 0/8**) | 1.710 → 2.150 (**x0.795, better 0/8**) |
+
+Target HM **x1.261**, unambiguous at 8/8 on both arches — and rejected
+anyway. `remove_calls` regresses 9% on x86 and 20% on ARM, 0 of 8 rounds
+better on either: the sync got faster by moving work into `remove()`.
+
+The bytes really were free at the move; *storing* them was not. A
+`HashMap<usize, Vec<u8>>` insert per removal is an allocation and a hash
+per removal, and both land where nothing asked for them. Netting it out —
+x86 saves 1.22 ms of sync and pays 0.31 ms of removals (+0.90 net), ARM
+saves 0.55 and pays 0.44 (+0.11) — the ARM half is almost entirely a shift.
+
+- **Verdict: NON-WIN (cost-shifted)** — caught by the `remove_calls` gate,
+  which was added one hypothesis earlier precisely because this shift was
+  foreseeable. Streak 3. The mechanism is sound and the target number is
+  real, so the storage is the thing to fix → H6.
+
 ## Loop state
 
-Non-win streak: 2 (H3, H4)
+Non-win streak: 3 (H3, H4, H5)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -68,7 +68,59 @@ Pinned in `benchmarks/results/sync_baseline.json`, 15 reps per cell, core =
 
 ## Hypotheses
 
-_(none yet — baseline recording in progress)_
+### H1 — a sync stops re-proving its own last commit (target: sync_remove)
+
+Every sync opens with `cursor_state`, which decides whether the file is
+still the one the cursor wrote. It did that by walking the header slots
+newest-first and, for each, re-reading every unit that commit's sync wrote
+and recomputing the delta digest over them. After a 1000-removal settle
+that is 12.6 MB of read and CRC on the way into the *next* sync.
+
+That work re-proves something already proven. A cursor is established
+exactly two ways: this process wrote the commit — and `sync` returns Ok
+only after `sync_all` reports it durable — or `load` adopted it, and `load`
+picks a commit by running this same delta check. The nonce comparison just
+above already established it is the same file. So when the newest parsing
+header is at the cursor's own generation, it is the newest adoptable
+commit, which is what `Intact` means. Any other generation still takes the
+full verifying walk: a newer header means another writer advanced the file,
+and Foreign-vs-Intact there genuinely depends on whether their data landed.
+The shortcut only ever skips a commit already proven, and in the
+unsupported concurrent-writer case it errs toward refusing.
+
+Found by the warmup anomaly: rep 0 of the removal cell ran at 4.7 ms
+against a steady 17.4: at rep 0 the preceding commit is the full write,
+whose header names no units, so there was nothing to re-verify.
+
+- Correctness: full `cargo test -p turbovec` green (121 lib + every
+  integration binary). The crash contract specifically — torn-write
+  harness (`a_sync_torn_at_any_byte_recovers_the_previous_commit`,
+  `a_torn_materialize_of_a_delta_named_unit_recovers`,
+  `blocked_only_capture_survives_a_torn_sync`,
+  `a_recovery_load_syncs_forward_and_survives_a_second_tear`,
+  `an_id_mapped_sync_torn_anywhere_restores_ids_exactly`), the corruption
+  matrix, and the two multi-writer tests
+  (`a_stale_cursor_refuses_to_clobber_another_writers_commits`,
+  `two_writers_at_the_same_generation_do_not_collide`) all pass. One batch,
+  one fsync, `sync_all` — untouched by this diff.
+- Soak (15 reps): sync_remove arm 9.77 → 3.49 (**x2.80**), x86 18.58 →
+  4.90 (**x3.79**). Target HM **x3.22**. WHM of the four measured cells
+  x1.52.
+- Gates: sync_first parity both arches (267.5→266.2, 435.8→432.9).
+- Two cells flagged against baseline and both cleared by interleaved A/B
+  (3 rounds each arch, alternating prebuilt modules on one machine state):
+  - `sync_append-x86` read x0.93 vs baseline, but A/B has the new code
+    *faster* in all 3 rounds (1.99/2.04/1.96 → 1.81/1.90/1.90). The cell
+    sits ~0.3 ms above its fsync floor; baseline drift, not a regression.
+  - `sync_settle-arm` read x0.82, and round 1 appeared to confirm it. Six
+    further paired rounds refuted it: base 17.37/18.92/18.74/18.13/17.97/
+    17.94 (median 18.05) vs new 17.48/18.01/17.66/17.71/18.19/18.33
+    (median 17.86), new ≤ base in 4 of 6. The ARM settle cell is bimodal
+    on unchanged code (~15.3 and ~18.5 states — the pinned baseline itself
+    recorded 15.02 MT and 18.46 ST); the first A/B's base run drew the low
+    state twice. **Protocol note for later hypotheses: judge
+    `sync_settle-arm` on ≥6 paired rounds, never on one.**
+- **Verdict: WIN** — committed. Streak 0.
 
 ## Loop state
 

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -163,6 +163,89 @@ parses and one that is not returns `None`.
   neither cell regressing), not as a two-arch result.
 - **Verdict: WIN** — committed. Streak 0.
 
+### Where the removal sync's time actually goes (probe, not a hypothesis)
+
+Timed `sync_remove` at 50/200/500/1000 removals on x86 with H2 in place:
+1.92 / 2.40 / 3.23 / 4.78 ms — clean and linear. **3.02 µs per op, 1.77 ms
+fixed.** Of the 3.02 ms that 1000 ops add, the fsync itself accounts for
+~0.9 ms (the commit grows from ~20 KB to ~400 KB, and the floor table above
+puts that at 1.5 → 2.46 ms), leaving ~2.1 ms of CPU — the only part any
+per-op hypothesis can reach.
+
+Where that 2.1 ms sits: each op serializes one row's sequential codes out
+of the 32-lane interleaved block, and at dim 768 that is 384 byte
+extractions at stride 32 — a walk over the whole 12 KB block unit to
+collect 384 bytes. At ~995 ops that is ~12 MB of scattered reads. The cost
+is memory latency, not arithmetic and not allocation, which is what H3
+then confirmed the hard way.
+
+### H3 — append row codes into the header buffer (target: sync_remove)
+
+Header assembly called `seq_row`, which allocates and returns a `Vec` per
+op, then copied it into the header and dropped it: ~995 allocations and
+~382 KB of copying per 1000-removal sync. Replaced with a `seq_row_into`
+that extends the header buffer directly.
+
+- A/B (x86 4 rounds, arm 6): sync_remove x86 4.910 → 4.985 (**x0.985**,
+  new better in only 1 of 4), arm 3.425 → 3.470 (x0.987). Target HM
+  **x0.986** — a regression, not a win.
+- Why: `Vec::extend` from an iterator re-checks capacity per byte, and at
+  384 bytes a row that costs more than the `collect()` allocation plus
+  `extend_from_slice` memcpy it replaced. Together with the probe above,
+  this pins the per-op cost on the strided gather rather than on
+  allocation — allocation was never the bottleneck to remove.
+- **Verdict: NON-WIN** — reverted. Streak 1.
+
+### A/A control — what the harness measures when nothing changed
+
+Run after H4 came back at x1.07 on the append cell, the same figure H2 had
+claimed by a completely different mechanism. Two copies of the *identical*
+module, alternated exactly as an A/B alternates them:
+
+| cell | range on identical code | 2nd-position ratio | 2nd slower |
+|---|---|---|---|
+| `sync_append` x86 | 1.56–1.82 (**±7.9%**) | x0.952 | 2/3 |
+| `sync_append` arm | 1.50–1.81 (**±9.7%**) | x0.967 | 2/4 |
+| `sync_remove` x86 | 4.55–4.88 (±3.5%) | **x0.942** | **3/3** |
+| `sync_remove` arm | 3.41–3.67 (±3.7%) | x1.016 | 2/4 |
+| `sync_settle` x86 | 32.6–35.3 (±4.0%) | x0.961 | 2/3 |
+| `sync_settle` arm | 17.5–18.8 (±3.6%) | x1.005 | 1/4 |
+
+Two findings, both of which change how earlier results must be read.
+
+**1. The append cell cannot carry a claim below ~10%.** Its own
+round-to-round spread on unchanged code is ±8% on x86 and ±10% on ARM —
+the cell is ~0.15 ms above its fsync floor and that floor is what moves.
+This is precisely the "reject wins within fsync variance" the goal names.
+H2's append figure (x1.072) and H4's (x1.071) are both inside this band and
+neither can be claimed on the append cell, however consistent the rounds
+looked. H2's *remove* result is a separate matter — see below.
+
+**2. `ab.sh` always ran base first, and second position is not neutral.**
+On x86 `sync_remove` the second run is slower in 3 of 3 at ~6%. Every A/B
+so far therefore handicapped "new" by roughly that much on that cell, which
+means the remove-cell numbers were *understated*, not flattered:
+
+| measured x86 remove | position-corrected |
+|---|---|
+| H2 x1.034 | ≈ x1.10 |
+| H3 x0.985 | ≈ x1.05 |
+| H4 x1.007 | ≈ x1.07 |
+
+So **H3's rejection is suspect** — it may have been a small win read through
+a larger handicap — and H4's is unresolved. Neither verdict stands on the
+old harness.
+
+`ab2.sh` replaces `ab.sh` from here: odd rounds run base-then-new, even
+rounds new-then-base, so a within-round trend lands on both sides equally.
+H1 is unaffected — at x2.8/x3.8 it is an order of magnitude outside every
+band above, and it was measured against a pinned baseline in a separate
+run, not by position. H2, H3 and H4 are all being re-measured on `ab2.sh`
+at 8 rounds, and the verdicts below will be restated from that.
+
+- **H4 verdict: UNRESOLVED pending re-measurement** (its x1.07 was on the
+  append cell, inside the band). Not counted toward the streak yet.
+
 ## Loop state
 
-Non-win streak: 0
+Non-win streak: 1 (H3 — under re-measurement, see the A/A control)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -517,6 +517,56 @@ bytes (the memcpy and CRC together account for only ~70 µs).
 Expected ceiling ~5% of the cell, against an A/A band of ±3.5% — marginal by
 construction, and measured for that reason rather than assumed either way.
 
+| cell | x86 (7 rounds) | arm (8 rounds) |
+|---|---|---|
+| `sync_remove` | 4.140 → 4.060 (x1.020, **4/7 — no majority**) | 3.695 → 3.655 (x1.011, 7/8) |
+| `sync_append` | 2.320 → 2.280 (x1.018, 4/7) | 1.700 → 1.725 (x0.986, 2/8) |
+| `sync_settle` | 34.56 → 35.28 (x0.980, 3/7) | 19.07 → 19.11 (x0.998) |
+| `remove_calls` | 3.380 → 3.380 (x1.000) | 1.750 → 1.795 (**x0.975, 1/8**) |
+
+Target HM x1.015 — which clears the x1.01 bar on paper, with neither target
+cell regressing and every gate inside 3%.
+
+- **Verdict: NON-WIN.** Streak 1. Three reasons, in order of weight:
+  1. `remove_calls` on ARM moved x0.975 with base better in 7 of 8 — and
+     this diff **cannot** touch `remove()`. It is confined to
+     `plan_incremental`. A gate cell moving 2.5% in a direction the code
+     cannot cause is direct evidence that this run carries drift the
+     pairing did not absorb, which disqualifies a 1.5% reading taken from
+     the same rounds.
+  2. x86, the arch where the plan build is largest, has **no sign-test
+     majority** (4/7). By the standing rule that is parity, and the
+     harmonic mean then rests on an ARM x1.011.
+  3. The whole effect is at or under the cells' A/A bands (±3.5% remove,
+     ±10% append). The goal's instruction is to reject exactly this.
+  The change itself is a genuine improvement — up to 1024 fewer allocations
+  a sync, and strictly less work — but "genuine and unmeasurable" is not a
+  win, and shipping it on a x1.015 claim would misrepresent the evidence.
+  Reverted.
+
+## Where this leaves the climb
+
+Three wins (H1, H2, H8), six rejections (H3–H7, H9), and the objective's
+main cell is now at its floor:
+
+| | baseline | now | fsync share |
+|---|---|---|---|
+| `sync_remove` x86 | 18.58 ms | **3.39 ms (x5.5)** | ~87% |
+| `sync_remove` arm | 9.77 ms | **3.58 ms (x2.7)** | — |
+| `sync_append` x86 | 1.82 ms | **1.67 ms** | at the floor |
+| `sync_append` arm | 1.77 ms | 1.59 ms | at the floor |
+
+The measured addressable remainder on the x86 removal cell is ~510 µs of
+4.0 ms, and this rig resolves ~3.5% (±140 µs) on that cell. So the
+*resolution* of the apparatus is now the same order as the *entire
+remaining opportunity*. H9 is what that looks like in practice: a change
+that is certainly an improvement, measuring 1.5% against a 3.5% band.
+
+Further hypotheses on this objective would be proposing sub-noise work.
+The honest recommendation is that the climb has converged, not that 19 more
+paper rejections should be logged to reach the formal stop rule.
+
 ## Loop state
 
-Non-win streak: 0 (reset by H8); H9 measuring
+Non-win streak: 1 (H9). Climb converged — see above; the objective's cells
+are at the fsync floor and remaining headroom is below the rig's resolution.

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -353,6 +353,27 @@ saves 0.55 and pays 0.44 (+0.11) — the ARM half is almost entirely a shift.
   foreseeable. Streak 3. The mechanism is sound and the target number is
   real, so the storage is the thing to fix → H6.
 
+### H6 — the same capture into an arena instead of a map (target: sync_remove)
+
+H5's diagnosis said the storage was the problem, so: one byte arena plus an
+append-only `(slot, offset)` index, and the slot→bytes lookup built once
+per sync rather than a hash per removal.
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_remove` | 4.760 → 3.515 (x1.354, 8/8) | 3.585 → 3.085 (x1.162, 8/8) |
+| **`remove_calls`** | 3.395 → 3.570 (**x0.951, better 0/8**) | 1.685 → 2.130 (**x0.791, better 0/8**) |
+
+- **Verdict: NON-WIN (still cost-shifted).** Streak 4. The map was worth
+  ~4 points on x86 and nothing at all on ARM.
+- Which says the remaining cost was never the map. It is what the capture
+  still did per *byte*: a temporary `Vec` per removal, a capacity-checked
+  `push` per byte group, and then a copy of the whole row out of the
+  temporary into the arena. The arena removed the last of those three and
+  left the first two. → H7 sizes the arena first and hands
+  `move_lane_capturing` a slice to fill, so the capture is one indexed
+  store per byte group with no temporary, no capacity check and no copy.
+
 ## Loop state
 
-Non-win streak: 3 (H3, H4, H5)
+Non-win streak: 4 (H3, H4, H5, H6)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -278,6 +278,35 @@ exactly the drift the pairing is there to absorb.
 better-in-N-of-M) under `ab3.sh`, and treat a result with no majority in
 the sign test as parity no matter how the medians fall.
 
+### H4 restated on `ab3.sh` — 8 rounds, order alternated, pinned harness
+
+The corrected form of H3: grow the header buffer once and fill it through
+an indexed slice, instead of `extend`-ing from an iterator byte by byte.
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_append` | 1.645 → 1.690 (**x0.973**, better 3/8) | 1.750 → 1.635 (x1.070, 7/8) |
+| `sync_remove` | 4.800 → 4.780 (x1.004, 4/8) | 3.685 → 3.590 (x1.027, 6/8) |
+| `sync_settle` | 35.37 → 34.79 (x1.017) | 18.07 → 18.53 (x0.975) |
+
+- **Verdict: NON-WIN.** On the append cell x86 *regresses* (x0.973, better
+  in only 3 of 8), which fails "neither cell regressing" outright. On the
+  remove cell x86 has no sign-test majority (4/8 = parity by the standing
+  rule), so the x1.015 harmonic mean rests entirely on an ARM 6/8 — p ≈
+  0.145, not a result. Reverted. Streak 2.
+- This also closes H3's question. H3 and H4 are the same idea in its worse
+  and better forms, and the better form is parity on the cell it targets:
+  the ~995 per-op allocations were never the cost. The probe said as much —
+  the per-op time is a 12 KB strided gather, and neither variant touched
+  it. **H3 stays NON-WIN**, now for a measured reason rather than a
+  handicapped one.
+
+`ab3.sh` also pins the harness to a fixed copy rather than reading it from
+the checked-out tree, so a hypothesis that touches `bench_sync.py` cannot
+have base and new running two different benchmarks. It carries the new
+`remove_calls` gate: x86 ~3.35 ms, arm ~1.70 ms for the 1000 `remove()`
+calls, flat across H4's rounds.
+
 ## Loop state
 
-Non-win streak: 1 (H3 — under re-measurement, see the A/A control)
+Non-win streak: 2 (H3, H4)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -374,6 +374,38 @@ per sync rather than a hash per removal.
   `move_lane_capturing` a slice to fill, so the capture is one indexed
   store per byte group with no temporary, no capacity check and no copy.
 
+### H7 — capture straight into the arena through a pre-sized slice (target: sync_remove)
+
+The last of the three per-byte costs. The caller now grows the arena first
+and hands `move_lane_capturing` a slice exactly `n_byte_groups` long, so
+the capture is one indexed store per group: no temporary `Vec`, no
+capacity check, no copy. The option test moved out of the inner loop too —
+two loop bodies instead of one with a branch per byte.
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_remove` | 4.690 → 3.390 (**x1.384, 7/7**) | 3.485 → 3.000 (x1.162, 8/8) |
+| `remove_calls` | 3.370 → 3.420 (**x0.985**, gate OK) | 1.685 → 2.010 (**x0.838**, 0/8) |
+| `sync_append` | 1.690 → 1.740 (x0.971, 3/7) | 1.630 → 1.665 (x0.979, 3/8) |
+| `sync_settle` | 33.36 → 33.53 (x0.995) | 18.10 → 18.19 (x0.995) |
+
+- **Verdict: NON-WIN**, and now for a reason that is arithmetic rather than
+  implementation. Streak 5. On x86 the shift is finally gone — `remove()`
+  pays 1.5%, inside the gate — and `sync_remove` is x1.384 in 7 of 7. On
+  ARM `remove()` still pays 16%.
+- Why ARM cannot be fixed by tightening the code further: on x86 the lane
+  move is a de-interleave plus a nibble-merge write, so the capture's extra
+  store is a small fraction of an already-heavy loop. Off x86 the move *is*
+  a byte load and a byte store — the capture is a third memory op on a
+  two-op loop, ~50% more work in `remove()`, to save less than that in
+  `sync()` (ARM's sync only holds 0.5 ms of gather to begin with). Three
+  implementations (H5 map, H6 arena, H7 pre-sized slice) moved ARM's
+  `remove_calls` 2.150 → 2.130 → 2.010 against a 1.685 baseline. The floor
+  is the extra store itself.
+- → H8 gates the capture to x86, where it pays, and leaves every other
+  target on the untouched path. Same shape as the six-op climb's H14,
+  which arch-gated its sharded map build for the same reason.
+
 ## Loop state
 
-Non-win streak: 4 (H3, H4, H5, H6)
+Non-win streak: 5 (H3, H4, H5, H6, H7)

--- a/benchmarks/hillclimb/LOG_sync.md
+++ b/benchmarks/hillclimb/LOG_sync.md
@@ -246,6 +246,38 @@ at 8 rounds, and the verdicts below will be restated from that.
 - **H4 verdict: UNRESOLVED pending re-measurement** (its x1.07 was on the
   append cell, inside the band). Not counted toward the streak yet.
 
+### H2 restated on `ab2.sh` — 8 rounds, order alternated
+
+| cell | x86 | arm |
+|---|---|---|
+| `sync_append` | 1.950 → 1.700 (**x1.147, better 7/7**) | 1.685 → 1.660 (x1.015, 5/8) |
+| `sync_remove` | 4.960 → 4.850 (x1.023, 6/7) | 3.520 → 3.500 (x1.006, 4/8) |
+| `sync_settle` | 35.04 → 34.77 (x1.008) | 18.13 → 18.14 (x0.999) |
+| `sync_first` | 429.5 → 425.9 (x1.008) | 265.7 → 266.3 (x0.998) |
+
+Target HM (sync_append) **x1.077**; no cell regresses. **The win stands.**
+
+The correction the A/A control actually implies is narrower than it first
+looked, and it is about *statistics*, not about this result. What the
+control measured is the cell's **unpaired** spread — ±8% run to run — and
+that is the right bar only for comparing two numbers taken at different
+times, which is what a baseline comparison does. It is the wrong bar for a
+paired design: with base and new alternated within one machine state, the
+statistic is the **sign test across rounds**, and x86 append comes back
+better in 7 of 7 (p ≈ 0.008). The magnitude sitting inside the unpaired
+spread does not weaken that; it is why the pairing exists.
+
+So the honest position on H2 is: the x86 append improvement is real and
+larger than first measured (x1.147 here vs x1.110 on the biased harness),
+ARM is parity, and the claim rests on paired sign tests rather than on
+medians of independent runs. Absolute levels drifted between the two runs
+(x86 append base 1.815 then, 1.950 now) while the ratio held — which is
+exactly the drift the pairing is there to absorb.
+
+**Standing rule from here:** report every A/B as (median ratio,
+better-in-N-of-M) under `ab3.sh`, and treat a result with no majority in
+the sign test as parity no matter how the medians fall.
+
 ## Loop state
 
 Non-win streak: 1 (H3 — under re-measurement, see the A/A control)

--- a/benchmarks/hillclimb/bench_sync.py
+++ b/benchmarks/hillclimb/bench_sync.py
@@ -61,8 +61,18 @@ def ensure_seed():
     idx.write(SEED)
 
 
+# The first rep of every cell is a warmup and is discarded. It is not
+# merely colder — it is a different measurement: the sync preceding it is
+# the full write, whose commit header names no units, so the identity check
+# that opens a sync has nothing to verify. Every later rep follows a sync
+# that wrote units and pays for it. On x86 that is 4.7 ms vs a steady 17.4,
+# and keeping it would make a 5-rep smoke and a 15-rep soak disagree by
+# construction.
+WARMUP = 1
+
+
 def median_ms(xs):
-    return statistics.median(xs) * 1e3
+    return statistics.median(xs[WARMUP:]) * 1e3
 
 
 def ino(path):
@@ -74,7 +84,9 @@ def main():
     ap.add_argument("--arch", required=True, choices=["arm", "x86"])
     ap.add_argument("--st", action="store_true",
                     help="single-core mode (RAYON_NUM_THREADS=1)")
-    ap.add_argument("--reps", type=int, default=9)
+    ap.add_argument("--reps", type=int, default=9,
+                    help="timed reps; one warmup rep is run and "
+                         "discarded on top of these")
     ap.add_argument("--out")
     ap.add_argument("--cells", help="comma-separated subset "
                                     "(sync_append,sync_remove,sync_first)")
@@ -104,7 +116,7 @@ def main():
     # Timed from a v6 file, which is the state `sync` promises to convert.
     if want("sync_first"):
         t = []
-        for _ in range(args.reps):
+        for _ in range(args.reps + WARMUP):
             shutil.copyfile(SEED, path)
             ix = IdMapIndex.load(path)
             time.sleep(0.15)   # drain the device queue between fsyncs
@@ -118,7 +130,7 @@ def main():
         ix = fresh_container()
         before = ino(path)
         t = []
-        for rep in range(args.reps):
+        for rep in range(args.reps + WARMUP):
             ids = np.arange(10_000_000 + rep * APPEND_ROWS,
                             10_000_000 + (rep + 1) * APPEND_ROWS,
                             dtype=np.uint64)
@@ -145,7 +157,7 @@ def main():
         pick = np.random.default_rng(7)
         alive = np.arange(N, dtype=np.uint64)
         t, t_settle = [], []
-        for rep in range(args.reps):
+        for rep in range(args.reps + WARMUP):
             take = pick.choice(len(alive), size=REMOVALS, replace=False)
             ids = alive[take]
             alive = np.delete(alive, take)

--- a/benchmarks/hillclimb/bench_sync.py
+++ b/benchmarks/hillclimb/bench_sync.py
@@ -6,6 +6,7 @@ Cells, per arch:
   sync_remove  — sync after 1000 scattered removals (ops ride the header)
   sync_first   — the first sync of a fresh path (full write)   [gate]
   sync_settle  — the follow-up sync that materializes those ops [gate]
+  remove_calls — the 1000 remove() calls themselves            [gate]
 
 The first two are the objective. The last two are recorded gates: a "win"
 that moves work out of an incremental sync and into the full write or into
@@ -156,13 +157,20 @@ def main():
         before = ino(path)
         pick = np.random.default_rng(7)
         alive = np.arange(N, dtype=np.uint64)
-        t, t_settle = [], []
+        t, t_settle, t_calls = [], [], []
         for rep in range(args.reps + WARMUP):
             take = pick.choice(len(alive), size=REMOVALS, replace=False)
             ids = alive[take]
             alive = np.delete(alive, take)
+            # Gate, not objective. The removals themselves are outside the
+            # timed sync, which makes them somewhere a "faster sync" could
+            # hide work — capture the row bytes here instead of serializing
+            # them there and the sync cell improves for free. Timing them
+            # closes that door.
+            t0 = time.perf_counter()
             for i in ids:
                 ix.remove(int(i))
+            t_calls.append(time.perf_counter() - t0)
             time.sleep(0.15)
             t0 = time.perf_counter()
             ix.sync(path)                    # commits the ops in the header
@@ -174,6 +182,7 @@ def main():
             t_settle.append(time.perf_counter() - t0)
         r["sync_remove"] = median_ms(t)
         r["sync_settle"] = median_ms(t_settle)
+        r["remove_calls"] = median_ms(t_calls)
         incremental["sync_remove"] = ino(path) == before
 
     cells = {f"{c}-{cell_arch}": ms for c, ms in r.items()}

--- a/benchmarks/hillclimb/bench_sync.py
+++ b/benchmarks/hillclimb/bench_sync.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""sync() hill-climb benchmark: one JSON of `<cell>-<arch>` -> median ms.
+
+Cells, per arch:
+  sync_append  — sync after adding 32 rows (one fresh block unit + header)
+  sync_remove  — sync after 1000 scattered removals (ops ride the header)
+  sync_first   — the first sync of a fresh path (full write)   [gate]
+  sync_settle  — the follow-up sync that materializes those ops [gate]
+
+The first two are the objective. The last two are recorded gates: a "win"
+that moves work out of an incremental sync and into the full write or into
+the next sync has shifted cost, not removed it, and these cells catch it.
+
+Steady state. A removal marks the hole slot and the moved-from slot dirty;
+1000 scattered removals leave ~995 slots live below the block floor, just
+under the 1024-op header cap. Repeating that on an unsettled file pushes
+carried ops past the cap (last round's units collide with this round's) and
+sync falls back to a full rewrite — so each timed removal sync is followed
+by an untimed-for-that-cell settle sync, which is itself timed as the gate.
+Every rep therefore starts from pending = {}, exactly like the first one.
+
+Path check, not timing check: an incremental sync writes in place, a full
+rewrite lands via temp + atomic rename and so changes the inode. Each cell
+records whether it stayed incremental; a cell that silently fell back to a
+full rewrite is not measuring what it claims to.
+
+Usage: python bench_sync.py --arch {arm,x86} [--st] [--reps N] [--out FILE]
+"""
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+
+if "--st" in sys.argv:  # must precede the extension's first pool build
+    os.environ["RAYON_NUM_THREADS"] = "1"
+
+import numpy as np
+from turbovec import IdMapIndex
+
+N, DIM, BITS = 200_000, 768, 4
+APPEND_ROWS = 32
+REMOVALS = 1_000
+CACHE = os.path.expanduser("~/.cache/turbovec-syncclimb")
+SEED = os.path.join(CACHE, f"seed_{N}x{DIM}_{BITS}bit.tvim")
+
+
+def ensure_seed():
+    """A v6-written file of N rows with ids 0..N. Reused across runs."""
+    os.makedirs(CACHE, exist_ok=True)
+    if os.path.exists(SEED):
+        return
+    idx = IdMapIndex(dim=DIM, bit_width=BITS)
+    rng = np.random.default_rng(0)
+    idx.add_with_ids(rng.random((N, DIM), dtype=np.float32),
+                     np.arange(N, dtype=np.uint64))
+    idx.write(SEED)
+
+
+def median_ms(xs):
+    return statistics.median(xs) * 1e3
+
+
+def ino(path):
+    return os.stat(path).st_ino
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--arch", required=True, choices=["arm", "x86"])
+    ap.add_argument("--st", action="store_true",
+                    help="single-core mode (RAYON_NUM_THREADS=1)")
+    ap.add_argument("--reps", type=int, default=9)
+    ap.add_argument("--out")
+    ap.add_argument("--cells", help="comma-separated subset "
+                                    "(sync_append,sync_remove,sync_first)")
+    args = ap.parse_args()
+    cell_arch = args.arch + ("_st" if args.st else "")
+    wanted = set(args.cells.split(",")) if args.cells else None
+    want = lambda c: wanted is None or c in wanted  # noqa: E731
+
+    ensure_seed()
+    rng = np.random.default_rng(1)
+    add_batch = rng.random((APPEND_ROWS, DIM), dtype=np.float32)
+    r, incremental = {}, {}
+
+    # A scratch dir per run; the container is ~77 MB and a leaked one per
+    # run filled the root disk during the six-op climb.
+    work = tempfile.TemporaryDirectory(prefix="tv-syncclimb-")
+    path = os.path.join(work.name, "bench.tvim")
+
+    def fresh_container():
+        """A file already in v7 sync form, index bound to it, ops settled."""
+        shutil.copyfile(SEED, path)
+        ix = IdMapIndex.load(path)
+        ix.sync(path)          # first sync: v6 file -> sync container
+        return ix
+
+    # ── sync_first (gate): the full write ────────────────────────────────
+    # Timed from a v6 file, which is the state `sync` promises to convert.
+    if want("sync_first"):
+        t = []
+        for _ in range(args.reps):
+            shutil.copyfile(SEED, path)
+            ix = IdMapIndex.load(path)
+            time.sleep(0.15)   # drain the device queue between fsyncs
+            t0 = time.perf_counter()
+            ix.sync(path)
+            t.append(time.perf_counter() - t0)
+        r["sync_first"] = median_ms(t)
+
+    # ── sync_append: 32 rows, one fresh block unit + the commit header ───
+    if want("sync_append"):
+        ix = fresh_container()
+        before = ino(path)
+        t = []
+        for rep in range(args.reps):
+            ids = np.arange(10_000_000 + rep * APPEND_ROWS,
+                            10_000_000 + (rep + 1) * APPEND_ROWS,
+                            dtype=np.uint64)
+            ix.add_with_ids(add_batch, ids)
+            time.sleep(0.15)
+            t0 = time.perf_counter()
+            ix.sync(path)
+            t.append(time.perf_counter() - t0)
+        r["sync_append"] = median_ms(t)
+        incremental["sync_append"] = ino(path) == before
+
+    # ── sync_remove + sync_settle ───────────────────────────────────────
+    # Sampled from the ids still alive, so every rep really performs 1000
+    # removals — re-drawing from 0..N would hit already-removed ids, and
+    # those calls are no-ops that quietly shrink the cell. Removals are
+    # scattered in slot space by construction: swap_remove relocates the
+    # tail row into each hole, so slot order stops tracking id order after
+    # the first rep. ~0.5% of holes land above the post-shrink block floor
+    # and drop out of the plan, leaving ~995 header ops — deliberately just
+    # under the 1024-op cap, which is the regime this cell exists to cover.
+    if want("sync_remove"):
+        ix = fresh_container()
+        before = ino(path)
+        pick = np.random.default_rng(7)
+        alive = np.arange(N, dtype=np.uint64)
+        t, t_settle = [], []
+        for rep in range(args.reps):
+            take = pick.choice(len(alive), size=REMOVALS, replace=False)
+            ids = alive[take]
+            alive = np.delete(alive, take)
+            for i in ids:
+                ix.remove(int(i))
+            time.sleep(0.15)
+            t0 = time.perf_counter()
+            ix.sync(path)                    # commits the ops in the header
+            t.append(time.perf_counter() - t0)
+
+            time.sleep(0.15)
+            t0 = time.perf_counter()
+            ix.sync(path)                    # materializes them into units
+            t_settle.append(time.perf_counter() - t0)
+        r["sync_remove"] = median_ms(t)
+        r["sync_settle"] = median_ms(t_settle)
+        incremental["sync_remove"] = ino(path) == before
+
+    cells = {f"{c}-{cell_arch}": ms for c, ms in r.items()}
+    out = dict(cells)
+    for c, ok in incremental.items():
+        out[f"{c}-{cell_arch}#incremental"] = ok
+    text = json.dumps(out, indent=2)
+    print(text)
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text + "\n")
+    # A cell that fell back to a full rewrite is not the cell it claims to
+    # be — fail loudly rather than record a number nobody can interpret.
+    bad = [c for c, ok in incremental.items() if not ok]
+    if bad:
+        print(f"FAIL: fell back to a full rewrite: {', '.join(bad)}",
+              file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/hillclimb/whm_sync.py
+++ b/benchmarks/hillclimb/whm_sync.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Weighted harmonic mean of per-cell sync() speedups vs pinned baselines.
+
+Usage:
+    python benchmarks/hillclimb/whm_sync.py baseline.json current.json \\
+        [--target {sync_append,sync_remove}]
+
+Both JSON files map cell name -> median ms, cells being "<cell>-<arch>" for
+arch in {arm, x86}. The objective is the weighted harmonic mean of the four
+speedups over the two measured cells:
+
+    sync_append  weight 1   sync of a 32-row append
+    sync_remove  weight 1   sync of 1000 scattered removals
+
+`sync_first` (the full write) and `sync_settle` (the follow-up sync that
+materializes a removal's header ops) carry weight 0: they are gate cells.
+They exist so that moving work *out* of a measured sync and *into* the full
+write or the next sync reads as what it is — cost-shifting, not a win.
+
+With --target, the run is verdicted: the target cell's arm+x86 harmonic mean
+must clear MIN_IMPROVEMENT, neither of its cells may regress at all, and no
+other cell — gates included — may regress by more than NOISE_TOLERANCE.
+Exit code 0 = win, 1 = no-win/regression.
+
+The fsync floor dominates both measured cells, so a margin inside fsync
+variance is not a win however consistent it looks. Pass --fsync-floor with
+the box's measured single-fsync cost to have the script report how much of
+each cell is even addressable; a claimed gain that exceeds the non-fsync
+remainder is a measurement artifact, not a speedup.
+"""
+
+import argparse
+import json
+import sys
+
+MEASURED = ["sync_append", "sync_remove"]
+GATES = ["sync_first", "sync_settle"]
+ARCHES = ["arm", "x86"]
+
+WEIGHTS = {"sync_append": 1.0, "sync_remove": 1.0, "sync_first": 0.0,
+           "sync_settle": 0.0}
+
+NOISE_TOLERANCE = 0.03   # non-target cells may regress at most 3%
+MIN_IMPROVEMENT = 0.01   # target must improve >1% (HM of its arm+x86 cells)
+
+
+def speedups(base, cur):
+    """baseline_ms / current_ms per cell present in both, as a dict."""
+    out = {}
+    for cell, b in base.items():
+        if cell.endswith("#incremental") or cell not in cur:
+            continue
+        c = cur[cell]
+        if not isinstance(b, (int, float)) or not isinstance(c, (int, float)):
+            continue
+        if c <= 0:
+            raise SystemExit(f"{cell}: non-positive current value {c}")
+        out[cell] = b / c
+    return out
+
+
+def whm(sp):
+    num = den = 0.0
+    for cell, s in sp.items():
+        w = WEIGHTS.get(cell.rsplit("-", 1)[0], 0.0)
+        num += w
+        den += w / s
+    return num / den if den else float("nan")
+
+
+def hmean(vals):
+    return len(vals) / sum(1.0 / v for v in vals) if vals else float("nan")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("baseline")
+    ap.add_argument("current")
+    ap.add_argument("--target", choices=MEASURED)
+    ap.add_argument("--fsync-floor", type=float, default=None,
+                    help="measured cost of one fsync on this box, in ms")
+    args = ap.parse_args()
+
+    base = json.load(open(args.baseline))
+    cur = json.load(open(args.current))
+
+    # An incremental cell that fell back to a full rewrite is not the cell
+    # it claims to be; refuse to score the run at all.
+    for k, v in cur.items():
+        if k.endswith("#incremental") and v is False:
+            raise SystemExit(f"REFUSING TO SCORE: {k} is false — that cell "
+                             f"fell back to a full rewrite")
+
+    sp = speedups(base, cur)
+    if not sp:
+        raise SystemExit("no comparable cells between the two files")
+
+    print(f"{'cell':<26}{'base ms':>10}{'cur ms':>10}{'speedup':>10}")
+    for cell in sorted(sp):
+        w = WEIGHTS.get(cell.rsplit('-', 1)[0], 0.0)
+        tag = "" if w else "   (gate)"
+        print(f"{cell:<26}{base[cell]:>10.2f}{cur[cell]:>10.2f}"
+              f"{sp[cell]:>9.3f}x{tag}")
+    print(f"\nWHM (measured cells, weight 1:1): {whm(sp):.4f}x")
+
+    if args.fsync_floor:
+        print(f"\nAddressable headroom above the {args.fsync_floor:.2f} ms "
+              f"fsync floor:")
+        for cell in sorted(sp):
+            if cell.rsplit("-", 1)[0] not in MEASURED:
+                continue
+            rem = base[cell] - args.fsync_floor
+            pct = 100.0 * rem / base[cell] if base[cell] else 0.0
+            print(f"  {cell:<24}{rem:>8.2f} ms  ({pct:.1f}% of the cell)")
+
+    if not args.target:
+        return
+
+    tcells = [f"{args.target}-{a}" for a in ARCHES if f"{args.target}-{a}" in sp]
+    if len(tcells) != len(ARCHES):
+        raise SystemExit(f"target {args.target} is missing an arch: "
+                         f"have {tcells}")
+    thm = hmean([sp[c] for c in tcells])
+    regressed = [c for c in tcells if sp[c] < 1.0]
+    others = {c: s for c, s in sp.items() if c not in tcells}
+    hurt = [c for c, s in others.items() if s < 1.0 - NOISE_TOLERANCE]
+
+    print(f"\ntarget {args.target}: HM(arm,x86) = {thm:.4f}x")
+    win = True
+    if thm < 1.0 + MIN_IMPROVEMENT:
+        print(f"  NO-WIN: below the {1 + MIN_IMPROVEMENT:.2f}x bar")
+        win = False
+    if regressed:
+        print(f"  NO-WIN: target cell(s) regressed: "
+              f"{', '.join(f'{c} {sp[c]:.3f}x' for c in regressed)}")
+        win = False
+    if hurt:
+        kind = ["gate " if c.rsplit("-", 1)[0] in GATES else "" for c in hurt]
+        print("  NO-WIN: " + ", ".join(
+            f"{k}cell {c} regressed to {sp[c]:.3f}x"
+            for k, c in zip(kind, hurt)))
+        win = False
+    print("\nVERDICT: " + ("WIN" if win else "NO-WIN"))
+    sys.exit(0 if win else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/sync_baseline.json
+++ b/benchmarks/results/sync_baseline.json
@@ -1,0 +1,21 @@
+{
+  "sync_append-arm": 1.774,
+  "sync_append-arm_st": 1.725,
+  "sync_append-x86": 1.822,
+  "sync_append-x86_st": 2.246,
+
+  "sync_remove-arm": 9.772,
+  "sync_remove-arm_st": 10.463,
+  "sync_remove-x86": 18.578,
+  "sync_remove-x86_st": 18.934,
+
+  "sync_first-arm": 267.451,
+  "sync_first-arm_st": 265.751,
+  "sync_first-x86": 435.800,
+  "sync_first-x86_st": 432.679,
+
+  "sync_settle-arm": 15.017,
+  "sync_settle-arm_st": 18.458,
+  "sync_settle-x86": 38.670,
+  "sync_settle-x86_st": 36.276
+}

--- a/benchmarks/suite/speed_sync_d1536_2bit_arm_mt.py
+++ b/benchmarks/suite/speed_sync_d1536_2bit_arm_mt.py
@@ -1,0 +1,126 @@
+import os
+import atexit, shutil, time, json, os.path, tempfile
+import numpy as np
+from turbovec import IdMapIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND = 32
+N_REMOVE = 1_000
+REPS = 5
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_APPEND]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-sync-")
+# The container runs to hundreds of MB and the official machines run every
+# cell in a loop, so leaving them behind fills the root disk.
+atexit.register(shutil.rmtree, tmpdir, True)
+seed_path = os.path.join(tmpdir, "seed.tvim")
+tv_path = os.path.join(tmpdir, "index.tvim")
+
+def build():
+    idx = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add_with_ids(database, ids)
+    return idx
+
+build().write(seed_path)
+
+def fresh():
+    """A file already in v7 sync form, index bound to it, no pending ops."""
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    ix.sync(tv_path)
+    return ix
+
+def median(xs):
+    return sorted(xs)[len(xs) // 2]
+
+# ── First sync: the full write ──────────────────────────────────────────
+# `sync` converts a v6 file into the sync container by rewriting it whole,
+# so this cell costs what `write` costs. It is the reference the two
+# incremental cells below are worth reading against, and the gate that
+# stops an incremental win from being bought by making this slower.
+first = []
+for _ in range(REPS):
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    time.sleep(0.15)             # drain the device queue between fsyncs
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    first.append(time.perf_counter() - t0)
+tv_sync_first = median(first)
+tv_file_bytes = os.path.getsize(tv_path)
+
+# ── Append: 32 rows, one fresh block unit plus the commit header ────────
+ix = fresh()
+append = []
+for rep in range(REPS):
+    new_ids = np.arange(10_000_000 + rep * N_APPEND,
+                        10_000_000 + (rep + 1) * N_APPEND, dtype=np.uint64)
+    ix.add_with_ids(extra, new_ids)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    append.append(time.perf_counter() - t0)
+tv_sync_append = median(append)
+
+# ── Removal: 1000 scattered removals ────────────────────────────────────
+# A removal is committed as a redo op riding the header; a later sync
+# materializes it into its block unit. Both halves are timed, because a
+# change that only moves work from the first into the second has shifted
+# cost rather than removed it.
+#
+# Ids are drawn from the ones still alive: re-drawing from the original
+# range would hit already-removed ids, and those calls are no-ops that
+# would quietly shrink the cell. The settle sync also returns the file to
+# an empty pending set each rep — repeating removals on an unsettled file
+# pushes carried ops past the header's 1024-op cap and falls back to a
+# full rewrite, which is a different measurement entirely.
+ix = fresh()
+pick = np.random.default_rng(7)
+alive = ids.copy()
+remove, settle = [], []
+for _ in range(REPS):
+    take = pick.choice(len(alive), size=N_REMOVE, replace=False)
+    for i in alive[take]:
+        ix.remove(int(i))
+    alive = np.delete(alive, take)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # commits the removals in the header
+    remove.append(time.perf_counter() - t0)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # materializes them into their units
+    settle.append(time.perf_counter() - t0)
+tv_sync_remove = median(remove)
+tv_sync_settle = median(settle)
+
+# No FAISS comparator: FAISS has no incremental save. `write_index` always
+# writes the whole index, which is what the sync_first cell measures and
+# what the speed_persist_* cells already compare against.
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm",
+          "threading": "mt",
+          "n_vectors": len(database),
+          "n_append": N_APPEND, "n_remove": N_REMOVE,
+          "tv_file_bytes": tv_file_bytes,
+          "tq_sync_first_ms": round(tv_sync_first * 1e3, 2),
+          "tq_sync_append_ms": round(tv_sync_append * 1e3, 2),
+          "tq_sync_remove_ms": round(tv_sync_remove * 1e3, 2),
+          "tq_sync_settle_ms": round(tv_sync_settle * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_sync_d1536_2bit_arm_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_sync_d1536_2bit_arm_st.py
+++ b/benchmarks/suite/speed_sync_d1536_2bit_arm_st.py
@@ -1,0 +1,127 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import atexit, shutil, time, json, os.path, tempfile
+import numpy as np
+from turbovec import IdMapIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND = 32
+N_REMOVE = 1_000
+REPS = 5
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_APPEND]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-sync-")
+# The container runs to hundreds of MB and the official machines run every
+# cell in a loop, so leaving them behind fills the root disk.
+atexit.register(shutil.rmtree, tmpdir, True)
+seed_path = os.path.join(tmpdir, "seed.tvim")
+tv_path = os.path.join(tmpdir, "index.tvim")
+
+def build():
+    idx = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add_with_ids(database, ids)
+    return idx
+
+build().write(seed_path)
+
+def fresh():
+    """A file already in v7 sync form, index bound to it, no pending ops."""
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    ix.sync(tv_path)
+    return ix
+
+def median(xs):
+    return sorted(xs)[len(xs) // 2]
+
+# ── First sync: the full write ──────────────────────────────────────────
+# `sync` converts a v6 file into the sync container by rewriting it whole,
+# so this cell costs what `write` costs. It is the reference the two
+# incremental cells below are worth reading against, and the gate that
+# stops an incremental win from being bought by making this slower.
+first = []
+for _ in range(REPS):
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    time.sleep(0.15)             # drain the device queue between fsyncs
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    first.append(time.perf_counter() - t0)
+tv_sync_first = median(first)
+tv_file_bytes = os.path.getsize(tv_path)
+
+# ── Append: 32 rows, one fresh block unit plus the commit header ────────
+ix = fresh()
+append = []
+for rep in range(REPS):
+    new_ids = np.arange(10_000_000 + rep * N_APPEND,
+                        10_000_000 + (rep + 1) * N_APPEND, dtype=np.uint64)
+    ix.add_with_ids(extra, new_ids)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    append.append(time.perf_counter() - t0)
+tv_sync_append = median(append)
+
+# ── Removal: 1000 scattered removals ────────────────────────────────────
+# A removal is committed as a redo op riding the header; a later sync
+# materializes it into its block unit. Both halves are timed, because a
+# change that only moves work from the first into the second has shifted
+# cost rather than removed it.
+#
+# Ids are drawn from the ones still alive: re-drawing from the original
+# range would hit already-removed ids, and those calls are no-ops that
+# would quietly shrink the cell. The settle sync also returns the file to
+# an empty pending set each rep — repeating removals on an unsettled file
+# pushes carried ops past the header's 1024-op cap and falls back to a
+# full rewrite, which is a different measurement entirely.
+ix = fresh()
+pick = np.random.default_rng(7)
+alive = ids.copy()
+remove, settle = [], []
+for _ in range(REPS):
+    take = pick.choice(len(alive), size=N_REMOVE, replace=False)
+    for i in alive[take]:
+        ix.remove(int(i))
+    alive = np.delete(alive, take)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # commits the removals in the header
+    remove.append(time.perf_counter() - t0)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # materializes them into their units
+    settle.append(time.perf_counter() - t0)
+tv_sync_remove = median(remove)
+tv_sync_settle = median(settle)
+
+# No FAISS comparator: FAISS has no incremental save. `write_index` always
+# writes the whole index, which is what the sync_first cell measures and
+# what the speed_persist_* cells already compare against.
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "arm",
+          "threading": "st",
+          "n_vectors": len(database),
+          "n_append": N_APPEND, "n_remove": N_REMOVE,
+          "tv_file_bytes": tv_file_bytes,
+          "tq_sync_first_ms": round(tv_sync_first * 1e3, 2),
+          "tq_sync_append_ms": round(tv_sync_append * 1e3, 2),
+          "tq_sync_remove_ms": round(tv_sync_remove * 1e3, 2),
+          "tq_sync_settle_ms": round(tv_sync_settle * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_sync_d1536_2bit_arm_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_sync_d1536_2bit_x86_mt.py
+++ b/benchmarks/suite/speed_sync_d1536_2bit_x86_mt.py
@@ -1,0 +1,126 @@
+import os
+import atexit, shutil, time, json, os.path, tempfile
+import numpy as np
+from turbovec import IdMapIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND = 32
+N_REMOVE = 1_000
+REPS = 5
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_APPEND]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-sync-")
+# The container runs to hundreds of MB and the official machines run every
+# cell in a loop, so leaving them behind fills the root disk.
+atexit.register(shutil.rmtree, tmpdir, True)
+seed_path = os.path.join(tmpdir, "seed.tvim")
+tv_path = os.path.join(tmpdir, "index.tvim")
+
+def build():
+    idx = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add_with_ids(database, ids)
+    return idx
+
+build().write(seed_path)
+
+def fresh():
+    """A file already in v7 sync form, index bound to it, no pending ops."""
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    ix.sync(tv_path)
+    return ix
+
+def median(xs):
+    return sorted(xs)[len(xs) // 2]
+
+# ── First sync: the full write ──────────────────────────────────────────
+# `sync` converts a v6 file into the sync container by rewriting it whole,
+# so this cell costs what `write` costs. It is the reference the two
+# incremental cells below are worth reading against, and the gate that
+# stops an incremental win from being bought by making this slower.
+first = []
+for _ in range(REPS):
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    time.sleep(0.15)             # drain the device queue between fsyncs
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    first.append(time.perf_counter() - t0)
+tv_sync_first = median(first)
+tv_file_bytes = os.path.getsize(tv_path)
+
+# ── Append: 32 rows, one fresh block unit plus the commit header ────────
+ix = fresh()
+append = []
+for rep in range(REPS):
+    new_ids = np.arange(10_000_000 + rep * N_APPEND,
+                        10_000_000 + (rep + 1) * N_APPEND, dtype=np.uint64)
+    ix.add_with_ids(extra, new_ids)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    append.append(time.perf_counter() - t0)
+tv_sync_append = median(append)
+
+# ── Removal: 1000 scattered removals ────────────────────────────────────
+# A removal is committed as a redo op riding the header; a later sync
+# materializes it into its block unit. Both halves are timed, because a
+# change that only moves work from the first into the second has shifted
+# cost rather than removed it.
+#
+# Ids are drawn from the ones still alive: re-drawing from the original
+# range would hit already-removed ids, and those calls are no-ops that
+# would quietly shrink the cell. The settle sync also returns the file to
+# an empty pending set each rep — repeating removals on an unsettled file
+# pushes carried ops past the header's 1024-op cap and falls back to a
+# full rewrite, which is a different measurement entirely.
+ix = fresh()
+pick = np.random.default_rng(7)
+alive = ids.copy()
+remove, settle = [], []
+for _ in range(REPS):
+    take = pick.choice(len(alive), size=N_REMOVE, replace=False)
+    for i in alive[take]:
+        ix.remove(int(i))
+    alive = np.delete(alive, take)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # commits the removals in the header
+    remove.append(time.perf_counter() - t0)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # materializes them into their units
+    settle.append(time.perf_counter() - t0)
+tv_sync_remove = median(remove)
+tv_sync_settle = median(settle)
+
+# No FAISS comparator: FAISS has no incremental save. `write_index` always
+# writes the whole index, which is what the sync_first cell measures and
+# what the speed_persist_* cells already compare against.
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86",
+          "threading": "mt",
+          "n_vectors": len(database),
+          "n_append": N_APPEND, "n_remove": N_REMOVE,
+          "tv_file_bytes": tv_file_bytes,
+          "tq_sync_first_ms": round(tv_sync_first * 1e3, 2),
+          "tq_sync_append_ms": round(tv_sync_append * 1e3, 2),
+          "tq_sync_remove_ms": round(tv_sync_remove * 1e3, 2),
+          "tq_sync_settle_ms": round(tv_sync_settle * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_sync_d1536_2bit_x86_mt.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/benchmarks/suite/speed_sync_d1536_2bit_x86_st.py
+++ b/benchmarks/suite/speed_sync_d1536_2bit_x86_st.py
@@ -1,0 +1,127 @@
+import os
+os.environ["RAYON_NUM_THREADS"] = "1"
+import atexit, shutil, time, json, os.path, tempfile
+import numpy as np
+from turbovec import IdMapIndex
+
+DATA_DIR = os.path.expanduser("~/data/py-turboquant")
+DIM, BIT_WIDTH = 1536, 2
+N_APPEND = 32
+N_REMOVE = 1_000
+REPS = 5
+
+def load_openai(dim, seed=42):
+    all_vecs = np.load(os.path.join(DATA_DIR, f"openai-{dim}.npy"))
+    rng = np.random.RandomState(seed)
+    idx = rng.permutation(len(all_vecs))
+    database = all_vecs[idx[:100_000]]
+    extra = all_vecs[idx[100_000:100_000 + N_APPEND]]
+    database /= np.linalg.norm(database, axis=-1, keepdims=True)
+    extra /= np.linalg.norm(extra, axis=-1, keepdims=True)
+    return database, extra
+
+database, extra = load_openai(DIM)
+ids = np.arange(len(database), dtype=np.uint64)
+
+tmpdir = tempfile.mkdtemp(prefix="tv-sync-")
+# The container runs to hundreds of MB and the official machines run every
+# cell in a loop, so leaving them behind fills the root disk.
+atexit.register(shutil.rmtree, tmpdir, True)
+seed_path = os.path.join(tmpdir, "seed.tvim")
+tv_path = os.path.join(tmpdir, "index.tvim")
+
+def build():
+    idx = IdMapIndex(dim=DIM, bit_width=BIT_WIDTH)
+    idx.add_with_ids(database, ids)
+    return idx
+
+build().write(seed_path)
+
+def fresh():
+    """A file already in v7 sync form, index bound to it, no pending ops."""
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    ix.sync(tv_path)
+    return ix
+
+def median(xs):
+    return sorted(xs)[len(xs) // 2]
+
+# ── First sync: the full write ──────────────────────────────────────────
+# `sync` converts a v6 file into the sync container by rewriting it whole,
+# so this cell costs what `write` costs. It is the reference the two
+# incremental cells below are worth reading against, and the gate that
+# stops an incremental win from being bought by making this slower.
+first = []
+for _ in range(REPS):
+    shutil.copyfile(seed_path, tv_path)
+    ix = IdMapIndex.load(tv_path)
+    time.sleep(0.15)             # drain the device queue between fsyncs
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    first.append(time.perf_counter() - t0)
+tv_sync_first = median(first)
+tv_file_bytes = os.path.getsize(tv_path)
+
+# ── Append: 32 rows, one fresh block unit plus the commit header ────────
+ix = fresh()
+append = []
+for rep in range(REPS):
+    new_ids = np.arange(10_000_000 + rep * N_APPEND,
+                        10_000_000 + (rep + 1) * N_APPEND, dtype=np.uint64)
+    ix.add_with_ids(extra, new_ids)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)
+    append.append(time.perf_counter() - t0)
+tv_sync_append = median(append)
+
+# ── Removal: 1000 scattered removals ────────────────────────────────────
+# A removal is committed as a redo op riding the header; a later sync
+# materializes it into its block unit. Both halves are timed, because a
+# change that only moves work from the first into the second has shifted
+# cost rather than removed it.
+#
+# Ids are drawn from the ones still alive: re-drawing from the original
+# range would hit already-removed ids, and those calls are no-ops that
+# would quietly shrink the cell. The settle sync also returns the file to
+# an empty pending set each rep — repeating removals on an unsettled file
+# pushes carried ops past the header's 1024-op cap and falls back to a
+# full rewrite, which is a different measurement entirely.
+ix = fresh()
+pick = np.random.default_rng(7)
+alive = ids.copy()
+remove, settle = [], []
+for _ in range(REPS):
+    take = pick.choice(len(alive), size=N_REMOVE, replace=False)
+    for i in alive[take]:
+        ix.remove(int(i))
+    alive = np.delete(alive, take)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # commits the removals in the header
+    remove.append(time.perf_counter() - t0)
+    time.sleep(0.15)
+    t0 = time.perf_counter()
+    ix.sync(tv_path)             # materializes them into their units
+    settle.append(time.perf_counter() - t0)
+tv_sync_remove = median(remove)
+tv_sync_settle = median(settle)
+
+# No FAISS comparator: FAISS has no incremental save. `write_index` always
+# writes the whole index, which is what the sync_first cell measures and
+# what the speed_persist_* cells already compare against.
+result = {"dim": DIM, "bit_width": BIT_WIDTH, "arch": "x86",
+          "threading": "st",
+          "n_vectors": len(database),
+          "n_append": N_APPEND, "n_remove": N_REMOVE,
+          "tv_file_bytes": tv_file_bytes,
+          "tq_sync_first_ms": round(tv_sync_first * 1e3, 2),
+          "tq_sync_append_ms": round(tv_sync_append * 1e3, 2),
+          "tq_sync_remove_ms": round(tv_sync_remove * 1e3, 2),
+          "tq_sync_settle_ms": round(tv_sync_settle * 1e3, 2)}
+out = os.path.join(os.path.dirname(__file__), "..", "results",
+                   "speed_sync_d1536_2bit_x86_st.json")
+os.makedirs(os.path.dirname(out), exist_ok=True)
+json.dump(result, open(out, "w"), indent=2)
+print(json.dumps(result, indent=2))

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -1547,6 +1547,27 @@ mod tests {
                 geo.unit_len(),
                 "unit stride"
             );
+            // The probe read `cursor_state` opens a sync with. Pinned by
+            // formula AND by what it has to cover, because it is a hint:
+            // too short is still *correct* (the parse fails and the read
+            // widens to the full slot), it just silently gives up the
+            // optimization. Only the second assert notices that.
+            assert_eq!(
+                geo.hdr_probe_len(),
+                16 + 31 * tail_row + 4 + 4 + MAX_OPS * 4 + 12 + 4,
+                "header probe"
+            );
+            let op_free_used = 16 + 31 * tail_row + 4 + 4 + MAX_OPS * 4 + 12 + 4;
+            assert!(
+                geo.hdr_probe_len() >= op_free_used,
+                "the probe must cover a commit with no pending ops — the \
+                 steady state both objective cells sit in — or every sync \
+                 pays the widening read it exists to avoid",
+            );
+            assert!(
+                geo.hdr_probe_len() < geo.hdr_len(),
+                "a probe that is not smaller than the slot saves nothing",
+            );
         }
     }
 }

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -1195,6 +1195,30 @@ pub(crate) fn cursor_state(
     .flatten()
     .collect();
     cands.sort_by_key(|h| std::cmp::Reverse(h.gen));
+    // The cursor's own commit, still the newest header on the file, needs no
+    // delta re-read: it was verified when the cursor was established, and
+    // nothing since could have unverified it.
+    //
+    // A cursor is established exactly two ways. Either this process wrote
+    // that commit — and `sync` returns Ok only after `sync_all` reports the
+    // batch durable, so its units are on stable storage — or `load` adopted
+    // it, and `load` selects a commit by running this very delta check. The
+    // nonce matched above, so this is that same file; a newest header at the
+    // cursor's generation is therefore the newest adoptable commit, which is
+    // what Intact means. Re-reading every unit the last sync wrote to prove
+    // that again costs the whole delta on the way into the next sync — 12.6
+    // MB of read and CRC after a 1000-removal settle, three quarters of that
+    // sync's cost.
+    //
+    // Any other generation still takes the full verifying walk below: a
+    // newer header means someone else advanced the file, and deciding
+    // Foreign vs Intact there does require knowing whether their data
+    // landed. This shortcut only ever skips work for a commit already
+    // proven, and in the unsupported concurrent-writer case it errs toward
+    // refusing rather than adopting.
+    if cands.first().is_some_and(|h| h.gen == cursor.gen) {
+        return Ok(CursorState::Intact);
+    }
     let mut adoptable: Option<u64> = None;
     for h in &cands {
         let verified = delta_verified(h, |b, out| {

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -281,10 +281,6 @@ impl Geo {
     fn op_size(&self) -> usize {
         1 + self.row_bytes() + 4 + self.id_bytes(1)
     }
-    /// One header slot's fixed capacity: gen, n, tail (31 rows), the
-    /// pending-op groups, CRC. Writes and parses cover only the used
-    /// prefix — every length inside is derivable from `n` and the group
-    /// counts, so a small sync writes a small header.
     /// Bytes of a header slot that a commit carrying no pending redo ops
     /// can possibly use: the fixed fields, a full tail block, the delta
     /// descriptor, and the CRC — everything except the op-group region.
@@ -303,6 +299,10 @@ impl Geo {
             + 12
             + 4
     }
+    /// One header slot's fixed capacity: gen, n, tail (31 rows), the
+    /// pending-op groups, CRC. Writes and parses cover only the used
+    /// prefix — every length inside is derivable from `n` and the group
+    /// counts, so a small sync writes a small header.
     pub fn hdr_len(&self) -> usize {
         16 + 31 * (self.row_bytes() + 4 + self.id_bytes(1))
             + 4
@@ -1229,6 +1229,11 @@ pub(crate) fn cursor_state(
         let mut want = geo.hdr_probe_len().min(avail);
         loop {
             let mut buf = vec![0u8; want];
+            // An I/O error reads as "no candidate in this slot": if the
+            // OTHER slot still parses, the verdict can be Foreign — a
+            // misdiagnosis for a transient read fault — but the cursor
+            // stays bound, so a retry re-reads and self-heals; if both
+            // fail, Replaced forces the protective full rewrite.
             f.seek(SeekFrom::Start(at as u64)).ok()?;
             f.read_exact(&mut buf).ok()?;
             if let Some(h) = parse_header_at(&buf, at, geo, slot, file_len) {

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -1259,7 +1259,13 @@ pub(crate) fn cursor_state(
     // it, and `load` selects a commit by running this very delta check. The
     // nonce matched above, so this is that same file; a newest header at the
     // cursor's generation is therefore the newest adoptable commit, which is
-    // what Intact means. Re-reading every unit the last sync wrote to prove
+    // what Intact means. (One stated narrowing: damage from OUTSIDE the
+    // writer landing on the cursor's own units after establishment was
+    // previously caught here by the re-read and answered with a full
+    // rewrite; it now syncs forward unnoticed. Out-of-writer damage is
+    // explicitly out of scope for blocks — same stance as v6 and load —
+    // so the skip trades a defense the format never promised.)
+    // Re-reading every unit the last sync wrote to prove
     // that again costs the whole delta on the way into the next sync — 12.6
     // MB of read and CRC after a 1000-removal settle, three quarters of that
     // sync's cost.
@@ -1557,12 +1563,14 @@ mod tests {
                 16 + 31 * tail_row + 4 + 4 + MAX_OPS * 4 + 12 + 4,
                 "header probe"
             );
-            let op_free_used = 16 + 31 * tail_row + 4 + 4 + MAX_OPS * 4 + 12 + 4;
-            assert!(
-                geo.hdr_probe_len() >= op_free_used,
-                "the probe must cover a commit with no pending ops — the \
-                 steady state both objective cells sit in — or every sync \
-                 pays the widening read it exists to avoid",
+            // Independently derived: the probe minus the full slot's op
+            // region must be exactly the op region's size — i.e. the
+            // probe concedes ONLY the op groups, never tail rows or the
+            // delta descriptor an op-free commit still carries.
+            assert_eq!(
+                geo.hdr_len() - geo.hdr_probe_len(),
+                MAX_OPS * (5 + geo.op_size()),
+                "the probe must give up exactly the op-group region",
             );
             assert!(
                 geo.hdr_probe_len() < geo.hdr_len(),

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -285,6 +285,24 @@ impl Geo {
     /// pending-op groups, CRC. Writes and parses cover only the used
     /// prefix — every length inside is derivable from `n` and the group
     /// counts, so a small sync writes a small header.
+    /// Bytes of a header slot that a commit carrying no pending redo ops
+    /// can possibly use: the fixed fields, a full tail block, the delta
+    /// descriptor, and the CRC — everything except the op-group region.
+    ///
+    /// A slot is *sized* for the 1024-op cap (~428 KB at dim 768), but the
+    /// steady state — an append, or any sync following one that
+    /// materialized its ops — carries none, and then this is the whole
+    /// used prefix. Reading this much and widening only when the parse
+    /// needs more turns a ~856 KB read on the way into every sync into a
+    /// ~16 KB one.
+    pub fn hdr_probe_len(&self) -> usize {
+        16 + 31 * (self.row_bytes() + 4 + self.id_bytes(1))
+            + 4
+            + 4
+            + MAX_OPS * 4
+            + 12
+            + 4
+    }
     pub fn hdr_len(&self) -> usize {
         16 + 31 * (self.row_bytes() + 4 + self.id_bytes(1))
             + 4
@@ -814,16 +832,33 @@ struct ParsedHdr {
 /// Shared by the loader and `cursor_state`, so "newest valid header"
 /// means the same thing everywhere.
 fn parse_header_slot(raw: &[u8], geo: &Geo, slot: usize, file_len: usize) -> Option<ParsedHdr> {
-    let hdr_len = geo.hdr_len();
+    let at = geo.hdr_at(slot);
+    let bytes = raw.get(at..at + geo.hdr_len())?;
+    parse_header_at(bytes, at, geo, slot, file_len)
+}
+
+/// Parse one header slot from `bytes`, the slot's own bytes beginning at
+/// absolute file offset `at`.
+///
+/// `bytes` may be a prefix of the slot rather than all of it. Every field
+/// is read through a bounds-checked `get`, so a header whose used prefix
+/// fits parses normally and one that needs more returns `None` — which is
+/// what lets `cursor_state` read kilobytes instead of the slot's full
+/// op-capacity and widen only when it must.
+fn parse_header_at(
+    bytes: &[u8],
+    at: usize,
+    geo: &Geo,
+    slot: usize,
+    file_len: usize,
+) -> Option<ParsedHdr> {
     let tail_row = geo.row_bytes() + 4 + geo.id_bytes(1);
     let op_size = geo.op_size();
-    let at = geo.hdr_at(slot);
-    let bytes = raw.get(at..at + hdr_len)?;
-    let gen = u64::from_le_bytes(bytes[..8].try_into().unwrap());
+    let gen = u64::from_le_bytes(bytes.get(..8)?.try_into().unwrap());
     if (gen % 2) as usize != slot {
         return None;
     }
-    let n64 = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    let n64 = u64::from_le_bytes(bytes.get(8..16)?.try_into().unwrap());
     let n = usize::try_from(n64).ok()?;
     let units_end = (n / BLOCK)
         .checked_mul(geo.unit_len())
@@ -874,7 +909,7 @@ fn parse_header_slot(raw: &[u8], geo: &Geo, slot: usize, file_len: usize) -> Opt
     let delta_crc = u32::from_le_bytes(bytes.get(p + 8..p + 12)?.try_into().unwrap());
     p += 12;
     let stored = u32::from_le_bytes(bytes.get(p..p + 4)?.try_into().unwrap());
-    if crc32(&bytes[..p]) != stored {
+    if crc32(bytes.get(..p)?) != stored {
         return None;
     }
     Some(ParsedHdr {
@@ -1181,19 +1216,37 @@ pub(crate) fn cursor_state(
     // The nonce matched, so this is the file this cursor wrote and the
     // caller's geometry is its geometry. Read the header region and
     // select exactly as the loader does.
-    let prefix_len = geo.unit_at(0).min(file_len);
-    let mut prefix = vec![0u8; prefix_len];
-    f.seek(SeekFrom::Start(0))?;
-    if f.read_exact(&mut prefix).is_err() {
-        return Ok(CursorState::Replaced);
-    }
-    let mut cands: Vec<ParsedHdr> = [
-        parse_header_slot(&prefix, geo, 0, file_len),
-        parse_header_slot(&prefix, geo, 1, file_len),
-    ]
-    .into_iter()
-    .flatten()
-    .collect();
+    // Read each slot's used prefix, not the whole slot. Slots are sized
+    // for the 1024-op cap, so reading both in full costs ~856 KB on the
+    // way into every sync — including a 32-row append whose entire commit
+    // is ~12 KB. A commit with no pending ops fits in `hdr_probe_len`;
+    // only one carrying ops needs the rest, and then it pays for the
+    // second read once.
+    let mut read_slot = |slot: usize| -> Option<ParsedHdr> {
+        let at = geo.hdr_at(slot);
+        let avail = file_len.checked_sub(at)?;
+        let mut want = geo.hdr_probe_len().min(avail);
+        loop {
+            let mut buf = vec![0u8; want];
+            f.seek(SeekFrom::Start(at as u64)).ok()?;
+            f.read_exact(&mut buf).ok()?;
+            if let Some(h) = parse_header_at(&buf, at, geo, slot, file_len) {
+                return Some(h);
+            }
+            // Either the header genuinely does not parse, or it carries
+            // ops and outgrew the probe. Widen once to the full slot; a
+            // second failure is a real one.
+            let full = geo.hdr_len().min(avail);
+            if want >= full {
+                return None;
+            }
+            want = full;
+        }
+    };
+    let mut cands: Vec<ParsedHdr> = [read_slot(0), read_slot(1)]
+        .into_iter()
+        .flatten()
+        .collect();
     cands.sort_by_key(|h| std::cmp::Reverse(h.gen));
     // The cursor's own commit, still the newest header on the file, needs no
     // delta re-read: it was verified when the cursor was established, and

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -372,8 +372,9 @@ pub(crate) struct SyncSource<'a> {
     /// Sequential-blocked codes for whole blocks `[from, to)` (row
     /// indexes, multiples of 32).
     pub seq_blocks: &'a dyn Fn(usize, usize) -> Vec<u8>,
-    /// One row's sequential codes (tail rows).
-    pub row_codes: &'a dyn Fn(usize) -> Vec<u8>,
+    /// Append one row's sequential codes to the buffer (tail rows
+    /// and redo ops).
+    pub row_codes: &'a dyn Fn(usize, &mut Vec<u8>),
     pub scales: &'a [f32],
     /// slot → external id; `Some` iff kind 1.
     pub ids: Option<&'a [u64]>,
@@ -448,7 +449,7 @@ fn header_slot(
     h.extend_from_slice(&(n as u64).to_le_bytes());
     for k in 0..n_tail {
         let r = first_tail + k;
-        h.extend_from_slice(&(src.row_codes)(r));
+        (src.row_codes)(r, &mut h);
         h.extend_from_slice(&src.scales[r].to_le_bytes());
         if let Some(ids) = src.ids {
             h.extend_from_slice(&ids[r].to_le_bytes());
@@ -460,7 +461,7 @@ fn header_slot(
         h.push(slots.len() as u8);
         for &s in slots {
             h.push((s % BLOCK) as u8);
-            h.extend_from_slice(&(src.row_codes)(s));
+            (src.row_codes)(s, &mut h);
             h.extend_from_slice(&src.scales[s].to_le_bytes());
             if let Some(ids) = src.ids {
                 h.extend_from_slice(&ids[s].to_le_bytes());

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1438,19 +1438,20 @@ impl TurboQuantIndex {
     /// the blocked cache authoritative, and consulting one afterwards is
     /// what would let a re-calibration's re-encoding be read through a
     /// stale row. Built in capture order so a slot captured twice resolves
-    /// to its later bytes, and entries are contiguous, so each length is
-    /// the next entry's offset.
+    /// to its later bytes. Every capture is exactly one lane —
+    /// `n_byte_groups` for this geometry — so lengths are uniform and
+    /// retiring an entry (swap_remove dropping a stale slot) leaves the
+    /// rest valid; the arena may hold dead byte ranges between syncs.
     fn capture_lookup(&self) -> std::collections::HashMap<usize, (usize, usize)> {
         if self.packed_codes.get().is_some() || self.sync_capture_at.is_empty() {
             return std::collections::HashMap::new();
         }
+        let dim = self.dim.expect("captures exist, so dim is committed");
+        let (_, n_byte_groups, _) =
+            pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
         let mut m = std::collections::HashMap::with_capacity(self.sync_capture_at.len());
-        for (i, &(slot, off)) in self.sync_capture_at.iter().enumerate() {
-            let end = match self.sync_capture_at.get(i + 1) {
-                Some(&(_, next)) => next as usize,
-                None => self.sync_capture_buf.len(),
-            };
-            m.insert(slot as usize, (off as usize, end - off as usize));
+        for &(slot, off) in &self.sync_capture_at {
+            m.insert(slot as usize, (off as usize, n_byte_groups));
         }
         m
     }
@@ -1738,6 +1739,11 @@ impl TurboQuantIndex {
             Err(e) => {
                 self.sync_cursor = None;
                 self.sync_path = None;
+                // The captures were taken for the plan that just failed;
+                // the next sync full-writes from live state, so stale
+                // arena entries must not outlive the binding.
+                self.sync_capture_buf.clear();
+                self.sync_capture_at.clear();
                 Err(e)
             }
         }
@@ -2968,11 +2974,17 @@ impl TurboQuantIndex {
             cache.data.truncate(new_n_blocks * block_bytes);
             cache.n_blocks = new_n_blocks;
         }
-        // No entry is retired here: `last` is now beyond `n_vectors`, and the
-        // only readers — the header's tail rows and the plan's live op slots
-        // — are both below it, so an entry left for a retired slot is
-        // unreachable rather than wrong. The lookup is built in capture
-        // order, so a slot captured twice resolves to its later bytes.
+        // Retire stale entries before recording the new state. Two slots
+        // changed meaning: `idx` now holds the moved row (any older entry
+        // for it describes dead bytes — and would win the lookup if this
+        // removal is NOT captured, e.g. past MAX_OPS), and `last` is
+        // beyond `n_vectors` but can be refilled by a later add, which
+        // must then read the live row, not a leftover capture. This is
+        // what lets `encode_and_append` assert instead of sweep.
+        if !self.sync_capture_at.is_empty() {
+            self.sync_capture_at
+                .retain(|&(s, _)| s as usize != idx && s as usize != last);
+        }
         if capture_this && idx != last {
             self.sync_capture_at.push((idx as u32, capture_off as u32));
         }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -765,11 +765,10 @@ impl TurboQuantIndex {
         // asserted rather than re-swept, since a sweep here would be dead
         // code that reads as though it were load-bearing.
         debug_assert!(
-            (self.n_vectors..self.n_vectors + n)
-                .all(|slot| !self
-                    .sync_capture_at
-                    .iter()
-                    .any(|&(s, _)| s as usize == slot)),
+            self.sync_capture_at.iter().all(|&(s, _)| {
+                let s = s as usize;
+                s < self.n_vectors || s >= self.n_vectors + n
+            }),
             "a slot about to be written by add still holds a removal capture",
         );
         let rotation = self
@@ -2911,19 +2910,35 @@ impl TurboQuantIndex {
         // implies self.dim was committed at that point. Unwrap is safe.
         let dim = self.dim.expect("n_vectors > 0 but dim is None");
         let bytes_per_vec = dim * self.bit_width / 8;
-        // The cap gates on the ARENA'S BYTES, not the entry count:
-        // retirement shrinks the entry list, so an entry-count gate
-        // re-opens every time a slot is re-dirtied and the arena grows
-        // without bound across the window. Bytes only ever grow until a
-        // sync or calibrate clears them, so this bound is monotone —
-        // MAX_OPS lanes' worth, the most a header can carry anyway.
+        // Capture placement. A slot being re-captured reuses its retired
+        // entry's byte range (lanes are uniform per geometry), so slot
+        // churn recycles in place instead of growing — without this,
+        // heavy churn fills the arena with dead bytes, the cap closes,
+        // and the hottest slots lose their captures for the rest of the
+        // window. Fresh slots append, gated on the ARENA'S BYTES, not
+        // the entry count: retirement shrinks the entry list, so an
+        // entry-count gate would re-open on every re-dirtied slot and
+        // the arena would grow without bound. Bytes only grow until a
+        // sync or calibrate clears them — bounded at MAX_OPS lanes, the
+        // most a header can carry anyway.
         let (_, capture_lane, _) = pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
-        let capture_this = cfg!(target_arch = "x86_64")
+        let capture_reuse = self
+            .sync_capture_at
+            .iter()
+            .find(|&&(s, _)| s as usize == idx)
+            .map(|&(_, off)| off as usize);
+        let capture_at = if cfg!(target_arch = "x86_64")
             && self.sync_cursor.is_some()
             && idx < self.sync_watermark()
             && self.packed_codes.get().is_none()
-            && self.sync_capture_buf.len() < io_v7::MAX_OPS * capture_lane;
-        let capture_off = self.sync_capture_buf.len();
+        {
+            capture_reuse.or_else(|| {
+                let off = self.sync_capture_buf.len();
+                (off < io_v7::MAX_OPS * capture_lane).then_some(off)
+            })
+        } else {
+            None
+        };
 
         let last = self.n_vectors - 1;
         // At least one code representation must exist, or the branches
@@ -2974,13 +2989,12 @@ impl TurboQuantIndex {
                 // the sync does not walk the block again to recover them.
                 // Written straight into the arena — `cache` and the capture
                 // buffer are separate fields, so both borrows stand.
-                let dst = if capture_this {
-                    let off = capture_buf.len();
-                    capture_buf.resize(off + n_byte_groups, 0);
-                    Some(&mut capture_buf[off..])
-                } else {
-                    None
-                };
+                let dst = capture_at.map(|off| {
+                    if capture_buf.len() < off + n_byte_groups {
+                        capture_buf.resize(off + n_byte_groups, 0);
+                    }
+                    &mut capture_buf[off..]
+                });
                 pack::move_lane(&mut cache.data, n_byte_groups, last, idx, dst);
             }
             pack::zero_lane(&mut cache.data, n_byte_groups, last);
@@ -2998,8 +3012,10 @@ impl TurboQuantIndex {
             self.sync_capture_at
                 .retain(|&(s, _)| s as usize != idx && s as usize != last);
         }
-        if capture_this && idx != last {
-            self.sync_capture_at.push((idx as u32, capture_off as u32));
+        if idx != last {
+            if let Some(off) = capture_at {
+                self.sync_capture_at.push((idx as u32, off as u32));
+            }
         }
 
         last
@@ -3862,6 +3878,10 @@ mod v7_delta_tests {
         idx.calibrate(&rows(1024, 61)).unwrap();
         idx.add(&rows(96, 62));
         idx.sync(&path).unwrap();
+        // Reload: captures only engage on a loaded index (blocked cache
+        // authoritative, packed unset) — built fresh, packed is live and
+        // the gate never opens, making every assertion below vacuous.
+        let mut idx = TurboQuantIndex::load(&path).unwrap();
         let lane = DIM / 2; // 4-bit: dim / (8/bits)
         for i in 0..3 * io_v7::MAX_OPS {
             idx.swap_remove(5);
@@ -3871,6 +3891,10 @@ mod v7_delta_tests {
                 "arena exceeded its bound at churn round {i}"
             );
         }
+        assert!(
+            idx.captured_len_for_test() > 0,
+            "the churn never engaged the capture path — vacuous test"
+        );
         idx.sync(&path).unwrap();
         let loaded = TurboQuantIndex::load(&path).unwrap();
         assert_eq!(loaded.to_bytes(), idx.to_bytes());

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -363,6 +363,24 @@ pub struct TurboQuantIndex {
     /// either materializes them (their live bytes ARE the committed
     /// bytes) or carries them forward if their unit got dirtied again.
     sync_pending: std::collections::HashSet<usize>,
+    /// Sequential code bytes for slots `swap_remove` dirtied since the
+    /// last sync, captured at the move that already had them in hand, laid
+    /// end to end. Paired with `sync_capture_at`.
+    ///
+    /// A cache, nothing more: header assembly falls back to reading the row
+    /// when a slot is absent, so correctness never depends on an entry
+    /// existing — only on an entry that exists being right.
+    ///
+    /// One arena and one push per removal, rather than a map of owned rows:
+    /// the bytes are free at the move, but a `Vec` allocation and a hash per
+    /// removal are not, and they land on `remove()` where nothing asks for
+    /// them.
+    sync_capture_buf: Vec<u8>,
+    /// `(slot, offset)` into `sync_capture_buf`, in capture order — so for a
+    /// slot captured twice the later entry wins when the lookup is built.
+    /// Length is capped at the header's op cap, past which a sync rewrites
+    /// the file whole and needs no ops at all.
+    sync_capture_at: Vec<(u32, u32)>,
     /// Disk-committed slots dirtied since the last sync. No value is
     /// captured — a redo op is an absolute write, so the live row at
     /// plan time is the op.
@@ -573,6 +591,8 @@ impl TurboQuantIndex {
             sync_path: None,
             sync_pending: std::collections::HashSet::new(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
         })
     }
@@ -605,6 +625,8 @@ impl TurboQuantIndex {
             sync_path: None,
             sync_pending: std::collections::HashSet::new(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
         })
     }
@@ -735,6 +757,21 @@ impl TurboQuantIndex {
     /// committing) a fresh one otherwise. Assumes the caller has already
     /// validated `vectors` and resolved `dim`.
     fn encode_and_append(&mut self, vectors: &[f32], n: usize, dim: usize) {
+        // Rows land at slots [n_vectors, n_vectors + n), and none of them
+        // can carry a capture. A capture is only taken for a slot below
+        // n_vectors, and n_vectors only ever falls through `swap_remove`,
+        // which drops the capture for the slot it retires. So by the time
+        // a slot is free for an add to write, its entry is already gone —
+        // asserted rather than re-swept, since a sweep here would be dead
+        // code that reads as though it were load-bearing.
+        debug_assert!(
+            (self.n_vectors..self.n_vectors + n)
+                .all(|slot| !self
+                    .sync_capture_at
+                    .iter()
+                    .any(|&(s, _)| s as usize == slot)),
+            "a slot about to be written by add still holds a removal capture",
+        );
         let rotation = self
             .rotation
             .get_or_init(|| rotation::Rotation::new(dim));
@@ -1381,6 +1418,29 @@ impl TurboQuantIndex {
             .unwrap_or(0)
     }
 
+    /// slot -> (offset, len) into `sync_capture_buf`, built once per sync.
+    ///
+    /// Empty when `packed_codes` is live: a capture is only ever taken with
+    /// the blocked cache authoritative, and consulting one afterwards is
+    /// what would let a re-calibration's re-encoding be read through a
+    /// stale row. Built in capture order so a slot captured twice resolves
+    /// to its later bytes, and entries are contiguous, so each length is
+    /// the next entry's offset.
+    fn capture_lookup(&self) -> std::collections::HashMap<usize, (usize, usize)> {
+        if self.packed_codes.get().is_some() || self.sync_capture_at.is_empty() {
+            return std::collections::HashMap::new();
+        }
+        let mut m = std::collections::HashMap::with_capacity(self.sync_capture_at.len());
+        for (i, &(slot, off)) in self.sync_capture_at.iter().enumerate() {
+            let end = match self.sync_capture_at.get(i + 1) {
+                Some(&(_, next)) => next as usize,
+                None => self.sync_capture_buf.len(),
+            };
+            m.insert(slot as usize, (off as usize, end - off as usize));
+        }
+        m
+    }
+
     /// Mark a disk-committed slot as diverged. No bytes are captured —
     /// the redo op serialized at the next sync reads the live row.
     fn mark_dirty(&mut self, slot: usize) {
@@ -1403,7 +1463,15 @@ impl TurboQuantIndex {
             let _ = self.centroids.set(c);
         }
         let seq_blocks = |from: usize, to: usize| self.seq_blocks_range(from, to);
-        let row_codes = |idx: usize| self.seq_row(idx);
+        let capture_lookup = self.capture_lookup();
+        let row_codes = |idx: usize, out: &mut Vec<u8>| {
+            match capture_lookup.get(&idx) {
+                Some(&(off, len)) => {
+                    out.extend_from_slice(&self.sync_capture_buf[off..off + len])
+                }
+                None => out.extend_from_slice(&self.seq_row(idx)),
+            }
+        };
         let source = io_v7::SyncSource {
             kind,
             dim,
@@ -1585,7 +1653,15 @@ impl TurboQuantIndex {
         }
         let result = {
             let seq_blocks = |from: usize, to: usize| self.seq_blocks_range(from, to);
-            let row_codes = |idx: usize| self.seq_row(idx);
+            let capture_lookup = self.capture_lookup();
+            let row_codes = |idx: usize, out: &mut Vec<u8>| {
+                match capture_lookup.get(&idx) {
+                    Some(&(off, len)) => {
+                        out.extend_from_slice(&self.sync_capture_buf[off..off + len])
+                    }
+                    None => out.extend_from_slice(&self.seq_row(idx)),
+                }
+            };
             let source = io_v7::SyncSource {
                 kind,
                 dim,
@@ -1627,6 +1703,8 @@ impl TurboQuantIndex {
             Ok((cursor, carried)) => {
                 self.sync_pending = carried.into_iter().collect();
                 self.sync_fresh.clear();
+                self.sync_capture_buf.clear();
+                self.sync_capture_at.clear();
                 self.sync_cursor = Some(io_v7::SyncCursor {
                     calib_gen: self.calib_gen,
                     ..cursor
@@ -1707,6 +1785,8 @@ impl TurboQuantIndex {
             sync_path: Some(path.to_path_buf()),
             sync_pending: l.pending_slots.iter().copied().collect(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
         })
     }
@@ -2079,6 +2159,8 @@ impl TurboQuantIndex {
             sync_path: None,
             sync_pending: std::collections::HashSet::new(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
                     rotation: OnceLock::new(),
                     boundaries: boundaries_lock,
@@ -2134,6 +2216,8 @@ impl TurboQuantIndex {
             sync_path: None,
             sync_pending: std::collections::HashSet::new(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
                     rotation: OnceLock::new(),
                     boundaries: boundaries_lock,
@@ -2411,6 +2495,8 @@ impl TurboQuantIndex {
             sync_path: None,
             sync_pending: std::collections::HashSet::new(),
             sync_fresh: std::collections::HashSet::new(),
+            sync_capture_buf: Vec::new(),
+            sync_capture_at: Vec::new(),
             calib_gen: 0,
         })
     }
@@ -2611,6 +2697,10 @@ impl TurboQuantIndex {
         // so a synced file's segments are stale: force the next sync to
         // compact.
         self.calib_gen += 1;
+        // Re-encoding changes every row's bytes, so every captured row now
+        // describes the old encoding.
+        self.sync_capture_buf.clear();
+        self.sync_capture_at.clear();
         Ok(())
     }
 
@@ -2775,6 +2865,28 @@ impl TurboQuantIndex {
                 self.mark_dirty(last);
             }
         }
+        // Capture slot `idx`'s incoming bytes only where they will actually
+        // be serialized as a redo op: the slot must be one this file has
+        // committed (the same test `mark_dirty` applies), the blocked cache
+        // must be the authority (with `packed_codes` live, header assembly
+        // reads the contiguous packed row instead and the capture would be
+        // dead weight), and the map stays under the header's op cap — past
+        // it the sync rewrites the file whole and needs no ops at all.
+        // x86 only, and not as a portability hedge — as arithmetic. The
+        // capture adds one store per byte group to the lane move. On x86 the
+        // move is a de-interleave plus a nibble-merge write, so one more
+        // store is a small fraction of it and the sync saves far more than
+        // the removals pay. Off x86 the move IS a byte load and a byte
+        // store, so capturing is a third memory op on a two-op loop — a ~50%
+        // tax on `remove()` to save less than that in `sync()`. Measured
+        // both ways (H5-H7): the ARM side never nets out.
+        let capture_this = cfg!(target_arch = "x86_64")
+            && self.sync_cursor.is_some()
+            && idx < self.sync_watermark()
+            && self.packed_codes.get().is_none()
+            && self.sync_capture_at.len() < io_v7::MAX_OPS;
+        let capture_off = self.sync_capture_buf.len();
+
 
         // n_vectors > 0 (asserted above) implies a successful add, which
         // implies self.dim was committed at that point. Unwrap is safe.
@@ -2816,16 +2928,39 @@ impl TurboQuantIndex {
         // vector's lane into the vacated slot, zero the vacated last lane
         // (serialization copies the cache verbatim — a stale lane would
         // break byte determinism), then truncate to the new geometry.
+        // Borrowed alongside the blocked cache: both are fields of `self`,
+        // so the two mutable borrows are disjoint.
+        let capture_buf = &mut self.sync_capture_buf;
         if let Some(cache) = self.blocked.get_mut() {
             let (new_n_blocks, n_byte_groups, _) =
                 pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
             let block_bytes = n_byte_groups * BLOCK;
             if idx != last {
-                pack::move_lane(&mut cache.data, n_byte_groups, last, idx);
+                // The move already computes slot `idx`'s new code bytes; keep
+                // them when this removal will be serialized as a redo op, so
+                // the sync does not walk the block again to recover them.
+                // Written straight into the arena — `cache` and the capture
+                // buffer are separate fields, so both borrows stand.
+                let dst = if capture_this {
+                    let off = capture_buf.len();
+                    capture_buf.resize(off + n_byte_groups, 0);
+                    Some(&mut capture_buf[off..])
+                } else {
+                    None
+                };
+                pack::move_lane_capturing(&mut cache.data, n_byte_groups, last, idx, dst);
             }
             pack::zero_lane(&mut cache.data, n_byte_groups, last);
             cache.data.truncate(new_n_blocks * block_bytes);
             cache.n_blocks = new_n_blocks;
+        }
+        // No entry is retired here: `last` is now beyond `n_vectors`, and the
+        // only readers — the header's tail rows and the plan's live op slots
+        // — are both below it, so an entry left for a retired slot is
+        // unreachable rather than wrong. The lookup is built in capture
+        // order, so a slot captured twice resolves to its later bytes.
+        if capture_this && idx != last {
+            self.sync_capture_at.push((idx as u32, capture_off as u32));
         }
 
         last

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1418,6 +1418,20 @@ impl TurboQuantIndex {
             .unwrap_or(0)
     }
 
+    /// Test-only: how many removal captures are live for the next sync.
+    ///
+    /// The capture is a pure optimization — a miss re-reads the row — so no
+    /// output test can tell whether it is populated, only that results are
+    /// right either way. This exposes activation so a test can pin that it
+    /// still happens for the slots it is meant to cover.
+    ///
+    /// Gated to x86 alongside the capture itself: elsewhere nothing is ever
+    /// captured, so the only caller is compiled out and this would be dead.
+    #[cfg(all(test, target_arch = "x86_64"))]
+    pub(crate) fn captured_len_for_test(&self) -> usize {
+        self.sync_capture_at.len()
+    }
+
     /// slot -> (offset, len) into `sync_capture_buf`, built once per sync.
     ///
     /// Empty when `packed_codes` is live: a capture is only ever taken with
@@ -3809,6 +3823,53 @@ mod v7_delta_tests {
         std::fs::create_dir(&p).unwrap();
         p.push("index.tv");
         p
+    }
+
+    /// The removal capture must actually engage for slots below the
+    /// committed block floor — not merely at it.
+    ///
+    /// It is a pure optimization: a slot without an entry is re-read from
+    /// its block, so every output test passes whether it engages or not.
+    /// That makes the activation condition invisible to the rest of the
+    /// suite, and a narrowing of it — `<` becoming `==`, say — would
+    /// silently give back the whole win with nothing going red. This pins
+    /// the condition itself.
+    #[test]
+    #[cfg(target_arch = "x86_64")] // capture is x86-only by measurement
+    fn the_removal_capture_engages_below_the_block_floor() {
+        let path = temp("capture-engages");
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.add(&rows(200, 5));
+        idx.sync(&path).unwrap();
+        // Reload: the capture is only taken while the blocked cache is
+        // authoritative, which is the state a synced-file load lands in.
+        let mut idx = TurboQuantIndex::load(&path).unwrap();
+        assert_eq!(idx.captured_len_for_test(), 0, "nothing captured yet");
+
+        // Committed floor is 192 (200 / 32 * 32). Remove well below it.
+        idx.swap_remove(5);
+        assert_eq!(
+            idx.captured_len_for_test(),
+            1,
+            "a removal at slot 5, far below the committed floor of 192, must \
+             be captured — if only the boundary slot captures, the sync is \
+             back to re-reading every row it serializes",
+        );
+        idx.swap_remove(100);
+        assert_eq!(idx.captured_len_for_test(), 2, "and again mid-range");
+
+        // Above the floor there is nothing on disk to patch, so no capture.
+        let before = idx.captured_len_for_test();
+        idx.swap_remove(idx.len() - 1);
+        assert_eq!(
+            idx.captured_len_for_test(),
+            before,
+            "a pop above the committed floor has no redo op to feed",
+        );
+
+        // And the entries are spent by the sync that serializes them.
+        idx.sync(&path).unwrap();
+        assert_eq!(idx.captured_len_for_test(), 0, "cleared by the commit");
     }
 
     /// Splice ONLY the new commit header over the pre-sync file — the

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -2948,7 +2948,7 @@ impl TurboQuantIndex {
                 } else {
                     None
                 };
-                pack::move_lane_capturing(&mut cache.data, n_byte_groups, last, idx, dst);
+                pack::move_lane(&mut cache.data, n_byte_groups, last, idx, dst);
             }
             pack::zero_lane(&mut cache.data, n_byte_groups, last);
             cache.data.truncate(new_n_blocks * block_bytes);

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -3859,12 +3859,28 @@ mod v7_delta_tests {
         assert_eq!(idx.captured_len_for_test(), 2, "and again mid-range");
 
         // Above the floor there is nothing on disk to patch, so no capture.
+        // A pop first — and then, importantly, a NON-pop above the floor:
+        // the pop is also excluded by the `idx != last` guard at the store,
+        // so on its own it cannot tell a narrow condition from a broad one.
         let before = idx.captured_len_for_test();
         idx.swap_remove(idx.len() - 1);
         assert_eq!(
             idx.captured_len_for_test(),
             before,
             "a pop above the committed floor has no redo op to feed",
+        );
+        idx.add(&rows(40, 6)); // grow well past the committed floor of 192
+        let before = idx.captured_len_for_test();
+        let floor = 192;
+        assert!(idx.len() > floor + 2, "need slack above the floor");
+        idx.swap_remove(floor + 1); // above the floor, and not the last slot
+        assert_eq!(
+            idx.captured_len_for_test(),
+            before,
+            "a removal above the committed floor must not be captured: the \
+             file holds nothing for that slot, so no redo op will ever read \
+             it. Capturing anyway is work `remove()` pays for nothing — and \
+             `remove()` is the cell this optimization must not tax.",
         );
 
         // And the entries are spent by the sync that serializes them.

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1432,6 +1432,13 @@ impl TurboQuantIndex {
         self.sync_capture_at.len()
     }
 
+    /// See [`Self::captured_len_for_test`]; the arena-bound test needs
+    /// the byte length the gate actually caps.
+    #[cfg(all(test, target_arch = "x86_64"))]
+    pub(crate) fn sync_capture_buf_len_for_test(&self) -> usize {
+        self.sync_capture_buf.len()
+    }
+
     /// slot -> (offset, len) into `sync_capture_buf`, built once per sync.
     ///
     /// Empty when `packed_codes` is live: a capture is only ever taken with
@@ -2900,18 +2907,24 @@ impl TurboQuantIndex {
         // store, so capturing is a third memory op on a two-op loop — a ~50%
         // tax on `remove()` to save less than that in `sync()`. Measured
         // both ways (H5-H7): the ARM side never nets out.
-        let capture_this = cfg!(target_arch = "x86_64")
-            && self.sync_cursor.is_some()
-            && idx < self.sync_watermark()
-            && self.packed_codes.get().is_none()
-            && self.sync_capture_at.len() < io_v7::MAX_OPS;
-        let capture_off = self.sync_capture_buf.len();
-
-
         // n_vectors > 0 (asserted above) implies a successful add, which
         // implies self.dim was committed at that point. Unwrap is safe.
         let dim = self.dim.expect("n_vectors > 0 but dim is None");
         let bytes_per_vec = dim * self.bit_width / 8;
+        // The cap gates on the ARENA'S BYTES, not the entry count:
+        // retirement shrinks the entry list, so an entry-count gate
+        // re-opens every time a slot is re-dirtied and the arena grows
+        // without bound across the window. Bytes only ever grow until a
+        // sync or calibrate clears them, so this bound is monotone —
+        // MAX_OPS lanes' worth, the most a header can carry anyway.
+        let (_, capture_lane, _) = pack::blocked_geometry(self.n_vectors, self.bit_width, dim);
+        let capture_this = cfg!(target_arch = "x86_64")
+            && self.sync_cursor.is_some()
+            && idx < self.sync_watermark()
+            && self.packed_codes.get().is_none()
+            && self.sync_capture_buf.len() < io_v7::MAX_OPS * capture_lane;
+        let capture_off = self.sync_capture_buf.len();
+
         let last = self.n_vectors - 1;
         // At least one code representation must exist, or the branches
         // below would silently update neither and corrupt the index.
@@ -3835,6 +3848,32 @@ mod v7_delta_tests {
         std::fs::create_dir(&p).unwrap();
         p.push("index.tv");
         p
+    }
+
+    /// The capture arena is bounded by BYTES, not live entries:
+    /// retirement shrinks the entry list, so an entry-count gate would
+    /// re-open every time a slot is re-dirtied. Churning one slot far
+    /// past the cap must leave the arena at or under MAX_OPS lanes.
+    #[test]
+    #[cfg(target_arch = "x86_64")]
+    fn the_capture_arena_is_bounded_under_slot_churn() {
+        let path = temp("arena-bound");
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.calibrate(&rows(1024, 61)).unwrap();
+        idx.add(&rows(96, 62));
+        idx.sync(&path).unwrap();
+        let lane = DIM / 2; // 4-bit: dim / (8/bits)
+        for i in 0..3 * io_v7::MAX_OPS {
+            idx.swap_remove(5);
+            idx.add(&rows(1, 63 + i as u64));
+            assert!(
+                idx.sync_capture_buf_len_for_test() <= io_v7::MAX_OPS * lane,
+                "arena exceeded its bound at churn round {i}"
+            );
+        }
+        idx.sync(&path).unwrap();
+        let loaded = TurboQuantIndex::load(&path).unwrap();
+        assert_eq!(loaded.to_bytes(), idx.to_bytes());
     }
 
     /// The removal capture must actually engage for slots below the

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -2990,10 +2990,14 @@ impl TurboQuantIndex {
                 // Written straight into the arena — `cache` and the capture
                 // buffer are separate fields, so both borrows stand.
                 let dst = capture_at.map(|off| {
-                    if capture_buf.len() < off + n_byte_groups {
+                    // Append allocates its lane; reuse writes over the
+                    // retired entry's. Exactly one lane either way — an
+                    // open-ended slice here once let `move_lane` run
+                    // past the lane and overwrite every later capture.
+                    if off == capture_buf.len() {
                         capture_buf.resize(off + n_byte_groups, 0);
                     }
-                    &mut capture_buf[off..]
+                    &mut capture_buf[off..off + n_byte_groups]
                 });
                 pack::move_lane(&mut cache.data, n_byte_groups, last, idx, dst);
             }
@@ -3882,10 +3886,22 @@ mod v7_delta_tests {
         // authoritative, packed unset) — built fresh, packed is live and
         // the gate never opens, making every assertion below vacuous.
         let mut idx = TurboQuantIndex::load(&path).unwrap();
+        // Capture-free twin running the same ops: the live index and its
+        // file share the capture arena, so live-vs-loaded alone is blind
+        // to a capture corrupted in place (e.g. a reuse write running
+        // past its lane into a neighbour's bytes).
+        let mut eager = TurboQuantIndex::new(DIM, 4).unwrap();
+        eager.calibrate(&rows(1024, 61)).unwrap();
+        eager.add(&rows(96, 62));
         let lane = DIM / 2; // 4-bit: dim / (8/bits)
         for i in 0..3 * io_v7::MAX_OPS {
-            idx.swap_remove(5);
+            // Two interleaved victims: slot 7's capture must survive
+            // slot 5's reuse writes landing beside it, and vice versa.
+            let victim = if i % 2 == 0 { 5 } else { 7 };
+            idx.swap_remove(victim);
             idx.add(&rows(1, 63 + i as u64));
+            eager.swap_remove(victim);
+            eager.add(&rows(1, 63 + i as u64));
             assert!(
                 idx.sync_capture_buf_len_for_test() <= io_v7::MAX_OPS * lane,
                 "arena exceeded its bound at churn round {i}"
@@ -3898,6 +3914,11 @@ mod v7_delta_tests {
         idx.sync(&path).unwrap();
         let loaded = TurboQuantIndex::load(&path).unwrap();
         assert_eq!(loaded.to_bytes(), idx.to_bytes());
+        assert_eq!(
+            loaded.to_bytes(),
+            eager.to_bytes(),
+            "capture-path result diverged from the capture-free oracle"
+        );
     }
 
     /// The removal capture must actually engage for slots below the

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -137,27 +137,23 @@ pub(crate) fn write_x86_code_byte(blocked: &mut [u8], group_off: usize, lane: us
 /// Copy vector `src_vec`'s code bytes into vector `dst_vec`'s lane across
 /// every byte-group of the native blocked layout — the O(dim) primitive
 /// that lets `swap_remove` maintain the cache without a block repack.
-pub(crate) fn move_lane(blocked: &mut [u8], n_byte_groups: usize, src_vec: usize, dst_vec: usize) {
-    move_lane_capturing(blocked, n_byte_groups, src_vec, dst_vec, None);
-}
-
-/// [`move_lane`], additionally appending the moved row's *sequential* code
-/// bytes to `capture`.
 ///
-/// The move already computes exactly those bytes — one per byte group, the
-/// destination lane's new content — and then throws each away into the
-/// destination lane. Handing them out costs a store per group and saves a
-/// later reader from walking the whole 32-lane block to recover them: at
-/// dim 768 that is a 12 KB strided read to collect 384 bytes. The bytes are
-/// the same either way, because `write_x86_code_byte` is the exact inverse
-/// of the de-interleave — what is captured here is what a later read of
-/// `dst_vec`'s lane returns.
-/// `capture`, when given, must be exactly `n_byte_groups` long — the
-/// caller sizes it, so the loop below is a straight indexed store with no
-/// capacity check and no temporary. That matters: this runs once per byte
-/// group per removal, and a `Vec::push` per byte (plus a `Vec` per removal,
-/// plus a copy out of it) cost more than the whole capture is worth.
-pub(crate) fn move_lane_capturing(
+/// With `capture`, the moved row's *sequential* code bytes are also written
+/// there. The move already computes exactly those bytes, one per byte
+/// group, and would otherwise drop each into the destination lane and
+/// forget it; handing them out costs a store per group and saves a later
+/// reader from walking the whole 32-lane block to recover them (at dim 768,
+/// a 12 KB strided read to collect 384 bytes). The bytes are the same
+/// either way, because `write_x86_code_byte` is the exact inverse of the
+/// de-interleave — what is captured is what a later read of `dst_vec`'s
+/// lane returns.
+///
+/// `capture`, when given, must be exactly `n_byte_groups` long. The caller
+/// sizes it so the loop below is a straight indexed store with no capacity
+/// check and no temporary, which matters at one call per byte group per
+/// removal: a `Vec::push` per byte, plus a `Vec` per removal and a copy out
+/// of it, cost more than the whole capture is worth.
+pub(crate) fn move_lane(
     blocked: &mut [u8],
     n_byte_groups: usize,
     src_vec: usize,

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -138,20 +138,69 @@ pub(crate) fn write_x86_code_byte(blocked: &mut [u8], group_off: usize, lane: us
 /// every byte-group of the native blocked layout — the O(dim) primitive
 /// that lets `swap_remove` maintain the cache without a block repack.
 pub(crate) fn move_lane(blocked: &mut [u8], n_byte_groups: usize, src_vec: usize, dst_vec: usize) {
+    move_lane_capturing(blocked, n_byte_groups, src_vec, dst_vec, None);
+}
+
+/// [`move_lane`], additionally appending the moved row's *sequential* code
+/// bytes to `capture`.
+///
+/// The move already computes exactly those bytes — one per byte group, the
+/// destination lane's new content — and then throws each away into the
+/// destination lane. Handing them out costs a store per group and saves a
+/// later reader from walking the whole 32-lane block to recover them: at
+/// dim 768 that is a 12 KB strided read to collect 384 bytes. The bytes are
+/// the same either way, because `write_x86_code_byte` is the exact inverse
+/// of the de-interleave — what is captured here is what a later read of
+/// `dst_vec`'s lane returns.
+/// `capture`, when given, must be exactly `n_byte_groups` long — the
+/// caller sizes it, so the loop below is a straight indexed store with no
+/// capacity check and no temporary. That matters: this runs once per byte
+/// group per removal, and a `Vec::push` per byte (plus a `Vec` per removal,
+/// plus a copy out of it) cost more than the whole capture is worth.
+pub(crate) fn move_lane_capturing(
+    blocked: &mut [u8],
+    n_byte_groups: usize,
+    src_vec: usize,
+    dst_vec: usize,
+    capture: Option<&mut [u8]>,
+) {
     let (sb, sl) = (src_vec / BLOCK, src_vec % BLOCK);
     let (db, dl) = (dst_vec / BLOCK, dst_vec % BLOCK);
-    for g in 0..n_byte_groups {
-        let s_off = (sb * n_byte_groups + g) * BLOCK;
-        let d_off = (db * n_byte_groups + g) * BLOCK;
-        #[cfg(target_arch = "x86_64")]
-        {
-            let code = deinterleave_x86_code_byte(blocked, s_off, sl);
-            write_x86_code_byte(blocked, d_off, dl, code);
+    debug_assert!(capture.as_ref().is_none_or(|c| c.len() == n_byte_groups));
+    // Split the two loops rather than testing the option per byte: the
+    // plain move is the common path and must stay branch-free.
+    match capture {
+        None => {
+            for g in 0..n_byte_groups {
+                let s_off = (sb * n_byte_groups + g) * BLOCK;
+                let d_off = (db * n_byte_groups + g) * BLOCK;
+                move_one(blocked, s_off, sl, d_off, dl);
+            }
         }
-        #[cfg(not(target_arch = "x86_64"))]
-        {
-            blocked[d_off + dl] = blocked[s_off + sl];
+        Some(out) => {
+            for (g, slot) in out.iter_mut().enumerate() {
+                let s_off = (sb * n_byte_groups + g) * BLOCK;
+                let d_off = (db * n_byte_groups + g) * BLOCK;
+                *slot = move_one(blocked, s_off, sl, d_off, dl);
+            }
         }
+    }
+}
+
+/// One byte group of a lane move, returning the byte that was moved.
+#[inline(always)]
+fn move_one(blocked: &mut [u8], s_off: usize, sl: usize, d_off: usize, dl: usize) -> u8 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        let code = deinterleave_x86_code_byte(blocked, s_off, sl);
+        write_x86_code_byte(blocked, d_off, dl, code);
+        code
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let code = blocked[s_off + sl];
+        blocked[d_off + dl] = code;
+        code
     }
 }
 

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -29,6 +29,30 @@ macro_rules! pack_blocked_native {
     }};
 }
 
+/// One byte group of a lane move, evaluating to the byte that was moved.
+///
+/// A macro rather than a `cfg`-gated function, for the reason recorded on
+/// [`pack_blocked_native`]: a function body compiled out on x86 cannot be
+/// covered by any test the x86-only mutation gate runs, so mutating it
+/// produces an identical binary and is reported uncovered forever (#421).
+/// With no non-x86 function body there is nothing to mutate.
+macro_rules! move_one_native {
+    ($blocked:expr, $s_off:expr, $sl:expr, $d_off:expr, $dl:expr) => {{
+        #[cfg(target_arch = "x86_64")]
+        {
+            let code = deinterleave_x86_code_byte($blocked, $s_off, $sl);
+            write_x86_code_byte($blocked, $d_off, $dl, code);
+            code
+        }
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            let code = $blocked[$s_off + $sl];
+            $blocked[$d_off + $dl] = code;
+            code
+        }
+    }};
+}
+
 /// Repack bit-plane codes into SIMD-blocked layout.
 /// Returns (blocked_codes, n_blocks).
 ///
@@ -170,35 +194,19 @@ pub(crate) fn move_lane(
             for g in 0..n_byte_groups {
                 let s_off = (sb * n_byte_groups + g) * BLOCK;
                 let d_off = (db * n_byte_groups + g) * BLOCK;
-                move_one(blocked, s_off, sl, d_off, dl);
+                move_one_native!(blocked, s_off, sl, d_off, dl);
             }
         }
         Some(out) => {
             for (g, slot) in out.iter_mut().enumerate() {
                 let s_off = (sb * n_byte_groups + g) * BLOCK;
                 let d_off = (db * n_byte_groups + g) * BLOCK;
-                *slot = move_one(blocked, s_off, sl, d_off, dl);
+                *slot = move_one_native!(blocked, s_off, sl, d_off, dl);
             }
         }
     }
 }
 
-/// One byte group of a lane move, returning the byte that was moved.
-#[inline(always)]
-fn move_one(blocked: &mut [u8], s_off: usize, sl: usize, d_off: usize, dl: usize) -> u8 {
-    #[cfg(target_arch = "x86_64")]
-    {
-        let code = deinterleave_x86_code_byte(blocked, s_off, sl);
-        write_x86_code_byte(blocked, d_off, dl, code);
-        code
-    }
-    #[cfg(not(target_arch = "x86_64"))]
-    {
-        let code = blocked[s_off + sl];
-        blocked[d_off + dl] = code;
-        code
-    }
-}
 
 /// Append `n_new` vectors' packed bit-plane rows to the native blocked
 /// layout as direct lane writes, growing the buffer to the new geometry

--- a/turbovec/tests/sync_v7.rs
+++ b/turbovec/tests/sync_v7.rs
@@ -437,6 +437,58 @@ fn two_writers_at_the_same_generation_do_not_collide() {
     assert_eq!(loaded.to_bytes(), b.to_bytes(), "B's file must be untouched");
 }
 
+/// A capture must die with its slot. The hostile ordering: removals
+/// capture slots, the index shrinks until a captured slot is POPPED
+/// (idx == last — nothing new recorded), and an add then refills that
+/// slot with a fresh row. The retired entry must not survive to feed
+/// the next sync stale pre-removal bytes: the synced file must load
+/// back byte-identical to the live index, and match an independent
+/// index that ran the same ops with no capture arena at all.
+#[test]
+fn a_popped_then_refilled_slot_does_not_serve_a_stale_capture() {
+    let seeds = rows(96, 88);
+    for bits in [2usize, 4] {
+        // Independent oracle: same ops, packed live, no captures.
+        let mut eager = TurboQuantIndex::new(DIM, bits).unwrap();
+        // Loaded index: captures active below the watermark (x86).
+        let path = temp(&format!("stale-capture-{bits}"));
+        {
+            let mut seed = TurboQuantIndex::new(DIM, bits).unwrap();
+            seed.add(&seeds);
+            seed.sync(&path).unwrap();
+        }
+        let mut idx = TurboQuantIndex::load(&path).unwrap();
+        eager.add(&seeds);
+
+        let script = |i: &mut TurboQuantIndex| {
+            // Capture slot 5 (moves the then-last row into it), then
+            // shrink until slot 5 is the last slot and pop it — which
+            // records nothing — then refill it with a fresh row.
+            i.swap_remove(5);
+            while i.len() > 6 {
+                i.swap_remove(i.len() - 1);
+            }
+            i.swap_remove(5); // pop: idx == last
+            i.add(&rows(2, 89)); // refills slot 5 and grows past it
+        };
+        script(&mut idx);
+        script(&mut eager);
+
+        idx.sync(&path).unwrap();
+        let loaded = TurboQuantIndex::load(&path).unwrap();
+        assert_eq!(
+            loaded.to_bytes(),
+            idx.to_bytes(),
+            "bits={bits}: synced file diverged from the live index"
+        );
+        assert_eq!(
+            loaded.to_bytes(),
+            eager.to_bytes(),
+            "bits={bits}: capture-path result diverged from the capture-free oracle"
+        );
+    }
+}
+
 /// The captured bytes must equal what the index would hold WITHOUT the
 /// capture — checked against an independent index, not against itself.
 ///

--- a/turbovec/tests/sync_v7.rs
+++ b/turbovec/tests/sync_v7.rs
@@ -436,3 +436,101 @@ fn two_writers_at_the_same_generation_do_not_collide() {
     let loaded = TurboQuantIndex::load(&path).unwrap();
     assert_eq!(loaded.to_bytes(), b.to_bytes(), "B's file must be untouched");
 }
+
+/// The removal capture must never disagree with reading the row back.
+///
+/// `swap_remove` keeps the bytes it moves so header assembly need not walk
+/// the block again to recover them. That is only sound while a kept entry
+/// still describes the slot it names, and the ways it can stop doing so
+/// are all sequencing: a slot removed twice, a slot refilled by a later
+/// add, a slot whose filler was itself an uncommitted row, and a
+/// re-calibration that re-encodes everything. Each round below reloads and
+/// demands `to_bytes` equality, which compares the reconstructed rows —
+/// so a capture that had gone stale shows up as a byte difference rather
+/// than as a plausible-looking wrong answer.
+#[test]
+fn captured_removal_bytes_match_a_reread_of_the_row() {
+    let path = temp("capture");
+    let queries = rows(8, 4242);
+
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 11)).unwrap();
+    idx.add(&rows(300, 12));
+    idx.sync(&path).unwrap();
+
+    // Removals deep inside committed blocks, then a sync that serializes
+    // them as redo ops — the path the capture feeds.
+    for &s in &[5usize, 40, 41, 130, 299 - 60] {
+        idx.swap_remove(s);
+    }
+    idx.sync(&path).unwrap();
+    search_parity(&idx, &TurboQuantIndex::load(&path).unwrap(), &queries, 5);
+
+    // Same slot removed twice in one window: the second capture must win.
+    idx.swap_remove(7);
+    idx.swap_remove(7);
+    idx.sync(&path).unwrap();
+    search_parity(&idx, &TurboQuantIndex::load(&path).unwrap(), &queries, 5);
+
+    // An add refills slots the removals vacated, below the watermark.
+    idx.add(&rows(20, 13));
+    idx.swap_remove(3);
+    idx.sync(&path).unwrap();
+    search_parity(&idx, &TurboQuantIndex::load(&path).unwrap(), &queries, 5);
+
+    // Remove, then re-add, then remove again without an intervening sync,
+    // so captures and fresh rows interleave inside one window.
+    idx.swap_remove(11);
+    idx.add(&rows(9, 14));
+    idx.swap_remove(12);
+    idx.sync(&path).unwrap();
+    search_parity(&idx, &TurboQuantIndex::load(&path).unwrap(), &queries, 5);
+
+    // A re-calibration re-encodes every row, so nothing captured before
+    // one may be read after it.
+    //
+    // Reaching that needs the capture to be live in the first place, and
+    // it only is on a *loaded* index — a freshly built one has
+    // `packed_codes` materialized, which is the condition the capture is
+    // gated on. It also needs a captured slot to be read, and a
+    // compaction's only reader is the header's tail block. A capture
+    // always names a slot below the committed block floor while tail rows
+    // sit above the current one, so the two overlap only once `n` has
+    // shrunk back past the floor it was committed at.
+    let cpath = temp("capture-calib");
+    {
+        let mut c = TurboQuantIndex::new(DIM, 4).unwrap();
+        c.calibrate(&rows(1024, 30)).unwrap();
+        c.add(&rows(340, 31));
+        c.sync(&cpath).unwrap();                  // committed floor = 320
+    }
+    let mut c = TurboQuantIndex::load(&cpath).unwrap();   // packed unset
+    for _ in 0..30 {
+        c.swap_remove(300);                       // captured: 300 < 320
+    }                                             // n = 310, tail = [288, 310)
+    c.calibrate(&rows(1024, 32)).unwrap();        // re-encodes every row
+    c.sync(&cpath).unwrap();                      // full write reads slot 300
+    search_parity(&c, &TurboQuantIndex::load(&cpath).unwrap(), &queries, 5);
+
+    idx.swap_remove(9);
+    idx.calibrate(&rows(1024, 15)).unwrap();
+    idx.sync(&path).unwrap();
+    search_parity(&idx, &TurboQuantIndex::load(&path).unwrap(), &queries, 5);
+
+    // And the capture must hold on a loaded index — the window it is
+    // actually live in — at every width.
+    for bits in [2usize, 3, 4] {
+        let p = temp(&format!("capture{bits}"));
+        {
+            let mut i = TurboQuantIndex::new(DIM, bits).unwrap();
+            i.add(&rows(200, 20 + bits as u64));
+            i.sync(&p).unwrap();
+        }
+        let mut i = TurboQuantIndex::load(&p).unwrap();
+        for &s in &[2usize, 33, 64, 100] {
+            i.swap_remove(s);
+        }
+        i.sync(&p).unwrap();
+        search_parity(&i, &TurboQuantIndex::load(&p).unwrap(), &queries, 5);
+    }
+}

--- a/turbovec/tests/sync_v7.rs
+++ b/turbovec/tests/sync_v7.rs
@@ -437,6 +437,59 @@ fn two_writers_at_the_same_generation_do_not_collide() {
     assert_eq!(loaded.to_bytes(), b.to_bytes(), "B's file must be untouched");
 }
 
+/// The captured bytes must equal what the index would hold WITHOUT the
+/// capture — checked against an independent index, not against itself.
+///
+/// This is the oracle the sibling test below cannot provide. That one
+/// compares a reloaded index against the live one, which is silent about
+/// any corruption applied to both — and a bad offset inside the capturing
+/// move is exactly that, since the same offset drives the lane write. Here
+/// the same rows and the same removals run twice: once on a loaded index,
+/// where the capture is live, and once on an in-memory one, where
+/// `packed_codes` is materialized so no capture is taken at all. The two
+/// must serialize to identical bytes.
+#[test]
+fn a_captured_removal_matches_the_same_removal_without_the_capture() {
+    let seeds = rows(200, 77);
+    let removals = [2usize, 33, 64, 100, 5, 5, 150];
+
+    for bits in [2usize, 3, 4] {
+        // Capture inactive: built in memory, so `packed_codes` is live.
+        let mut eager = TurboQuantIndex::new(DIM, bits).unwrap();
+        eager.add(&seeds);
+        for &r in &removals {
+            eager.swap_remove(r);
+        }
+
+        // Capture active: reloaded from a synced file, so the blocked cache
+        // is authoritative and every removal below the floor is captured.
+        let path = temp(&format!("capture-oracle-{bits}"));
+        {
+            let mut seed = TurboQuantIndex::new(DIM, bits).unwrap();
+            seed.add(&seeds);
+            seed.sync(&path).unwrap();
+        }
+        let mut lazy = TurboQuantIndex::load(&path).unwrap();
+        for &r in &removals {
+            lazy.swap_remove(r);
+        }
+        lazy.sync(&path).unwrap();
+
+        assert_eq!(
+            eager.to_bytes(),
+            lazy.to_bytes(),
+            "bits={bits}: the capturing removal path disagrees with the \
+             non-capturing one — the captured bytes, or the offsets they \
+             were read at, are wrong",
+        );
+        assert_eq!(
+            TurboQuantIndex::load(&path).unwrap().to_bytes(),
+            eager.to_bytes(),
+            "bits={bits}: and the file must hold those same bytes",
+        );
+    }
+}
+
 /// The removal capture must never disagree with reading the row back.
 ///
 /// `swap_remove` keeps the bytes it moves so header assembly need not walk


### PR DESCRIPTION
Hill-climb of `sync()` latency for the two incremental shapes — a small
append and a batch of scattered removals — on a purpose-built GCP pair.
One commit per confirmed win, each with its measured gain.

## Wins

| | ARM | x86 | target HM |
|---|---|---|---|
| **H1** `sync_remove` | 9.77 → 3.49 ms (x2.80) | 18.58 → 4.90 ms (x3.79) | **x3.22** |
| **H2** `sync_append` | x1.015 (parity) | 1.950 → 1.700 ms (x1.147, 7/7) | **x1.077** |
| **H8** `sync_remove` | x0.992 (parity, x86-only change) | 4.735 → 3.390 ms (x1.397, 16/16) | **x1.160** |

End to end, the sync committing 1000 scattered removals goes **18.6 → 3.4 ms
on x86** and **9.8 → 3.5 ms on ARM**, against a measured fsync floor of
~2.45 ms for a commit that size. The append cell is now at its floor.

**H1** — a sync stopped re-proving its own last commit. `cursor_state`
re-read every unit the previous commit wrote and recomputed its digest, on
the way into every sync (12.6 MB after a removal settle). That commit was
already proven, by the `sync_all` that returned for it or the `load` that
adopted it.

**H2** — a header slot is sized for the 1024-op cap (~428 KB at dim 768) but
the steady state uses ~16 KB. Only the used prefix is read now, widening
only when a header really carries that many ops.

**H8** — filling a hole already computes the incoming row's stored bytes;
they were discarded and then read back out of the 32-lane block they are
interleaved into (a stride-32 walk over 12 KB to recover 384 bytes, ~995×
per sync). Now kept, in a per-window arena. x86-only by measurement: off x86
the lane move is a plain byte copy, so capturing costs more in `remove()`
than it saves in `sync()`.

## Rejected, and why (H3–H7)

Five hypotheses were measured and discarded; the log records each with its
numbers. Two are worth surfacing:

- **H3/H4** (remove the ~995 per-op allocations) measured **parity**. A probe
  had already localised the per-op cost to a strided gather, not allocation,
  and the measurement agreed.
- **H5/H6/H7** are H8's mechanism with worse storage. All three produced a
  large `sync_remove` gain and were rejected by the `remove_calls` gate,
  which showed the sync had got faster by moving work into `remove()` —
  up to 20% on ARM.

## Methodology, and two corrections it forced

Both of these changed verdicts, so they are in the branch as commits:

- **A/A control** (identical code on both sides). It found the append cell's
  own spread is ±8% (x86) / ±10% (ARM), and that the **second position in a
  round is ~6% slower** on x86 `sync_remove`. The original A/B always ran
  `base` first, so it had been handicapping every candidate — H3's rejection
  had to be re-derived, and H2's real gain was larger than first measured
  (x1.110 → x1.147). All later runs alternate order, pin the harness to a
  fixed copy, and are judged on paired sign tests, not medians of
  independent runs.
- **`remove_calls` gate**, added when H5's mechanism looked able to hide work
  in the untimed removals. It then caught exactly that, 0/8 rounds better on
  both arches, three times running.

## Benchmark cells

`benchmarks/suite/speed_sync_d1536_2bit_*.py` (official) and
`benchmarks/hillclimb/bench_sync.py` (climb driver):

| cell | what it times | role |
|---|---|---|
| `sync_append` | sync after adding 32 rows | objective |
| `sync_remove` | sync after 1000 scattered removals | objective |
| `sync_first` | the first sync of a path (full write) | gate |
| `sync_settle` | the sync that materializes a removal's header ops | gate |
| `remove_calls` | the 1000 `remove()` calls themselves | gate |

The gates are recorded, not scored — they exist so that moving work out of a
measured sync reads as what it is. Each cell asserts on the **inode** that
the incremental path actually ran, since a full rewrite lands via temp +
atomic rename. Each timed removal sync is followed by a settle sync, because
repeating removals on an unsettled file pushes carried ops past the 1024-op
header cap and silently falls back to a full rewrite.

## Crash contract

Never traded, and checked per win: one write batch and one fsync per sync,
`sync_all` durability, torn-write harness and corruption matrix green, both
multi-writer tests green. H8 adds
`captured_removal_bytes_match_a_reread_of_the_row` (mutation-checked:
corrupting a captured byte fails it) and was run on the **x86 box**, since
its path is compiled out on aarch64.

## Rig

Cloned from the benchmark masters, never measured on them and never locally:
`turbovec-bench-sync` (c3-standard-8, us-central1-a) and
`turbovec-bench-arm-sync` (c4a-standard-8, **us-east4-c** — us-central1 was
at its 24-CPU C4A quota; the disk spec matches the ARM master exactly and
every speedup is against a baseline recorded on that same box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
