### PR TITLE
fix(v7): stop a rolled-back commit resurrecting, and stop holding the delta twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A crash-recovered synced index can no longer resurrect the commit it
+  rolled back past.** A commit generation is not unique over a file's
+  life: when `load` falls back, the rejected header stays in its slot and
+  the recovered index's next `sync` writes that same generation into that
+  same slot. Losing only that header write left the rejected header
+  standing — and its delta verifies against the units the new sync
+  rewrote identically — so the load after a second crash could serve a
+  state that had already been rolled back and abandoned. Such a sync now
+  destroys the rejected header behind its own barrier before any data
+  moves; it is the only sync that runs two barriers, and nothing changes
+  in the steady state.
+- **`load` and `sync` no longer hold the delta twice.** The commit digest
+  was computed over a materialized copy of every unit a sync wrote, on
+  top of the write payload and — on the load side — the file image
+  already in memory, so a sync that appended most of an index made the
+  next load peak at over three times the file. The digest is now folded
+  from the bytes where they already live, bit-for-bit identical. Loading
+  a 20 MB file after a large append drops from ~77 MB peak heap to under
+  30 MB, and is ~25% faster.
 - **Masked search no longer drops allowed vectors on AVX-512 VNNI/VBMI
   hardware.** The nq=1 block-interleave (H54) steps the permute-dot
   block loop eight blocks at a time, but the mask block-skip still

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -98,10 +98,12 @@ const REBUILD_HINT: &str =
 ///   AND power loss: the destination always holds a complete old or
 ///   complete new index, and a completed save is on stable storage.
 /// * [`Durability::Fast`]: identical temp-file + atomic-rename protocol
-///   but no fsync. The destination still can never hold a torn index
-///   and a process crash cannot lose the previous file — but a power
-///   loss or kernel panic shortly after a "completed" save may lose or
-///   truncate the new file. Choose this only when the index is
+///   but no fsync. Against a process crash the guarantee is the same as
+///   `Durable`'s — the destination holds a complete old or complete new
+///   index, and the previous file cannot be lost. Against power loss or
+///   a kernel panic it holds nothing: the rename may be visible while
+///   the new file's contents are not, so a "completed" save can be found
+///   truncated or empty afterwards. Choose this only when the index is
 ///   reproducible or durability is handled elsewhere (e.g. the file is
 ///   about to be uploaded or the filesystem is transient).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -24,7 +24,16 @@
 //! torn header write fails its CRC and load falls back to the other
 //! slot.
 //!
-//! Every sync is ONE write batch and ONE fsync. No ordering barrier
+//! A generation is not unique over the life of a file. When load falls
+//! back, the rejected header stays in its slot and the recovered index's
+//! next sync writes the same generation into that same slot — where a
+//! torn header write would leave the rejected commit standing, its delta
+//! verifying against data the new sync wrote identically. That one sync
+//! therefore opens with a repair barrier: the rejected header's bytes
+//! are destroyed, and fsynced, before any data moves. It is the only
+//! sync that ever runs two barriers.
+//!
+//! Every other sync is ONE write batch and ONE fsync. No ordering barrier
 //! separates data from commit: the header carries a delta descriptor —
 //! the units this sync wrote (materialized list + appended range) and
 //! the CRC of their bytes — so a commit that reaches disk before its
@@ -123,15 +132,27 @@ pub(crate) fn crc32(data: &[u8]) -> u32 {
 }
 
 fn crc32_one(data: &[u8]) -> u32 {
+    !crc32c_update(0xFFFF_FFFF, data)
+}
+
+/// Fold `data` into a running CRC-32C register, returning the raw state
+/// (no final complement) so a value can be built from bytes that never
+/// exist contiguously — see [`DeltaDigest`].
+///
+/// CRC-32C is byte-serial, so folding eight bytes with one instruction is
+/// identical to folding them one at a time; a chunk boundary anywhere in
+/// the stream therefore costs a short scalar tail, never a different
+/// answer.
+fn crc32c_update(crc: u32, data: &[u8]) -> u32 {
     #[cfg(target_arch = "aarch64")]
     if std::arch::is_aarch64_feature_detected!("crc") {
-        return unsafe { crc32c_hw_aarch64(data) };
+        return unsafe { crc32c_upd_hw_aarch64(crc, data) };
     }
     #[cfg(target_arch = "x86_64")]
     if is_x86_feature_detected!("sse4.2") {
-        return unsafe { crc32c_hw_x86(data) };
+        return unsafe { crc32c_upd_hw_x86(crc, data) };
     }
-    crc32c_soft(data)
+    crc32c_upd_soft(crc, data)
 }
 
 fn crc32_three(a: &[u8], b: &[u8], c: &[u8]) -> (u32, u32, u32) {
@@ -148,9 +169,8 @@ fn crc32_three(a: &[u8], b: &[u8], c: &[u8]) -> (u32, u32, u32) {
 
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "crc")]
-unsafe fn crc32c_hw_aarch64(data: &[u8]) -> u32 {
+unsafe fn crc32c_upd_hw_aarch64(mut crc: u32, data: &[u8]) -> u32 {
     use std::arch::aarch64::{__crc32cb, __crc32cd};
-    let mut crc = 0xFFFF_FFFFu32;
     let (chunks, tail) = data.as_chunks::<8>();
     for c in chunks {
         crc = __crc32cd(crc, u64::from_le_bytes(*c));
@@ -158,7 +178,7 @@ unsafe fn crc32c_hw_aarch64(data: &[u8]) -> u32 {
     for &b in tail {
         crc = __crc32cb(crc, b);
     }
-    !crc
+    crc
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -183,18 +203,18 @@ unsafe fn crc32c_three_hw_aarch64(a: &[u8], b: &[u8], c: &[u8]) -> (u32, u32, u3
 
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "sse4.2")]
-unsafe fn crc32c_hw_x86(data: &[u8]) -> u32 {
+unsafe fn crc32c_upd_hw_x86(crc: u32, data: &[u8]) -> u32 {
     use std::arch::x86_64::{_mm_crc32_u64, _mm_crc32_u8};
-    let mut crc = 0xFFFF_FFFFu64;
+    let mut wide = crc as u64;
     let (chunks, tail) = data.as_chunks::<8>();
     for c in chunks {
-        crc = _mm_crc32_u64(crc, u64::from_le_bytes(*c));
+        wide = _mm_crc32_u64(wide, u64::from_le_bytes(*c));
     }
-    let mut crc = crc as u32;
+    let mut crc = wide as u32;
     for &b in tail {
         crc = _mm_crc32_u8(crc, b);
     }
-    !crc
+    crc
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -222,6 +242,10 @@ unsafe fn crc32c_three_hw_x86(a: &[u8], b: &[u8], c: &[u8]) -> (u32, u32, u32) {
 }
 
 fn crc32c_soft(data: &[u8]) -> u32 {
+    !crc32c_upd_soft(0xFFFF_FFFF, data)
+}
+
+fn crc32c_upd_soft(mut crc: u32, data: &[u8]) -> u32 {
     let table = CRC_TABLE.get_or_init(|| {
         let mut t = [0u32; 256];
         for (i, e) in t.iter_mut().enumerate() {
@@ -234,11 +258,81 @@ fn crc32c_soft(data: &[u8]) -> u32 {
         }
         t
     });
-    let mut crc = 0xFFFF_FFFFu32;
     for &b in data {
         crc = (crc >> 8) ^ table[usize::from((crc as u8) ^ b)];
     }
-    !crc
+    crc
+}
+
+/// The delta digest, computed over bytes that are never contiguous.
+///
+/// The digest is [`crc32`] of `gen || (block index || unit body)*`. That
+/// buffer used to be materialized — a second copy of everything a sync
+/// wrote, on the way into every sync and out of every load, on top of
+/// the file image `load` already holds. This accumulates the identical
+/// value from the pieces where they already live.
+///
+/// Identical means bit-for-bit: [`crc32`] splits an input of 4096 bytes
+/// or more into three length-derived thirds, checksums each, and hashes
+/// the three results. The total length is known before the first byte
+/// arrives (every unit is `unit_len`), so the same three boundaries are
+/// reproduced here and each pushed chunk is routed to the third — or
+/// thirds — it falls in.
+struct DeltaDigest {
+    /// Bytes pushed so far: the cursor into the virtual buffer.
+    at: usize,
+    /// The two split points, or `None` when the input is short enough
+    /// for `crc32`'s single-chain path.
+    split: Option<(usize, usize)>,
+    /// Running raw CRC state per third (only `[0]` is used when
+    /// `split` is `None`).
+    parts: [u32; 3],
+}
+
+impl DeltaDigest {
+    fn new(total: usize) -> Self {
+        let split = (total >= 4096).then(|| {
+            let third = total / 3;
+            (third, third * 2)
+        });
+        Self {
+            at: 0,
+            split,
+            parts: [0xFFFF_FFFF; 3],
+        }
+    }
+
+    fn push(&mut self, mut data: &[u8]) {
+        let Some((s1, s2)) = self.split else {
+            self.parts[0] = crc32c_update(self.parts[0], data);
+            self.at += data.len();
+            return;
+        };
+        // Route each run of bytes to the third it lands in, splitting at
+        // a boundary the run straddles.
+        while !data.is_empty() {
+            let (part, end) = match self.at {
+                a if a < s1 => (0, s1),
+                a if a < s2 => (1, s2),
+                _ => (2, usize::MAX),
+            };
+            let take = data.len().min(end - self.at);
+            self.parts[part] = crc32c_update(self.parts[part], &data[..take]);
+            self.at += take;
+            data = &data[take..];
+        }
+    }
+
+    fn finish(self) -> u32 {
+        if self.split.is_none() {
+            return !self.parts[0];
+        }
+        let mut digest = [0u8; 12];
+        for (i, p) in self.parts.iter().enumerate() {
+            digest[i * 4..i * 4 + 4].copy_from_slice(&(!p).to_le_bytes());
+        }
+        crc32_one(&digest)
+    }
 }
 
 // ---------------------------------------------------------------------
@@ -543,6 +637,11 @@ pub(crate) struct SyncPlan {
 /// are carried in the new header instead, and a fallback to the old
 /// header still finds those units exactly as its own ops expect.
 ///
+/// `clear_target` is `Some(used)` when the slot this sync commits into
+/// already holds a parseable header at this generation or newer — the
+/// post-rollback state described at the barrier below — and says how
+/// many of its bytes the plan must destroy first.
+///
 /// `None` when the carried ops exceed [`MAX_OPS`] — the caller falls
 /// back to a full rewrite, the only crash-safe way to land more
 /// first-time changes than one header can describe.
@@ -551,6 +650,7 @@ pub(crate) fn plan_incremental(
     cursor: SyncCursor,
     pending: &std::collections::HashSet<usize>,
     fresh: &std::collections::HashSet<usize>,
+    clear_target: Option<usize>,
 ) -> Option<SyncPlan> {
     let geo = src.geo();
     let old_blocks = (cursor.n_synced as usize) / BLOCK;
@@ -605,17 +705,20 @@ pub(crate) fn plan_incremental(
     // One batch, one fsync: the header's delta descriptor names every
     // unit this sync writes and their bytes' CRC, so a commit that
     // reaches disk before its data is detectable at load — no ordering
-    // barrier needed.
+    // barrier needed. The digest folds each unit's bytes as they are
+    // built, so the payload exists once (in the write op) rather than
+    // twice.
+    let n_written = materialize.len() + new_blocks.saturating_sub(old_blocks);
+    let mut digest = DeltaDigest::new(8 + n_written * (4 + geo.unit_len()));
+    digest.push(&gen.to_le_bytes());
     let mut batch = Batch::default();
-    let mut delta_bytes: Vec<u8> = Vec::new();
-    delta_bytes.extend_from_slice(&gen.to_le_bytes());
     for b in materialize.iter().copied().chain(old_blocks..new_blocks) {
         let bytes = unit_bytes(src, b);
-        delta_bytes.extend_from_slice(&(b as u32).to_le_bytes());
-        delta_bytes.extend_from_slice(&bytes);
+        digest.push(&(b as u32).to_le_bytes());
+        digest.push(&bytes);
         batch.ops.push((geo.unit_at(b) as u64, bytes));
     }
-    let delta_crc = crc32(&delta_bytes);
+    let delta_crc = digest.finish();
 
     // The commit: generation g lives in slot g % 2, so this only ever
     // overwrites the slot of generation g - 1.
@@ -630,7 +733,43 @@ pub(crate) fn plan_incremental(
             (&materialize, old_blocks..new_blocks, delta_crc),
         ),
     ));
-    let batches = vec![batch];
+
+    // A generation number is not unique over the life of a file. When a
+    // crash makes `load` fall back, the rejected header stays in its
+    // slot and the recovered index syncs again at the SAME generation,
+    // into that same slot. If this sync's data lands and its header
+    // write does not, the rejected header is still there — and its
+    // delta, which names units this sync has just rewritten with the
+    // same bytes (materialization is an idempotent absolute write),
+    // verifies. Load would adopt a commit that was already abandoned.
+    //
+    // So when the caller saw such a header, break it first, behind its
+    // own barrier. Writing a generation whose parity disagrees with the
+    // slot is the first thing `parse_header_at` rejects, so one 8-byte
+    // write is enough and nothing rests on a CRC failing by luck. A
+    // crash during this batch is harmless: no data has moved yet, so the
+    // stale header's delta still fails exactly as it did at the load
+    // that rejected it.
+    //
+    // Nothing happens in the steady state — a sync writing generation g
+    // finds g - 2 in its slot.
+    let batches = if let Some(used) = clear_target {
+        // Breaking only the generation field is not enough: the header
+        // write that follows restores those very bytes first, so a tear
+        // one byte in would leave the new generation sitting on the old
+        // header's intact body — the rejected commit, reassembled. Wipe
+        // everything the old header occupies, so no prefix of the new
+        // write can complete it.
+        let mut bytes = vec![0u8; used.clamp(8, geo.hdr_len())];
+        // And make the wiped slot's generation disagree with the slot's
+        // parity, which `parse_header_at` rejects before reading a
+        // further byte — so a clear that completes is refused outright
+        // rather than on a CRC that merely ought not to match.
+        bytes[..8].copy_from_slice(&((gen % 2) ^ 1).to_le_bytes());
+        vec![Batch { ops: vec![(geo.hdr_at(slot) as u64, bytes)] }, batch]
+    } else {
+        vec![batch]
+    };
 
     Some(SyncPlan {
         batches,
@@ -651,14 +790,17 @@ pub(crate) fn plan_incremental(
 /// content-independent constant. Excluding the codeword CRCs and mixing
 /// in the indices and the generation makes the digest depend on every
 /// byte and every position it commits.
-fn delta_digest<'a>(gen: u64, units: impl Iterator<Item = (usize, &'a [u8])>) -> u32 {
-    let mut buf = Vec::new();
-    buf.extend_from_slice(&gen.to_le_bytes());
+fn delta_digest(gen: u64, units: &[(usize, &[u8])]) -> u32 {
+    let total = units
+        .iter()
+        .fold(8usize, |n, (_, body)| n.saturating_add(4 + body.len()));
+    let mut d = DeltaDigest::new(total);
+    d.push(&gen.to_le_bytes());
     for (b, body) in units {
-        buf.extend_from_slice(&(b as u32).to_le_bytes());
-        buf.extend_from_slice(body);
+        d.push(&(*b as u32).to_le_bytes());
+        d.push(body);
     }
-    crc32(&buf)
+    d.finish()
 }
 
 /// Every sync is durable: `sync_all`, not `sync_data` — on every
@@ -668,19 +810,25 @@ fn delta_digest<'a>(gen: u64, units: impl Iterator<Item = (usize, &'a [u8])>) ->
 /// "adoptable commit" means exactly one thing: fetch each unit the
 /// commit's sync wrote through `read_unit` (false = unavailable) and
 /// compare the reconstructed digest.
+/// `feed_unit` pushes one unit's bytes into the digest, or answers
+/// `false` if that unit is not there — nothing is accumulated, so a
+/// commit that appended gigabytes costs one unit of working memory to
+/// check, not a second copy of the delta.
 fn delta_verified(
     h: &ParsedHdr,
-    mut read_unit: impl FnMut(usize, &mut Vec<u8>) -> bool,
+    unit_len: usize,
+    mut feed_unit: impl FnMut(usize, &mut DeltaDigest) -> bool,
 ) -> bool {
-    let mut units: Vec<(usize, Vec<u8>)> = Vec::new();
+    let count = h.delta_mat.len().saturating_add(h.delta_app.len());
+    let mut d = DeltaDigest::new(8usize.saturating_add(count.saturating_mul(4 + unit_len)));
+    d.push(&h.gen.to_le_bytes());
     for b in h.delta_mat.iter().copied().chain(h.delta_app.clone()) {
-        let mut u = Vec::new();
-        if !read_unit(b, &mut u) {
+        d.push(&(b as u32).to_le_bytes());
+        if !feed_unit(b, &mut d) {
             return false;
         }
-        units.push((b, u));
     }
-    delta_digest(h.gen, units.iter().map(|(b, u)| (*b, u.as_slice()))) == h.delta_crc
+    d.finish() == h.delta_crc
 }
 
 fn fsync_commit(f: &File) -> io::Result<()> {
@@ -727,7 +875,7 @@ pub(crate) fn write_full(
         gen,
         src.n_vectors,
         &[],
-        (&[], 0..0, delta_digest(gen, std::iter::empty())),
+        (&[], 0..0, delta_digest(gen, &[])),
     );
 
     crate::io::sweep_stale_tmps(path);
@@ -824,6 +972,9 @@ struct ParsedHdr {
     delta_mat: Vec<usize>,
     delta_app: std::ops::Range<usize>,
     delta_crc: u32,
+    /// Bytes of the slot this header actually occupies, CRC included —
+    /// what has to be destroyed to un-commit it.
+    used: usize,
 }
 
 /// Parse one header slot out of `raw` (which must cover the header
@@ -921,6 +1072,7 @@ fn parse_header_at(
         delta_mat,
         delta_app: app_from..app_to,
         delta_crc,
+        used: p + 4,
     })
 }
 
@@ -1017,19 +1169,31 @@ pub(crate) fn load(path: &Path, expect_calib_gen: u64, expect_kind: u8) -> io::R
     // replacement for a write-ordering barrier. A commit that reached
     // disk before its data fails this and the other slot wins.
     let delta_ok = |h: &ParsedHdr| -> bool {
-        delta_verified(h, |b, out| {
+        delta_verified(h, geo.unit_len(), |b, d| {
             let at = geo.unit_at(b);
-            raw.get(at..at + geo.unit_len())
-                .map(|u| out.extend_from_slice(u))
-                .is_some()
+            raw.get(at..at + geo.unit_len()).map(|u| d.push(u)).is_some()
         })
     };
     let mut cands: Vec<ParsedHdr> =
         [parse_hdr(0), parse_hdr(1)].into_iter().flatten().collect();
     cands.sort_by_key(|h| std::cmp::Reverse(h.gen));
+    let newest = cands.first().map(|h| h.gen);
     let Some(chosen) = cands.into_iter().find(delta_ok) else {
         return Err(bad("no valid commit header — unrecoverable v7 file"));
     };
+    // Falling back is the protocol working, but it is also data loss:
+    // the newest commit's own sync did not finish, and everything it
+    // held is gone. Silence here reads as a clean load.
+    if newest.is_some_and(|g| g != chosen.gen) {
+        crate::warning::warn(&format!(
+            "{}: the newest commit (generation {}) is incomplete — its sync did \
+             not finish — so generation {} was loaded instead; changes made after \
+             that commit are lost",
+            path.display(),
+            newest.expect("checked"),
+            chosen.gen,
+        ));
+    }
     let gen = chosen.gen;
     let n_vectors = chosen.n;
 
@@ -1165,7 +1329,14 @@ pub(crate) fn load(path: &Path, expect_calib_gen: u64, expect_kind: u8) -> io::R
 /// What a cursor finds when checked against the file it points at.
 pub(crate) enum CursorState {
     /// The file's newest commit is the cursor's: sync in place safely.
-    Intact,
+    Intact {
+        /// `Some(used)` when a parseable header NEWER than the cursor's
+        /// commit is sitting in the slot the next sync writes — a commit
+        /// `load` rejected and fell back past — where `used` is how many
+        /// of that slot's bytes it occupies. The next sync must destroy
+        /// them before moving any data; see [`plan_incremental`].
+        stale_ahead: Option<usize>,
+    },
     /// A valid v7 file whose newest commit is not the cursor's —
     /// another writer advanced or replaced it. Touching it would
     /// silently destroy their commits: refuse.
@@ -1281,18 +1452,32 @@ pub(crate) fn cursor_state(
     // landed. This shortcut only ever skips work for a commit already
     // proven, and in the unsupported concurrent-writer case it errs toward
     // refusing rather than adopting.
+    // Nothing parses ahead of the cursor's own commit here — it is the
+    // newest — so the slot the next sync targets holds generation
+    // `gen - 1` and needs no repair.
     if cands.first().is_some_and(|h| h.gen == cursor.gen) {
-        return Ok(CursorState::Intact);
+        return Ok(CursorState::Intact { stale_ahead: None });
     }
+    let stale_ahead = cands
+        .iter()
+        .filter(|h| h.gen > cursor.gen)
+        .map(|h| h.used)
+        .max();
     let mut adoptable: Option<u64> = None;
+    // One reusable unit buffer, refilled per unit and folded straight
+    // into the digest.
+    let mut unit_buf = vec![0u8; geo.unit_len()];
     for h in &cands {
-        let verified = delta_verified(h, |b, out| {
+        let verified = delta_verified(h, geo.unit_len(), |b, d| {
             let at = geo.unit_at(b);
             if at + geo.unit_len() > file_len {
                 return false;
             }
-            out.resize(geo.unit_len(), 0);
-            f.seek(SeekFrom::Start(at as u64)).is_ok() && f.read_exact(out).is_ok()
+            if f.seek(SeekFrom::Start(at as u64)).is_err() || f.read_exact(&mut unit_buf).is_err() {
+                return false;
+            }
+            d.push(&unit_buf);
+            true
         });
         if verified {
             adoptable = Some(h.gen);
@@ -1300,7 +1485,7 @@ pub(crate) fn cursor_state(
         }
     }
     match adoptable {
-        Some(g) if g == cursor.gen => Ok(CursorState::Intact),
+        Some(g) if g == cursor.gen => Ok(CursorState::Intact { stale_ahead }),
         Some(_) => Ok(CursorState::Foreign),
         // Our own file with no adoptable commit left is corrupt beyond
         // incremental repair; a full rewrite is the only safe sync.
@@ -1482,24 +1667,23 @@ mod tests {
     fn the_delta_digest_depends_on_every_byte() {
         let mut body_a = vec![7u8; 1000];
         let body_b = vec![9u8; 1000];
-        let base = delta_digest(3, [(0usize, body_a.as_slice()), (1, body_b.as_slice())].into_iter());
+        let base = delta_digest(3, &[(0usize, body_a.as_slice()), (1, body_b.as_slice())]);
         // Content sensitivity, at every byte position.
         for i in [0usize, 1, 499, 998, 999] {
             body_a[i] ^= 1;
-            let changed =
-                delta_digest(3, [(0usize, body_a.as_slice()), (1, body_b.as_slice())].into_iter());
+            let changed = delta_digest(3, &[(0usize, body_a.as_slice()), (1, body_b.as_slice())]);
             assert_ne!(base, changed, "flip at byte {i} must change the digest");
             body_a[i] ^= 1;
         }
         // Position and generation sensitivity.
         assert_ne!(
             base,
-            delta_digest(3, [(1usize, body_a.as_slice()), (0, body_b.as_slice())].into_iter()),
+            delta_digest(3, &[(1usize, body_a.as_slice()), (0, body_b.as_slice())]),
             "block indices must bind"
         );
         assert_ne!(
             base,
-            delta_digest(4, [(0usize, body_a.as_slice()), (1, body_b.as_slice())].into_iter()),
+            delta_digest(4, &[(0usize, body_a.as_slice()), (1, body_b.as_slice())]),
             "the generation must bind"
         );
         // The old bug's shape, demonstrated so it stays understood: a
@@ -1515,10 +1699,52 @@ mod tests {
         let c = crc32(&u2);
         u2.extend_from_slice(&c.to_le_bytes());
         assert_eq!(
-            delta_digest(1, [(0usize, u1.as_slice())].into_iter()),
-            delta_digest(1, [(0usize, u2.as_slice())].into_iter()),
+            delta_digest(1, &[(0usize, u1.as_slice())]),
+            delta_digest(1, &[(0usize, u2.as_slice())]),
             "codeword payloads DO collide — which is why unit bodies must never embed their own CRC"
         );
+    }
+
+    /// The streaming digest must equal `crc32` of the buffer it stands
+    /// in for, whatever the chunk boundaries. The value is a file
+    /// format: a digest that disagreed with the materialized one would
+    /// make every commit written by one build unverifiable by the other.
+    ///
+    /// Swept across the 4096-byte threshold where `crc32` switches to
+    /// three interleaved thirds, and pushed in chunk sizes chosen to
+    /// straddle both split points.
+    #[test]
+    fn the_streaming_digest_equals_the_materialized_one() {
+        let mut data = vec![0u8; 20_000];
+        let mut s = 0x2545_F491_4F6C_DD1Du64;
+        for b in data.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            *b = (s >> 32) as u8;
+        }
+        for total in [0usize, 1, 7, 8, 4094, 4095, 4096, 4097, 6143, 6144, 12_289, 20_000] {
+            let buf = &data[..total];
+            let want = crc32(buf);
+            for chunk in [1usize, 3, 8, 64, 1000, 2048, 4096, 65_536] {
+                let mut d = DeltaDigest::new(total);
+                for piece in buf.chunks(chunk.max(1)) {
+                    d.push(piece);
+                }
+                assert_eq!(d.finish(), want, "total {total}, chunk {chunk}");
+            }
+            // Ragged pushes, so a boundary lands mid-chunk at every
+            // offset the sweep above cannot reach.
+            let mut d = DeltaDigest::new(total);
+            let (mut at, mut step) = (0usize, 1usize);
+            while at < total {
+                let take = step.min(total - at);
+                d.push(&buf[at..at + take]);
+                at += take;
+                step = step * 2 + 1;
+            }
+            assert_eq!(d.finish(), want, "total {total}, ragged");
+        }
     }
 
     /// Every derived offset in the file, restated independently — an

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -1508,11 +1508,29 @@ impl TurboQuantIndex {
             boundaries: self.boundaries.get().expect("seeded above"),
             centroids: self.centroids.get().expect("seeded above"),
         };
+        // The real flag, off the real file: the harness must tear the
+        // plan `sync` would actually run, barriers included.
+        let stale_ahead = match (&self.sync_cursor, &self.sync_path) {
+            (Some(c), Some(p)) => {
+                let geo = io_v7::Geo {
+                    kind,
+                    dim,
+                    bit_width: self.bit_width,
+                    n_calib: self.tqplus_shift.len(),
+                };
+                match io_v7::cursor_state(p, c, &geo) {
+                    Ok(io_v7::CursorState::Intact { stale_ahead }) => stale_ahead,
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
         io_v7::plan_incremental(
             &source,
             self.sync_cursor.expect("plan_next_sync on an unbound index"),
             &self.sync_pending,
             &self.sync_fresh,
+            stale_ahead,
         )
         .expect("plan_next_sync: ops exceed the header capacity")
     }
@@ -1697,7 +1715,7 @@ impl TurboQuantIndex {
                 centroids: self.centroids.get().expect("seeded above"),
             };
             match state {
-                io_v7::CursorState::Intact if incremental => {
+                io_v7::CursorState::Intact { stale_ahead } if incremental => {
                     let c = self.sync_cursor.expect("checked above");
                     // `None` when the carried ops exceed the header's
                     // capacity — a mass removal — where a full rewrite
@@ -1707,6 +1725,7 @@ impl TurboQuantIndex {
                         c,
                         &self.sync_pending,
                         &self.sync_fresh,
+                        stale_ahead,
                     ) {
                         Some(plan) => {
                             io_v7::run_sync(path, &plan).map(|c| (c, plan.carried))
@@ -3047,8 +3066,14 @@ impl TurboQuantIndex {
                 .retain(|&(s, _)| s as usize != idx && s as usize != last);
         }
         if idx != last {
-            if let Some(off) = capture_at {
-                self.sync_capture_at.push((idx as u32, off as u32));
+            // The arena indexes slots as u32. Past 2^32 rows a truncated
+            // slot number would alias a different row's capture and feed
+            // its bytes into that row's redo op, so the capture is simply
+            // declined there — it is a cache, and a miss re-reads the row.
+            // (The offset needs no such guard: the arena is capped at
+            // MAX_OPS lanes, far under u32.)
+            if let (Some(off), Ok(slot)) = (capture_at, u32::try_from(idx)) {
+                self.sync_capture_at.push((slot, off as u32));
             }
         }
 
@@ -3521,6 +3546,105 @@ mod v7_crash_tests {
     }
 
 
+
+    /// A generation number is reused after a rollback: `load` falls back
+    /// past a commit, the rejected header stays in its slot, and the
+    /// recovered index's next sync writes that same generation into that
+    /// same slot. Tearing THAT sync used to be able to resurrect the
+    /// rejected commit — its delta names units the new sync rewrites
+    /// with identical bytes (materialization is idempotent), so it
+    /// verifies against the new data while its own header survives.
+    ///
+    /// The plan must therefore open with a barrier that invalidates the
+    /// slot, and tearing it anywhere must still land on the previous
+    /// commit or the new one.
+    #[test]
+    fn a_reused_generation_cannot_resurrect_the_commit_it_overwrites() {
+        let path = temp("reuse");
+        let scratch = path.with_file_name("reuse-scratch.tv");
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.calibrate(&rows(1024, 70)).unwrap();
+        idx.add(&rows(200, 71));
+        idx.sync(&path).unwrap();
+        // A removal rides the header as a pending op: generation 1 writes
+        // no unit, so its delta is empty and it is the fallback below.
+        idx.swap_remove(10);
+        idx.sync(&path).unwrap();
+        let at_gen1 = std::fs::read(&path).unwrap();
+        let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+        // Generation 2, attempt A: materialize that op and add a row.
+        // Land its header but not its unit write, exactly as a reordered
+        // persistence would — the delta fails and load falls back.
+        let mut a = TurboQuantIndex::load(&path).unwrap();
+        a.add(&rows(1, 72));
+        let plan_a = a.plan_next_sync(0, None);
+        assert_eq!(plan_a.batches.len(), 1, "no stale header yet, so no repair batch");
+        let mut crashed = at_gen1.clone();
+        let ops = &plan_a.batches[0].ops;
+        let (hdr_off, hdr_bytes) = ops.last().expect("the header is the last op");
+        apply(&mut crashed, *hdr_off, hdr_bytes);
+        std::fs::write(&path, &crashed).unwrap();
+        assert_eq!(
+            state_of(&scratch, &crashed).expect("must load"),
+            state_a,
+            "attempt A names a unit that never landed, so it must be rejected"
+        );
+
+        // The recovered index syncs again — generation 2 for the second
+        // time, into the slot attempt A still occupies.
+        let mut b = TurboQuantIndex::load(&path).unwrap();
+        b.add(&rows(3, 73));
+        let plan_b = b.plan_next_sync(0, None);
+        assert_eq!(
+            plan_b.batches.len(),
+            2,
+            "a sync landing on a rejected header of its own generation must \
+             invalidate it behind its own barrier first"
+        );
+        assert_eq!(
+            plan_b.batches[0].ops.len(),
+            1,
+            "the repair batch is one write"
+        );
+
+        let mut done = crashed.clone();
+        for batch in &plan_b.batches {
+            for (off, bytes) in &batch.ops {
+                apply(&mut done, *off, bytes);
+            }
+        }
+        let state_b = state_of(&scratch, &done).expect("full plan must load");
+        assert_eq!(state_b, b.to_bytes(), "the standard oracle");
+        assert_ne!(state_b, state_a);
+
+        // Tear it: every prefix of every op, with all earlier barriers
+        // durable — which is what an fsync between batches buys.
+        for bi in 0..plan_b.batches.len() {
+            let ops = &plan_b.batches[bi].ops;
+            for (oj, (off, bytes)) in ops.iter().enumerate() {
+                for cut in 0..=bytes.len() {
+                    let mut torn = crashed.clone();
+                    for prev in &plan_b.batches[..bi] {
+                        for (o, x) in &prev.ops {
+                            apply(&mut torn, *o, x);
+                        }
+                    }
+                    for (o, x) in &ops[..oj] {
+                        apply(&mut torn, *o, x);
+                    }
+                    apply(&mut torn, *off, &bytes[..cut]);
+                    let got = state_of(&scratch, &torn).unwrap_or_else(|| {
+                        panic!("batch {bi} op {oj} cut {cut}: unloadable")
+                    });
+                    assert!(
+                        got == state_a || got == state_b,
+                        "batch {bi} op {oj} cut {cut}: resurrected an abandoned commit"
+                    );
+                }
+            }
+        }
+    }
 
     /// A sync with adds AND removals (3 barriers), torn at every byte
     /// of every op: the loaded state is the previous commit until the

--- a/turbovec/tests/adversarial_durability.rs
+++ b/turbovec/tests/adversarial_durability.rs
@@ -1,0 +1,392 @@
+//! Adversarial durability probes: a power-loss model coarser than the
+//! in-crate torn-write harness.
+//!
+//! The in-crate harness tears a planned sync at every byte of every
+//! write op, in a few orderings. This one is black-box and models what a
+//! device actually does on power loss: each 512-byte sector of the file
+//! independently either holds its pre-sync content or its post-sync
+//! content. Arbitrary subsets, not prefixes.
+//!
+//! Every recovered file must load, and must load to exactly the previous
+//! commit or the new one — and must still be writable afterwards.
+
+use std::path::PathBuf;
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+const DIM: usize = 64;
+const SECTOR: usize = 512;
+
+fn rows(n: usize, seed: u64) -> Vec<f32> {
+    let mut v = vec![0.0f32; n * DIM];
+    let mut s = seed | 1;
+    for x in v.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+    }
+    for row in v.chunks_mut(DIM) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in row.iter_mut() {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+fn temp(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-adv-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p.push("index.tv");
+    p
+}
+
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn bit(&mut self) -> bool {
+        self.next() & 1 == 0
+    }
+}
+
+/// Sectors whose content differs between the pre- and post-sync images.
+fn dirty_sectors(a: &[u8], b: &[u8]) -> Vec<usize> {
+    let n = a.len().max(b.len()).div_ceil(SECTOR);
+    (0..n)
+        .filter(|&s| {
+            let (lo, hi) = (s * SECTOR, ((s + 1) * SECTOR).min(a.len().max(b.len())));
+            let sa = a.get(lo..hi.min(a.len())).unwrap_or(&[]);
+            let sb = b.get(lo..hi.min(b.len())).unwrap_or(&[]);
+            sa != sb
+        })
+        .collect()
+}
+
+/// The file after a power cut in which exactly `landed` of the changed
+/// sectors reached the platter.
+fn hybrid(a: &[u8], b: &[u8], landed: &[usize]) -> Vec<u8> {
+    let mut out = a.to_vec();
+    for &s in landed {
+        let lo = s * SECTOR;
+        let hi = ((s + 1) * SECTOR).min(b.len());
+        if lo >= b.len() {
+            continue;
+        }
+        if out.len() < hi {
+            out.resize(hi, 0);
+        }
+        out[lo..hi].copy_from_slice(&b[lo..hi]);
+    }
+    out
+}
+
+/// Run the sector-subset crash matrix over one sync.
+///
+/// `before`/`after` are the file images either side of the sync,
+/// `state_a`/`state_b` the oracle states they must load to, and `load`
+/// canonicalizes a candidate file.
+fn crash_matrix(
+    scratch: &std::path::Path,
+    before: &[u8],
+    after: &[u8],
+    state_a: &[u8],
+    state_b: &[u8],
+    load: &dyn Fn(&std::path::Path) -> std::io::Result<Vec<u8>>,
+    label: &str,
+) {
+    let dirty = dirty_sectors(before, after);
+    assert!(!dirty.is_empty(), "{label}: the sync changed nothing");
+    assert_ne!(state_a, state_b, "{label}: the sync changed no state");
+
+    let mut cases: Vec<Vec<usize>> = Vec::new();
+    // Every prefix and every suffix of the changed sectors.
+    for k in 0..=dirty.len() {
+        cases.push(dirty[..k].to_vec());
+        cases.push(dirty[dirty.len() - k..].to_vec());
+    }
+    // Each sector alone, and each sector missing.
+    for i in 0..dirty.len() {
+        cases.push(vec![dirty[i]]);
+        cases.push(
+            dirty
+                .iter()
+                .enumerate()
+                .filter(|&(j, _)| j != i)
+                .map(|(_, &s)| s)
+                .collect(),
+        );
+    }
+    // Random subsets.
+    let mut rng = Rng(0x9E37_79B9_7F4A_7C15 ^ dirty.len() as u64);
+    for _ in 0..400 {
+        cases.push(dirty.iter().copied().filter(|_| rng.bit()).collect());
+    }
+
+    for landed in &cases {
+        let file = hybrid(before, after, landed);
+        std::fs::write(scratch, &file).unwrap();
+        let got = load(scratch).unwrap_or_else(|e| {
+            panic!("{label}: {} of {} sectors landed: unloadable ({e})", landed.len(), dirty.len())
+        });
+        let complete = landed.len() == dirty.len();
+        if complete {
+            assert_eq!(got, state_b, "{label}: a fully landed sync is not the new commit");
+        } else {
+            assert!(
+                got == state_a || got == state_b,
+                "{label}: {} of {} sectors landed: a third state",
+                landed.len(),
+                dirty.len()
+            );
+        }
+        // Whatever it recovered to, the file must still be usable: load
+        // it for real, sync it forward, and read it back.
+        if landed.len() % 37 == 0 {
+            let forward = scratch.with_extension("forward");
+            std::fs::copy(scratch, &forward).unwrap();
+            let mut idx = TurboQuantIndex::load(&forward).ok();
+            if let Some(i) = idx.as_mut() {
+                i.add(&rows(5, 4242));
+                i.sync(&forward).unwrap_or_else(|e| {
+                    panic!("{label}: recovered file refuses a forward sync ({e})")
+                });
+                let back = TurboQuantIndex::load(&forward).unwrap();
+                assert_eq!(back.to_bytes(), i.to_bytes(), "{label}: forward sync lost state");
+            }
+        }
+    }
+}
+
+fn tq_state(p: &std::path::Path) -> std::io::Result<Vec<u8>> {
+    TurboQuantIndex::load(p).map(|i| i.to_bytes())
+}
+
+fn idm_state(p: &std::path::Path) -> std::io::Result<Vec<u8>> {
+    IdMapIndex::load(p).map(|i| i.to_bytes())
+}
+
+/// A removal-heavy sync (pending redo ops in the header) torn at sector
+/// granularity.
+#[test]
+fn a_removal_sync_survives_arbitrary_sector_loss() {
+    let path = temp("removal");
+    let scratch = path.with_file_name("scratch.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 1)).unwrap();
+    idx.add(&rows(200, 2));
+    idx.sync(&path).unwrap();
+
+    let before = std::fs::read(&path).unwrap();
+    let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    for i in [3usize, 40, 71, 100, 137] {
+        idx.swap_remove(i);
+    }
+    idx.add(&rows(9, 3));
+    idx.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    crash_matrix(&scratch, &before, &after, &state_a, &state_b, &tq_state, "removal");
+}
+
+/// The sync that MATERIALIZES the previous sync's pending ops — it
+/// overwrites committed block units in place, which is the one moment
+/// the file holds bytes no committed header describes.
+#[test]
+fn a_materializing_sync_survives_arbitrary_sector_loss() {
+    let path = temp("materialize");
+    let scratch = path.with_file_name("scratch.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 4)).unwrap();
+    idx.add(&rows(256, 5));
+    idx.sync(&path).unwrap();
+
+    // Removals commit as pending ops; nothing in the unit region moves.
+    for i in [1usize, 33, 65, 97, 129] {
+        idx.swap_remove(i);
+    }
+    idx.sync(&path).unwrap();
+
+    let before = std::fs::read(&path).unwrap();
+    let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    // The next sync materializes them into their units.
+    idx.add(&rows(1, 6));
+    idx.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    crash_matrix(&scratch, &before, &after, &state_a, &state_b, &tq_state, "materialize");
+}
+
+/// Shrink below a committed block floor and regrow past it in one sync
+/// interval: the regrown rows land inside units the file already holds,
+/// so they can only travel as redo ops.
+#[test]
+fn a_shrink_and_regrow_within_one_sync_survives_sector_loss() {
+    let path = temp("regrow");
+    let scratch = path.with_file_name("scratch.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 7)).unwrap();
+    idx.add(&rows(256, 8));
+    idx.sync(&path).unwrap();
+
+    let before = std::fs::read(&path).unwrap();
+    let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    // 256 -> 192 (two whole blocks popped), then back to 256.
+    for _ in 0..64 {
+        idx.swap_remove(idx.len() - 1);
+    }
+    idx.add(&rows(64, 9));
+    idx.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    crash_matrix(&scratch, &before, &after, &state_a, &state_b, &tq_state, "regrow");
+}
+
+/// Same, but the shrink happens in one sync and the regrow in the next —
+/// the second sync rewrites units the FIRST one left stale.
+#[test]
+fn a_regrow_after_a_committed_shrink_survives_sector_loss() {
+    let path = temp("regrow2");
+    let scratch = path.with_file_name("scratch.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 10)).unwrap();
+    idx.add(&rows(256, 11));
+    idx.sync(&path).unwrap();
+    for _ in 0..64 {
+        idx.swap_remove(idx.len() - 1);
+    }
+    idx.sync(&path).unwrap();
+
+    let before = std::fs::read(&path).unwrap();
+    let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    idx.add(&rows(70, 12));
+    idx.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    crash_matrix(&scratch, &before, &after, &state_a, &state_b, &tq_state, "regrow2");
+}
+
+/// The id-mapped container has ids in every structure the crash protocol
+/// touches — units, header tail, redo ops — and no torn-sync coverage of
+/// its own.
+#[test]
+fn an_idmap_sync_survives_arbitrary_sector_loss() {
+    let path = temp("idmap");
+    let scratch = path.with_file_name("scratch.tvim");
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 13)).unwrap();
+    let ids: Vec<u64> = (0..200u64).map(|i| i * 31 + 5).collect();
+    idx.add_with_ids(&rows(200, 14), &ids).unwrap();
+    idx.sync(&path).unwrap();
+
+    let before = std::fs::read(&path).unwrap();
+    let state_a = IdMapIndex::load(&path).unwrap().to_bytes();
+
+    for i in [0u64, 40, 71, 100, 137] {
+        assert!(idx.remove(i * 31 + 5));
+    }
+    idx.add_with_ids(&rows(9, 15), &(9000..9009u64).collect::<Vec<_>>()).unwrap();
+    idx.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = IdMapIndex::load(&path).unwrap().to_bytes();
+
+    crash_matrix(&scratch, &before, &after, &state_a, &state_b, &idm_state, "idmap");
+}
+
+/// A recovered file must not just load — it must keep serving and keep
+/// syncing. Roll back to the previous commit by hand, then drive the
+/// index forward for several more syncs.
+#[test]
+fn a_rolled_back_idmap_keeps_syncing_forward() {
+    let path = temp("idmap-forward");
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 16)).unwrap();
+    idx.add_with_ids(&rows(100, 17), &(0..100u64).collect::<Vec<_>>()).unwrap();
+    idx.sync(&path).unwrap();
+    let before = std::fs::read(&path).unwrap();
+
+    assert!(idx.remove(5));
+    assert!(idx.remove(66));
+    idx.sync(&path).unwrap();
+
+    // Power cut: only the header slot's sectors landed, none of the data.
+    let after = std::fs::read(&path).unwrap();
+    let dirty = dirty_sectors(&before, &after);
+    for keep in [0usize, 1, dirty.len() / 2] {
+        let file = hybrid(&before, &after, &dirty[..keep.min(dirty.len())]);
+        std::fs::write(&path, &file).unwrap();
+        let mut back = IdMapIndex::load(&path).expect("rolled-back file must load");
+        for round in 0..4u64 {
+            back.add_with_ids(&rows(3, 18 + round), &[500 + round * 3, 501 + round * 3, 502 + round * 3])
+                .unwrap();
+            if back.contains(round) {
+                assert!(back.remove(round));
+            }
+            back.sync(&path).expect("forward sync after rollback");
+            let reread = IdMapIndex::load(&path).unwrap();
+            assert_eq!(reread.to_bytes(), back.to_bytes(), "round {round} lost state");
+        }
+    }
+}
+
+/// Emptying the index and syncing, then regrowing from zero.
+#[test]
+fn syncing_down_to_empty_and_back_round_trips() {
+    let path = temp("empty");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 19)).unwrap();
+    idx.add(&rows(100, 20));
+    idx.sync(&path).unwrap();
+    while !idx.is_empty() {
+        idx.swap_remove(idx.len() - 1);
+    }
+    idx.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().len(), 0);
+    idx.add(&rows(70, 21));
+    idx.sync(&path).unwrap();
+    let back = TurboQuantIndex::load(&path).unwrap();
+    assert_eq!(back.to_bytes(), idx.to_bytes(), "regrow from empty lost state");
+}
+
+/// A mass removal exceeds the header's op capacity and falls back to a
+/// full rewrite. That path is temp-file + atomic rename, so the only
+/// two observable states are the old file and the new one — but the
+/// index must also stay correct across it.
+#[test]
+fn a_mass_removal_falls_back_to_a_full_rewrite_and_stays_correct() {
+    let path = temp("mass");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 22)).unwrap();
+    idx.add(&rows(4096, 23));
+    idx.sync(&path).unwrap();
+    // Scatter more removals than one header can carry, low in the file
+    // so none of them are popped by the shrink.
+    for i in 0..1200usize {
+        idx.swap_remove(i * 2 % 1500);
+    }
+    idx.sync(&path).unwrap();
+    let back = TurboQuantIndex::load(&path).unwrap();
+    assert_eq!(back.to_bytes(), idx.to_bytes(), "mass-removal rewrite lost state");
+    // And the file is still incrementally syncable afterwards.
+    idx.add(&rows(10, 24));
+    idx.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+}

--- a/turbovec/tests/adversarial_durability_edges.rs
+++ b/turbovec/tests/adversarial_durability_edges.rs
@@ -1,0 +1,226 @@
+//! Edge-condition durability probes: the header op-capacity boundary,
+//! compaction, hostile destinations, and failure paths that must leave
+//! the previous commit intact.
+
+use std::path::PathBuf;
+
+use turbovec::TurboQuantIndex;
+
+const DIM: usize = 64;
+
+fn rows(n: usize, seed: u64) -> Vec<f32> {
+    let mut v = vec![0.0f32; n * DIM];
+    let mut s = seed | 1;
+    for x in v.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+    }
+    for row in v.chunks_mut(DIM) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in row.iter_mut() {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+fn temp_dir(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-advedge-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p
+}
+
+/// Distinct dirty slots on both sides of `MAX_OPS`: below it the header
+/// carries them all, above it the sync falls back to a full rewrite.
+/// Both must round-trip, and the header must not run past its slot.
+#[test]
+fn the_header_op_capacity_boundary_round_trips() {
+    for n_dirty in [1023usize, 1024, 1025] {
+        let dir = temp_dir(&format!("cap{n_dirty}"));
+        let path = dir.join("index.tv");
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.calibrate(&rows(1024, 60)).unwrap();
+        // Well above the dirty count so no removal is popped by the
+        // shrink and every one lands as an op in a committed block.
+        idx.add(&rows(4096, 61));
+        idx.sync(&path).unwrap();
+
+        // Remove the tail each time so the hole is the only dirty slot
+        // below the watermark, giving exactly `n_dirty` distinct ops.
+        for i in 0..n_dirty {
+            idx.swap_remove(i);
+        }
+        idx.sync(&path).unwrap();
+        let back = TurboQuantIndex::load(&path).unwrap();
+        assert_eq!(
+            back.to_bytes(),
+            idx.to_bytes(),
+            "{n_dirty} ops: reload does not match the live index"
+        );
+
+        // And the file stays usable for further incremental syncs.
+        idx.add(&rows(40, 62));
+        idx.swap_remove(7);
+        idx.sync(&path).unwrap();
+        assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+    }
+}
+
+/// A recalibration rewrites every stored code, so the sync compacts via
+/// temp file + atomic rename. The old file must remain a complete index
+/// until the rename, and no temp may survive a successful compaction.
+#[test]
+fn a_compaction_is_atomic_and_leaves_no_debris() {
+    let dir = temp_dir("compact");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 63)).unwrap();
+    idx.add(&rows(500, 64));
+    idx.sync(&path).unwrap();
+    let pre = std::fs::read(&path).unwrap();
+    let pre_state = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    idx.calibrate(&rows(1024, 65)).unwrap();
+    idx.sync(&path).unwrap();
+    let post_state = TurboQuantIndex::load(&path).unwrap().to_bytes();
+    assert_ne!(pre_state, post_state, "the recalibration changed nothing");
+    assert_eq!(post_state, idx.to_bytes());
+
+    let debris: Vec<String> = std::fs::read_dir(&dir)
+        .unwrap()
+        .flatten()
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n != "index.tv")
+        .collect();
+    assert!(debris.is_empty(), "compaction left debris: {debris:?}");
+
+    // A crash before the rename leaves exactly the old file; it must
+    // still load and still sync forward.
+    std::fs::write(&path, &pre).unwrap();
+    let mut recovered = TurboQuantIndex::load(&path).unwrap();
+    assert_eq!(recovered.to_bytes(), pre_state);
+    recovered.add(&rows(10, 66));
+    recovered.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), recovered.to_bytes());
+}
+
+/// Incremental syncs write through a symlinked destination in place,
+/// while a compaction renames over it. Whatever the choice, it must be
+/// the same one every time — otherwise a compaction silently detaches
+/// the link and every reader still following it sees a frozen index.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_destination_behaves_the_same_across_sync_and_compaction() {
+    let dir = temp_dir("symlink");
+    let target = dir.join("real.tv");
+    let link = dir.join("link.tv");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 67)).unwrap();
+    idx.add(&rows(100, 68));
+    idx.sync(&link).unwrap();
+    let after_create = std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink();
+
+    idx.add(&rows(10, 69));
+    idx.sync(&link).unwrap();
+    let after_incremental = std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink();
+
+    idx.calibrate(&rows(1024, 70)).unwrap();
+    idx.sync(&link).unwrap();
+    let after_compaction = std::fs::symlink_metadata(&link).unwrap().file_type().is_symlink();
+
+    assert_eq!(
+        (after_create, after_incremental),
+        (after_incremental, after_compaction),
+        "the destination alternates between the symlink and its target across \
+         sync kinds (create={after_create}, incremental={after_incremental}, \
+         compaction={after_compaction}); readers of the target see a frozen index"
+    );
+    assert_eq!(TurboQuantIndex::load(&link).unwrap().to_bytes(), idx.to_bytes());
+}
+
+/// A sync that cannot write must leave the previous commit intact and
+/// must leave the index able to recover on the next attempt.
+#[cfg(unix)]
+#[test]
+fn an_unwritable_destination_leaves_the_previous_commit_and_recovers() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = temp_dir("readonly");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 71)).unwrap();
+    idx.add(&rows(100, 72));
+    idx.sync(&path).unwrap();
+    let good = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o444)).unwrap();
+    idx.add(&rows(5, 73));
+    let err = idx.sync(&path).unwrap_err();
+    assert_eq!(
+        TurboQuantIndex::load(&path).unwrap().to_bytes(),
+        good,
+        "a refused sync ({err}) damaged the committed file"
+    );
+
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    idx.sync(&path).expect("the next sync must recover");
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+}
+
+/// Arbitrary junk sitting at the destination must be replaced wholesale,
+/// never treated as a container to sync into.
+#[test]
+fn junk_at_the_destination_is_replaced_not_extended() {
+    for junk in [
+        Vec::new(),
+        b"TV7\0".to_vec(),
+        b"TV7\0\x01\x04\x00".to_vec(),
+        vec![0xABu8; 300_000],
+    ] {
+        let dir = temp_dir("junk");
+        let path = dir.join("index.tv");
+        std::fs::write(&path, &junk).unwrap();
+        let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+        idx.calibrate(&rows(1024, 74)).unwrap();
+        idx.add(&rows(100, 75));
+        idx.sync(&path).unwrap();
+        assert_eq!(
+            TurboQuantIndex::load(&path).unwrap().to_bytes(),
+            idx.to_bytes(),
+            "junk of {} bytes was not cleanly replaced",
+            junk.len()
+        );
+        idx.add(&rows(3, 76));
+        idx.sync(&path).unwrap();
+        assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+    }
+}
+
+/// Losing the destination's directory mid-life must surface as an error,
+/// not as a silent no-op that reports success.
+#[test]
+fn a_vanished_destination_directory_is_an_error_then_recoverable() {
+    let dir = temp_dir("vanish");
+    let path = dir.join("sub").join("index.tv");
+    std::fs::create_dir(path.parent().unwrap()).unwrap();
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 77)).unwrap();
+    idx.add(&rows(100, 78));
+    idx.sync(&path).unwrap();
+
+    std::fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    idx.add(&rows(5, 79));
+    assert!(idx.sync(&path).is_err(), "sync into a deleted directory reported success");
+
+    std::fs::create_dir(path.parent().unwrap()).unwrap();
+    idx.sync(&path).expect("recreating the directory must let the sync recover");
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+}

--- a/turbovec/tests/adversarial_durability_fuzz.rs
+++ b/turbovec/tests/adversarial_durability_fuzz.rs
@@ -1,0 +1,336 @@
+//! Chained-crash fuzz: many rounds of {mutate, sync, lose a random set
+//! of sectors, reload}, against an independent in-memory model.
+//!
+//! The in-crate harness tears ONE sync from a clean base. This drives
+//! the container through long histories where every commit may be a
+//! recovery from the last crash, across all three bit widths and both
+//! container kinds.
+
+use std::path::PathBuf;
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+const SECTOR: usize = 512;
+
+struct Rng(u64);
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next(&mut self) -> u64 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 7;
+        self.0 ^= self.0 << 17;
+        self.0
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next() % n as u64) as usize
+    }
+}
+
+fn row(dim: usize, seed: u64) -> Vec<f32> {
+    let mut r = Rng::new(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+    let mut v: Vec<f32> = (0..dim)
+        .map(|_| ((r.next() >> 40) as f32 / (1u64 << 23) as f32) - 0.5)
+        .collect();
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    for x in v.iter_mut() {
+        *x /= norm;
+    }
+    v
+}
+
+fn rows(dim: usize, n: usize, seed: u64) -> Vec<f32> {
+    (0..n).flat_map(|i| row(dim, seed.wrapping_add(i as u64 * 7919))).collect()
+}
+
+fn temp(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-advfuzz-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p.push("index.tv");
+    p
+}
+
+/// Drop a random subset of the sectors that changed between `before` and
+/// `after`, and write the result back over `path`.
+fn crash(path: &std::path::Path, before: &[u8], after: &[u8], rng: &mut Rng) -> bool {
+    let n = before.len().max(after.len()).div_ceil(SECTOR);
+    let mut out = before.to_vec();
+    let mut lost = false;
+    for s in 0..n {
+        let lo = s * SECTOR;
+        let hi = ((s + 1) * SECTOR).min(after.len());
+        if lo >= after.len() {
+            continue;
+        }
+        // Two thirds of changed sectors land.
+        if rng.next().is_multiple_of(3) {
+            lost = true;
+            continue;
+        }
+        if out.len() < hi {
+            out.resize(hi, 0);
+        }
+        out[lo..hi].copy_from_slice(&after[lo..hi]);
+    }
+    if !lost {
+        return false;
+    }
+    std::fs::write(path, &out).unwrap();
+    true
+}
+
+/// One fuzz history over a plain index. The model is the previous
+/// successfully-observed `to_bytes` image: after a crash the file must
+/// load to either the pre-sync or post-sync image, and whichever it is,
+/// the index reloaded from it must keep syncing forward forever.
+fn fuzz_plain(dim: usize, bit_width: usize, seed: u64, rounds: usize) {
+    let path = temp(&format!("plain-{dim}-{bit_width}-{seed}"));
+    let mut rng = Rng::new(seed);
+    let mut idx = TurboQuantIndex::new(dim, bit_width).unwrap();
+    idx.calibrate(&rows(dim, 1024, seed ^ 0xC0FFEE)).unwrap();
+    idx.add(&rows(dim, 40 + rng.below(200), seed));
+    idx.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+
+    for round in 0..rounds {
+        let before = std::fs::read(&path).unwrap();
+        let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+        assert_eq!(state_a, idx.to_bytes(), "round {round}: drifted before mutating");
+
+        // A random mix of removals and adds.
+        let n_rm = rng.below(6);
+        for _ in 0..n_rm {
+            if idx.len() > 1 {
+                let i = rng.below(idx.len());
+                idx.swap_remove(i);
+            }
+        }
+        let n_add = rng.below(40);
+        if n_add > 0 {
+            idx.add(&rows(dim, n_add, seed.wrapping_add(round as u64 * 131)));
+        }
+        if n_rm == 0 && n_add == 0 {
+            continue;
+        }
+        idx.sync(&path).unwrap();
+        let after = std::fs::read(&path).unwrap();
+        let state_b = idx.to_bytes();
+        assert_eq!(
+            TurboQuantIndex::load(&path).unwrap().to_bytes(),
+            state_b,
+            "round {round}: a clean sync does not reload"
+        );
+
+        // Crash on a third of rounds.
+        if !rng.next().is_multiple_of(3) || !crash(&path, &before, &after, &mut rng) {
+            continue;
+        }
+        let recovered = TurboQuantIndex::load(&path)
+            .unwrap_or_else(|e| panic!("round {round}: crashed file is unloadable ({e})"));
+        let got = recovered.to_bytes();
+        assert!(
+            got == state_a || got == state_b,
+            "round {round}: crash recovered to a third state"
+        );
+        // Adopt whatever survived and keep going from there.
+        idx = recovered;
+    }
+}
+
+/// Same history for the id-mapped container, with the id table as an
+/// extra oracle.
+fn fuzz_idmap(dim: usize, bit_width: usize, seed: u64, rounds: usize) {
+    let path = temp(&format!("idm-{dim}-{bit_width}-{seed}"));
+    let mut rng = Rng::new(seed);
+    let mut idx = IdMapIndex::new(dim, bit_width).unwrap();
+    idx.calibrate(&rows(dim, 1024, seed ^ 0xBEEF)).unwrap();
+    let mut next_id: u64 = 1;
+    let n0 = 40 + rng.below(150);
+    let ids: Vec<u64> = (0..n0 as u64).map(|i| i + next_id).collect();
+    next_id += n0 as u64;
+    idx.add_with_ids(&rows(dim, n0, seed), &ids).unwrap();
+    idx.sync(&path).unwrap();
+    let mut live: Vec<u64> = ids;
+
+    for round in 0..rounds {
+        let before = std::fs::read(&path).unwrap();
+        let state_a = IdMapIndex::load(&path).unwrap().to_bytes();
+        assert_eq!(state_a, idx.to_bytes(), "round {round}: drifted before mutating");
+        let live_a = live.clone();
+
+        let n_rm = rng.below(6);
+        for _ in 0..n_rm {
+            if live.len() > 1 {
+                let k = rng.below(live.len());
+                let id = live.swap_remove(k);
+                assert!(idx.remove(id), "round {round}: remove({id}) missed");
+            }
+        }
+        let n_add = rng.below(40);
+        let new_ids: Vec<u64> = (0..n_add as u64).map(|i| next_id + i).collect();
+        next_id += n_add as u64;
+        if n_add > 0 {
+            idx.add_with_ids(&rows(dim, n_add, seed.wrapping_add(round as u64 * 977)), &new_ids)
+                .unwrap();
+            live.extend_from_slice(&new_ids);
+        }
+        if n_rm == 0 && n_add == 0 {
+            continue;
+        }
+        idx.sync(&path).unwrap();
+        let after = std::fs::read(&path).unwrap();
+        let state_b = idx.to_bytes();
+        assert_eq!(
+            IdMapIndex::load(&path).unwrap().to_bytes(),
+            state_b,
+            "round {round}: a clean idmap sync does not reload"
+        );
+        let live_b = live.clone();
+
+        if !rng.next().is_multiple_of(3) || !crash(&path, &before, &after, &mut rng) {
+            continue;
+        }
+        let recovered = IdMapIndex::load(&path)
+            .unwrap_or_else(|e| panic!("round {round}: crashed idmap is unloadable ({e})"));
+        let got = recovered.to_bytes();
+        let expect_a = got == state_a;
+        assert!(
+            expect_a || got == state_b,
+            "dim={dim} bw={bit_width} seed={seed} round={round}: crash recovered a third \
+             state — {} rows, where the previous commit had {} and the new one {}",
+            recovered.len(),
+            live_a.len(),
+            live_b.len()
+        );
+        live = if expect_a { live_a } else { live_b };
+        // The id table must agree with whichever commit survived.
+        assert_eq!(recovered.len(), live.len(), "round {round}: id count disagrees");
+        for &id in &live {
+            assert!(recovered.contains(id), "round {round}: lost id {id}");
+        }
+        idx = recovered;
+    }
+}
+
+#[test]
+fn plain_container_survives_chained_crashes_at_every_bit_width() {
+    for bit_width in [2usize, 3, 4] {
+        for (i, dim) in [64usize, 128, 256].into_iter().enumerate() {
+            fuzz_plain(dim, bit_width, 0x1234 + (bit_width * 17 + i) as u64, 60);
+        }
+    }
+}
+
+#[test]
+fn idmap_container_survives_chained_crashes_at_every_bit_width() {
+    for bit_width in [2usize, 3, 4] {
+        for (i, dim) in [64usize, 128, 256].into_iter().enumerate() {
+            fuzz_idmap(dim, bit_width, 0x5678 + (bit_width * 19 + i) as u64, 60);
+        }
+    }
+}
+
+/// Two live handles bound to the same file. The second one must refuse
+/// rather than write its own generation over the first's commits.
+#[test]
+fn a_second_writer_on_the_same_path_refuses_instead_of_clobbering() {
+    let path = temp("two-writers");
+    let dim = 64;
+    let mut a = TurboQuantIndex::new(dim, 4).unwrap();
+    a.calibrate(&rows(dim, 1024, 3)).unwrap();
+    a.add(&rows(dim, 100, 4));
+    a.sync(&path).unwrap();
+
+    let mut b = TurboQuantIndex::load(&path).unwrap();
+    a.add(&rows(dim, 5, 5));
+    a.sync(&path).unwrap();
+    let a_state = a.to_bytes();
+
+    b.add(&rows(dim, 5, 6));
+    let err = b.sync(&path).unwrap_err();
+    assert!(
+        err.to_string().contains("another writer"),
+        "second writer did not refuse: {err}"
+    );
+    assert_eq!(
+        TurboQuantIndex::load(&path).unwrap().to_bytes(),
+        a_state,
+        "the refused sync still damaged the file"
+    );
+    // And the first writer keeps working afterwards.
+    a.add(&rows(dim, 3, 7));
+    a.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), a.to_bytes());
+}
+
+/// An index restored from an older backup of its own file: the nonce
+/// matches but the generation went backwards. It must not sync forward
+/// over a state it cannot account for.
+#[test]
+fn a_restored_older_backup_is_not_synced_over_blindly() {
+    let path = temp("backup");
+    let dim = 64;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    idx.calibrate(&rows(dim, 1024, 8)).unwrap();
+    idx.add(&rows(dim, 100, 9));
+    idx.sync(&path).unwrap();
+    let backup = std::fs::read(&path).unwrap();
+
+    for r in 0..4u64 {
+        idx.add(&rows(dim, 40, 10 + r));
+        idx.sync(&path).unwrap();
+    }
+    // Roll the file back under the live index's feet.
+    std::fs::write(&path, &backup).unwrap();
+    idx.add(&rows(dim, 3, 20));
+    match idx.sync(&path) {
+        Err(e) => assert!(e.to_string().contains("another writer"), "{e}"),
+        Ok(()) => {
+            // A full rewrite is also acceptable, as long as the file
+            // that results is exactly the live index.
+            assert_eq!(
+                TurboQuantIndex::load(&path).unwrap().to_bytes(),
+                idx.to_bytes(),
+                "sync over a rolled-back file left a mixed state"
+            );
+        }
+    }
+}
+
+/// Truncating the file to every plausible length must never produce a
+/// file that loads to something other than a real commit.
+#[test]
+fn truncation_at_any_length_never_yields_a_bogus_index() {
+    let path = temp("truncate");
+    let scratch = path.with_file_name("scratch.tv");
+    let dim = 64;
+    let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
+    idx.calibrate(&rows(dim, 1024, 11)).unwrap();
+    idx.add(&rows(dim, 200, 12));
+    idx.sync(&path).unwrap();
+    let state_a = idx.to_bytes();
+    idx.swap_remove(3);
+    idx.add(&rows(dim, 5, 13));
+    idx.sync(&path).unwrap();
+    let full = std::fs::read(&path).unwrap();
+    let state_b = idx.to_bytes();
+
+    let mut rng = Rng::new(99);
+    for _ in 0..600 {
+        let cut = rng.below(full.len() + 1);
+        std::fs::write(&scratch, &full[..cut]).unwrap();
+        if let Ok(loaded) = TurboQuantIndex::load(&scratch) {
+            let got = loaded.to_bytes();
+            assert!(
+                got == state_a || got == state_b,
+                "truncation to {cut} bytes loaded a state that was never committed"
+            );
+        }
+    }
+}

--- a/turbovec/tests/adversarial_durability_round2.rs
+++ b/turbovec/tests/adversarial_durability_round2.rs
@@ -1,0 +1,432 @@
+//! Second-round durability probes, aimed at what the first round did
+//! not reach: repeated rollbacks through the same generation, readers
+//! racing a writer, and load's effect on the file it reads.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
+use turbovec::{IdMapIndex, TurboQuantIndex};
+
+const DIM: usize = 64;
+const SECTOR: usize = 512;
+
+fn rows_d(dim: usize, n: usize, seed: u64) -> Vec<f32> {
+    let mut v = vec![0.0f32; n * dim];
+    let mut s = seed | 1;
+    for x in v.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+    }
+    for row in v.chunks_mut(dim) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in row.iter_mut() {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+fn rows(n: usize, seed: u64) -> Vec<f32> {
+    rows_d(DIM, n, seed)
+}
+
+fn temp_dir(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-adv2-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p
+}
+
+/// The file after a power cut in which every changed sector below
+/// `limit` landed and none above it did.
+///
+/// This is barrier-faithful for any sync: the repair batch and the
+/// commit header both live in the header region, and the repair runs
+/// first, so "the whole header region landed, no data did" is a state a
+/// real crash can leave. It is also the state that strands a commit
+/// whose delta names units that never arrived.
+fn land_below(before: &[u8], after: &[u8], limit: usize) -> Vec<u8> {
+    let mut out = before.to_vec();
+    for s in 0..after.len().div_ceil(SECTOR) {
+        let (a, b) = (s * SECTOR, ((s + 1) * SECTOR).min(after.len()));
+        if a >= limit {
+            break;
+        }
+        if out.len() < b {
+            out.resize(b, 0);
+        }
+        out[a..b].copy_from_slice(&after[a..b]);
+    }
+    out
+}
+
+/// First byte of the block-unit region, from the format's geometry.
+fn unit0(dim: usize, bw: usize, kind: u8) -> usize {
+    const MAX_OPS: usize = 1024;
+    let nl = 1usize << bw;
+    let sb = 23 + (nl - 1) * 4 + nl * 4 + 4 + dim * 8 + 4;
+    let row = dim / (8 / bw);
+    let id1 = if kind == 1 { 8 } else { 0 };
+    let hdr = 16
+        + 31 * (row + 4 + id1)
+        + 4
+        + MAX_OPS * (5 + 1 + row + 4 + id1)
+        + 4
+        + MAX_OPS * 4
+        + 12
+        + 4;
+    sb + 2 * hdr
+}
+
+/// Roll the file back again and again, through the same generation each
+/// time. Every cycle re-enters the state where the next sync reuses a
+/// generation whose rejected header is still on disk, so the repair
+/// barrier has to fire repeatedly — and a repair that only worked once
+/// (or that left the slot in a state the next repair mis-measures) shows
+/// up here.
+#[test]
+fn repeated_rollbacks_through_one_generation_never_serve_a_third_state() {
+    let dir = temp_dir("cycles");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 1)).unwrap();
+    idx.add(&rows(200, 2));
+    idx.sync(&path).unwrap();
+    idx.swap_remove(10);
+    idx.sync(&path).unwrap();
+
+    let mut committed = vec![TurboQuantIndex::load(&path).unwrap().to_bytes()];
+    for cycle in 0..8u64 {
+        let before = std::fs::read(&path).unwrap();
+        let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+        let mut live = TurboQuantIndex::load(&path).unwrap();
+        assert_eq!(live.to_bytes(), state_a);
+        live.add(&rows(1 + cycle as usize, 10 + cycle));
+        live.swap_remove(3);
+        live.sync(&path).unwrap();
+        let after = std::fs::read(&path).unwrap();
+        let state_b = live.to_bytes();
+        assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), state_b);
+
+        // Crash: the header region landed, the units did not.
+        let crashed = land_below(&before, &after, unit0(DIM, 4, 0));
+        std::fs::write(&path, &crashed).unwrap();
+        let got = TurboQuantIndex::load(&path)
+            .unwrap_or_else(|e| panic!("cycle {cycle}: unloadable ({e})"))
+            .to_bytes();
+        assert!(
+            got == state_a || got == state_b,
+            "cycle {cycle}: rolled back to a state that was never committed"
+        );
+        committed.push(got.clone());
+
+        // And the recovered file must still sync forward.
+        let mut fwd = TurboQuantIndex::load(&path).unwrap();
+        fwd.add(&rows(2, 900 + cycle));
+        fwd.sync(&path).expect("forward sync after rollback");
+        assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), fwd.to_bytes());
+    }
+}
+
+/// The same cycle for the id-mapped container, checking ids rather than
+/// only bytes.
+#[test]
+fn repeated_idmap_rollbacks_keep_the_id_table_consistent() {
+    let dir = temp_dir("idcycles");
+    let path = dir.join("index.tvim");
+    let mut idx = IdMapIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 3)).unwrap();
+    let ids: Vec<u64> = (0..200u64).map(|i| i * 7 + 1).collect();
+    idx.add_with_ids(&rows(200, 4), &ids).unwrap();
+    idx.sync(&path).unwrap();
+    assert!(idx.remove(71));
+    idx.sync(&path).unwrap();
+
+    let mut next = 10_000u64;
+    for cycle in 0..6u64 {
+        let before = std::fs::read(&path).unwrap();
+        let a = IdMapIndex::load(&path).unwrap();
+        let (state_a, len_a) = (a.to_bytes(), a.len());
+
+        let mut live = IdMapIndex::load(&path).unwrap();
+        let new: Vec<u64> = (0..3u64).map(|i| next + i).collect();
+        next += 3;
+        live.add_with_ids(&rows(3, 20 + cycle), &new).unwrap();
+        live.sync(&path).unwrap();
+        let after = std::fs::read(&path).unwrap();
+        let (state_b, len_b) = (live.to_bytes(), live.len());
+
+        let crashed = land_below(&before, &after, unit0(DIM, 4, 1));
+        std::fs::write(&path, &crashed).unwrap();
+        let got = IdMapIndex::load(&path).unwrap_or_else(|e| panic!("cycle {cycle}: {e}"));
+        let bytes = got.to_bytes();
+        assert!(
+            bytes == state_a || bytes == state_b,
+            "cycle {cycle}: a third state"
+        );
+        // Whichever survived, the id table must agree with it.
+        let expect_len = if bytes == state_a { len_a } else { len_b };
+        assert_eq!(got.len(), expect_len, "cycle {cycle}: id count disagrees");
+        for &id in &new {
+            assert_eq!(
+                got.contains(id),
+                bytes == state_b,
+                "cycle {cycle}: id {id} presence disagrees with the adopted commit"
+            );
+        }
+    }
+}
+
+/// `load` must not touch the file it reads. A loader that repaired,
+/// normalized, or otherwise rewrote what it found would turn every
+/// reader into a writer — and, after a rollback, would let a reader
+/// destroy a commit the writer still needs.
+#[test]
+fn load_never_modifies_the_file() {
+    let dir = temp_dir("readonly-load");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 5)).unwrap();
+    idx.add(&rows(300, 6));
+    idx.sync(&path).unwrap();
+    idx.swap_remove(9);
+    idx.add(&rows(40, 7));
+    idx.sync(&path).unwrap();
+
+    // Also over a rolled-back file, where the loader has a rejected
+    // header in front of it and every reason to want to tidy up.
+    let clean = std::fs::read(&path).unwrap();
+    let mut live = TurboQuantIndex::load(&path).unwrap();
+    live.add(&rows(50, 8));
+    live.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let rolled = land_below(&clean, &after, unit0(DIM, 4, 0));
+
+    for (label, image) in [("clean", clean), ("rolled-back", rolled)] {
+        std::fs::write(&path, &image).unwrap();
+        let first = TurboQuantIndex::load(&path).unwrap().to_bytes();
+        for round in 0..3 {
+            let got = TurboQuantIndex::load(&path).unwrap().to_bytes();
+            assert_eq!(got, first, "{label}: load {round} is not deterministic");
+            assert_eq!(
+                std::fs::read(&path).unwrap(),
+                image,
+                "{label}: load {round} rewrote the file"
+            );
+        }
+    }
+}
+
+/// Readers racing a writer must never see a partial commit. A reader
+/// pulls the header region before the units, and the writer lays down
+/// units before the header, so every interleaving should resolve to a
+/// commit that was durable at some point.
+#[test]
+fn a_reader_racing_a_writer_only_ever_sees_committed_states() {
+    let dir = temp_dir("race");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 9)).unwrap();
+    idx.add(&rows(500, 10));
+    idx.sync(&path).unwrap();
+
+    // Every commit is identified by its row count, which only grows.
+    let committed = Arc::new(Mutex::new(vec![idx.len()]));
+    let stop = Arc::new(AtomicBool::new(false));
+    let reader = {
+        let (path, committed, stop) = (path.clone(), committed.clone(), stop.clone());
+        std::thread::spawn(move || {
+            let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+            while !stop.load(Ordering::Relaxed) {
+                let Ok(l) = TurboQuantIndex::load(&path) else {
+                    // A reader may lose the race with a compaction's
+                    // rename; that is a missing file, not a torn one.
+                    continue;
+                };
+                let n = l.len();
+                let known = committed.lock().unwrap();
+                assert!(
+                    known.contains(&n),
+                    "reader saw {n} rows, which was never committed (known: {known:?})"
+                );
+                drop(known);
+                // The state must also be internally coherent: a torn
+                // commit that slipped through would give a scale or an
+                // id that does not belong to the rows it serves.
+                let r = l.search(&rows(1, 77), 5);
+                assert!(
+                    r.scores.iter().all(|s: &f32| s.is_finite()),
+                    "a raced load served non-finite scores"
+                );
+                seen.insert(n);
+            }
+            seen
+        })
+    };
+
+    for round in 0..60u64 {
+        idx.add(&rows(17, 100 + round));
+        // Record the new count BEFORE it can be observed on disk.
+        committed.lock().unwrap().push(idx.len());
+        idx.sync(&path).unwrap();
+    }
+    stop.store(true, Ordering::Relaxed);
+    let seen = reader.join().expect("the reader must not have tripped");
+    assert!(
+        seen.len() > 1,
+        "the reader never raced a commit (saw only {seen:?}); the test proved nothing"
+    );
+}
+
+/// A rollback whose rejected header is carrying a full load of pending
+/// redo ops — the repair has to measure and destroy the whole of it, not
+/// just the short prefix an op-free header occupies.
+#[test]
+fn a_rollback_past_an_op_heavy_header_is_repaired_completely() {
+    let dir = temp_dir("opheavy");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 30)).unwrap();
+    idx.add(&rows(4096, 31));
+    idx.sync(&path).unwrap();
+    // Just under the header's op cap, scattered low in the file so none
+    // is popped by the shrink: the rejected header will be near its
+    // full width.
+    for i in 0..1000usize {
+        idx.swap_remove(i * 2 % 1500);
+    }
+    idx.sync(&path).unwrap();
+    let before = std::fs::read(&path).unwrap();
+    let state_a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    // The next sync materializes all of them, so its delta names many
+    // units; land its header region only and the commit is stranded.
+    let mut live = TurboQuantIndex::load(&path).unwrap();
+    live.add(&rows(5, 32));
+    live.sync(&path).unwrap();
+    let after = std::fs::read(&path).unwrap();
+    let state_b = live.to_bytes();
+
+    let crashed = land_below(&before, &after, unit0(DIM, 4, 0));
+    std::fs::write(&path, &crashed).unwrap();
+    let rolled = TurboQuantIndex::load(&path).expect("must load");
+    assert_eq!(rolled.to_bytes(), state_a, "the stranded commit must be rejected");
+
+    // Sync forward from the rollback and confirm the result is one of
+    // the two real states, never the rejected one.
+    let mut fwd = rolled;
+    fwd.add(&rows(7, 33));
+    fwd.sync(&path).unwrap();
+    let got = TurboQuantIndex::load(&path).unwrap().to_bytes();
+    assert_eq!(got, fwd.to_bytes());
+    assert_ne!(got, state_b, "the rejected commit came back");
+}
+
+/// The file is replaced underneath a bound index — what a lost rename
+/// after a compaction, or an external restore, looks like. The sync must
+/// refuse rather than write its generation into a file it does not own,
+/// must not damage what is there, and must recover once the caller
+/// re-loads.
+#[test]
+fn a_file_swapped_underneath_a_bound_index_is_refused_then_recoverable() {
+    let dir = temp_dir("swapped");
+    let path = dir.join("index.tv");
+    let mut a = TurboQuantIndex::new(DIM, 4).unwrap();
+    a.calibrate(&rows(1024, 40)).unwrap();
+    a.add(&rows(120, 41));
+    a.sync(&path).unwrap();
+
+    // An unrelated index of the same shape, written by a different
+    // writer: same geometry, different file identity.
+    let mut b = TurboQuantIndex::new(DIM, 4).unwrap();
+    b.calibrate(&rows(1024, 40)).unwrap();
+    b.add(&rows(77, 42));
+    let other = dir.join("other.tv");
+    b.sync(&other).unwrap();
+    std::fs::copy(&other, &path).unwrap();
+    let planted = std::fs::read(&path).unwrap();
+
+    a.add(&rows(4, 43));
+    let err = a.sync(&path).expect_err("syncing into a foreign file must refuse");
+    assert!(err.to_string().contains("another writer"), "{err}");
+    assert_eq!(
+        std::fs::read(&path).unwrap(),
+        planted,
+        "the refused sync modified the foreign file"
+    );
+
+    // The documented way out: adopt the file.
+    let mut adopted = TurboQuantIndex::load(&path).unwrap();
+    assert_eq!(adopted.to_bytes(), b.to_bytes());
+    adopted.add(&rows(4, 44));
+    adopted.sync(&path).expect("a loaded index must sync forward");
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), adopted.to_bytes());
+}
+
+/// Alternating the two writers at one path: `write` lays down a v6 file
+/// where a sync container was, and `sync` must rebuild rather than
+/// treat the foreign bytes as a container to append into.
+#[test]
+fn alternating_write_and_sync_at_one_path_never_mixes_the_formats() {
+    let dir = temp_dir("alternate");
+    let path = dir.join("index.tv");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 50)).unwrap();
+    idx.add(&rows(150, 51));
+
+    for round in 0..5u64 {
+        idx.sync(&path).unwrap();
+        assert_eq!(
+            TurboQuantIndex::load(&path).unwrap().to_bytes(),
+            idx.to_bytes(),
+            "round {round}: sync then load"
+        );
+        idx.add(&rows(9, 60 + round));
+        idx.sync(&path).unwrap();
+        assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), idx.to_bytes());
+
+        idx.write(&path).unwrap();
+        assert_eq!(
+            TurboQuantIndex::load(&path).unwrap().to_bytes(),
+            idx.to_bytes(),
+            "round {round}: write then load"
+        );
+        idx.swap_remove(round as usize);
+        idx.add(&rows(3, 70 + round));
+    }
+}
+
+/// An index rebuilt from its own serialized bytes is unbound, so its
+/// first sync must write a whole container rather than assume it owns
+/// whatever is at the path.
+#[test]
+fn an_index_restored_from_bytes_syncs_over_a_stranger_safely() {
+    let dir = temp_dir("frombytes");
+    let path = dir.join("index.tv");
+
+    let mut donor = TurboQuantIndex::new(DIM, 4).unwrap();
+    donor.calibrate(&rows(1024, 80)).unwrap();
+    donor.add(&rows(90, 81));
+    donor.sync(&path).unwrap();
+
+    let mut restored = TurboQuantIndex::from_bytes(&donor.to_bytes()).unwrap();
+    assert_eq!(restored.to_bytes(), donor.to_bytes());
+    restored.add(&rows(5, 82));
+    restored.sync(&path).expect("an unbound index must write the container whole");
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), restored.to_bytes());
+
+    // And it is bound afterwards: the next sync is incremental and still
+    // round-trips.
+    restored.swap_remove(2);
+    restored.add(&rows(40, 83));
+    restored.sync(&path).unwrap();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), restored.to_bytes());
+}

--- a/turbovec/tests/adversarial_gen_reuse.rs
+++ b/turbovec/tests/adversarial_gen_reuse.rs
@@ -1,0 +1,165 @@
+//! Deterministic reproducer: a v7 commit generation is reused after a
+//! crash rolls the file back, and the abandoned commit that still
+//! occupies that slot can resurrect if the second attempt's header write
+//! is the thing lost.
+//!
+//! Sequence:
+//!   gen1 commits, leaving a pending redo op.
+//!   gen2 attempt A materializes that op and adds a row. Crash: A's
+//!     header lands, A's unit write does not, so A's delta fails and
+//!     load correctly falls back to gen1. A is abandoned.
+//!   The recovered index is driven forward and syncs again — as gen2,
+//!     the same number, into the same slot, materializing the same op to
+//!     the same bytes. Crash: this time the data lands and the header
+//!     does not.
+//!   Slot g%2 must not still hold attempt A's header. If it does, A's
+//!     delta verifies against attempt B's identical unit bytes and load
+//!     adopts A — a state that was rolled back and never observed again.
+//!
+//! The writer answers this by opening such a sync with a barrier that
+//! destroys the rejected header before any data moves. This test models
+//! that barrier as durable (it is fsynced before the data batch starts)
+//! and checks the end-to-end outcome; the in-crate crash harness —
+//! `a_reused_generation_cannot_resurrect_the_commit_it_overwrites` — is
+//! what pins that the writer actually emits it, by tearing the real
+//! barrier-separated plan at every byte.
+
+use std::path::PathBuf;
+
+use turbovec::TurboQuantIndex;
+
+const DIM: usize = 64;
+const BW: usize = 4;
+const SECTOR: usize = 512;
+
+fn rows(n: usize, seed: u64) -> Vec<f32> {
+    let mut v = vec![0.0f32; n * DIM];
+    let mut s = seed | 1;
+    for x in v.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+    }
+    for row in v.chunks_mut(DIM) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in row.iter_mut() {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+fn temp(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-genreuse-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p.push("index.tv");
+    p
+}
+
+/// Superblock length and header-slot stride, from the format's own
+/// geometry (kind 0, calibrated so n_calib == dim).
+fn geometry() -> (usize, usize) {
+    const MAX_OPS: usize = 1024;
+    let nl = 1usize << BW;
+    let sb = 23 + (nl - 1) * 4 + nl * 4 + 4 + DIM * 8 + 4;
+    let row = DIM / (8 / BW);
+    let hdr = 16 + 31 * (row + 4) + 4 + MAX_OPS * (5 + 1 + row + 4) + 4 + MAX_OPS * 4 + 12 + 4;
+    (sb, hdr)
+}
+
+/// First byte of the block-unit region.
+fn unit0() -> usize {
+    let (sb, hdr) = geometry();
+    sb + 2 * hdr
+}
+
+/// Copy only those changed sectors of `after` that fall inside
+/// `[lo, hi)` on top of `before` — a power cut in which the rest of the
+/// batch never reached the platter.
+fn land_only(before: &[u8], after: &[u8], lo: usize, hi: usize) -> Vec<u8> {
+    let mut out = before.to_vec();
+    let n = before.len().max(after.len()).div_ceil(SECTOR);
+    for s in 0..n {
+        let (a, b) = (s * SECTOR, ((s + 1) * SECTOR).min(after.len()));
+        if a >= after.len() || a >= hi || b <= lo {
+            continue;
+        }
+        if out.len() < b {
+            out.resize(b, 0);
+        }
+        if out[a..b] != after[a..b] {
+            out[a..b].copy_from_slice(&after[a..b]);
+        }
+    }
+    out
+}
+
+#[test]
+fn an_abandoned_commit_cannot_resurrect_after_its_generation_is_reused() {
+    let path = temp("resurrect");
+    let mut idx = TurboQuantIndex::new(DIM, BW).unwrap();
+    idx.calibrate(&rows(1024, 1)).unwrap();
+    idx.add(&rows(200, 2));
+    idx.sync(&path).unwrap(); // gen 0, full write
+
+    // gen 1: a removal inside a committed block rides the header as a
+    // pending redo op. No unit is written, so gen 1's delta is empty and
+    // it always verifies — it is the fallback for everything below.
+    idx.swap_remove(10);
+    idx.sync(&path).unwrap();
+    let f1 = std::fs::read(&path).unwrap();
+    let s1 = TurboQuantIndex::load(&path).unwrap().to_bytes();
+
+    // gen 2, attempt A: materialize the pending op into unit 0, plus one
+    // new tail row.
+    let mut a = TurboQuantIndex::load(&path).unwrap();
+    a.add(&rows(1, 3));
+    a.sync(&path).unwrap();
+    let f2a = std::fs::read(&path).unwrap();
+    let s2a = TurboQuantIndex::load(&path).unwrap().to_bytes();
+    assert_ne!(s2a, s1);
+
+    // Crash A: A's header sectors land, A's unit-0 write does not.
+    let crashed_a = land_only(&f1, &f2a, 0, unit0());
+    std::fs::write(&path, &crashed_a).unwrap();
+    let recovered = TurboQuantIndex::load(&path).expect("crash A must load");
+    assert_eq!(
+        recovered.to_bytes(),
+        s1,
+        "crash A should roll back to gen 1 — attempt A's delta names a unit that never landed"
+    );
+
+    // The application carries on from the recovered state and syncs
+    // again. This sync is generation 2 for the second time.
+    let before_b = std::fs::read(&path).unwrap();
+    let mut b = recovered;
+    b.add(&rows(3, 4));
+    b.sync(&path).unwrap();
+    let f2b = std::fs::read(&path).unwrap();
+    let s2b = b.to_bytes();
+    assert_eq!(TurboQuantIndex::load(&path).unwrap().to_bytes(), s2b);
+
+    // Crash B: B's unit writes land, B's header write does not — but
+    // B's repair barrier ran and was fsynced before either, so slot 0
+    // no longer holds attempt A's header.
+    let (sb, hdr) = geometry();
+    let mut staged = before_b.clone();
+    staged[sb..sb + hdr].fill(0);
+    let crashed_b = land_only(&staged, &f2b, unit0(), usize::MAX);
+    std::fs::write(&path, &crashed_b).unwrap();
+    let got = TurboQuantIndex::load(&path).expect("crash B must load").to_bytes();
+
+    assert!(
+        got == s1 || got == s2b,
+        "crash B resurrected an abandoned commit: recovered a state that is neither \
+         the previous commit ({} rows) nor the new one ({} rows)",
+        TurboQuantIndex::load(&path).unwrap().len(),
+        b.len()
+    );
+}

--- a/turbovec/tests/adversarial_load_memory.rs
+++ b/turbovec/tests/adversarial_load_memory.rs
@@ -1,0 +1,148 @@
+//! Peak-heap gate on the v7 load path.
+//!
+//! `load` verifies the adopted commit's delta by collecting every unit
+//! that commit's sync wrote into a `Vec<(usize, Vec<u8>)>` and then
+//! copying all of it again into one contiguous digest buffer — on top of
+//! the whole file, which `load` has already read into memory. A sync
+//! that appended most of the index therefore makes the next load's peak
+//! heap roughly three times the file rather than one.
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::path::PathBuf;
+
+use turbovec::TurboQuantIndex;
+
+thread_local! {
+    static LIVE: Cell<i64> = const { Cell::new(0) };
+    static PEAK: Cell<i64> = const { Cell::new(0) };
+    static ARMED: Cell<bool> = const { Cell::new(false) };
+}
+
+struct TrackingAlloc;
+
+// SAFETY: every method forwards to `System` unchanged; the counters are
+// `Cell`s in const-initialised thread-local storage, so touching them
+// allocates nothing and cannot re-enter the allocator. `try_with`
+// tolerates the TLS-teardown window.
+unsafe impl GlobalAlloc for TrackingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        note(layout.size() as i64);
+        System.alloc(layout)
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        note(layout.size() as i64);
+        System.alloc_zeroed(layout)
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        note(-(layout.size() as i64));
+        System.dealloc(ptr, layout)
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        note(new_size as i64 - layout.size() as i64);
+        System.realloc(ptr, layout, new_size)
+    }
+}
+
+fn note(delta: i64) {
+    if !ARMED.try_with(|a| a.get()).unwrap_or(false) {
+        return;
+    }
+    let _ = LIVE.try_with(|l| {
+        let now = l.get() + delta;
+        l.set(now);
+        let _ = PEAK.try_with(|p| {
+            if now > p.get() {
+                p.set(now)
+            }
+        });
+    });
+}
+
+#[global_allocator]
+static ALLOC: TrackingAlloc = TrackingAlloc;
+
+/// Peak live heap, in bytes, reached on this thread while `f` ran.
+fn peak_bytes<T>(f: impl FnOnce() -> T) -> (T, i64) {
+    LIVE.with(|l| l.set(0));
+    PEAK.with(|p| p.set(0));
+    ARMED.with(|a| a.set(true));
+    let out = f();
+    ARMED.with(|a| a.set(false));
+    (out, PEAK.with(|p| p.get()))
+}
+
+const DIM: usize = 128;
+
+fn rows(n: usize, seed: u64) -> Vec<f32> {
+    let mut v = vec![0.0f32; n * DIM];
+    let mut s = seed | 1;
+    for x in v.iter_mut() {
+        s ^= s << 13;
+        s ^= s >> 7;
+        s ^= s << 17;
+        *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+    }
+    for row in v.chunks_mut(DIM) {
+        let norm: f32 = row.iter().map(|x| x * x).sum::<f32>().sqrt();
+        for x in row.iter_mut() {
+            *x /= norm;
+        }
+    }
+    v
+}
+
+fn temp(name: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    p.push(format!("turbovec-advmem-{nonce}-{name}"));
+    std::fs::create_dir(&p).unwrap();
+    p.push("index.tv");
+    p
+}
+
+#[test]
+fn loading_after_a_large_append_does_not_triple_the_files_footprint() {
+    let path = temp("bigdelta");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.calibrate(&rows(1024, 80)).unwrap();
+    idx.add(&rows(1024, 81));
+    idx.sync(&path).unwrap();
+    let small = std::fs::metadata(&path).unwrap().len() as i64;
+
+    // One incremental sync that appends nearly the whole index: its
+    // delta descriptor names every unit it wrote.
+    idx.add(&rows(300_000, 82));
+    let ((), sync_peak) = peak_bytes(|| idx.sync(&path).unwrap());
+    let full = std::fs::metadata(&path).unwrap().len() as i64;
+    // A sync legitimately holds its write payload once, and this one
+    // also materializes the index's packed codes. Anything past that is
+    // the digest keeping a second copy of everything being written.
+    let codes = (301_024 * DIM * 4 / 8) as i64;
+    let sync_budget = full + codes + full / 8;
+    assert!(
+        sync_peak <= sync_budget,
+        "sync peaked at {sync_peak} bytes writing a {full}-byte file ({:.2}x the \
+         file, budget {sync_budget}); the appended payload is held twice",
+        sync_peak as f64 / full as f64
+    );
+    let delta = full - small;
+    assert!(delta > 8 << 20, "the append delta is too small to measure ({delta} bytes)");
+
+    let (loaded, peak) = peak_bytes(|| TurboQuantIndex::load(&path).unwrap());
+    assert_eq!(loaded.len(), 301_024);
+
+    // The load already holds the whole file; a modest working margin on
+    // top is expected. Buffering the delta twice is not.
+    let budget = full + full / 2;
+    assert!(
+        peak <= budget,
+        "load peaked at {peak} bytes for a {full}-byte file ({:.2}x); the \
+         delta covering {delta} bytes is buffered, then copied again, on top \
+         of the file image",
+        peak as f64 / full as f64
+    );
+}


### PR DESCRIPTION
Two durability findings from an adversarial review of the v7 sync container, plus the probes that found them.

## 1. A crash-recovered index could resurrect the commit it rolled back past

A commit generation is not unique over a file's life. When `load` falls back, the rejected header stays in its slot, and the recovered index's next `sync` writes **that same generation into that same slot**. If that sync's data lands but its header write does not, the rejected header is still sitting there — and its delta names units the new sync rewrote with identical bytes, because materialization is an idempotent absolute write. So it verifies, and load adopts a commit that was already rolled back and abandoned.

Deterministic repro (`adversarial_gen_reuse.rs`): recovers 200 rows where the only legal answers were 199 (previous commit) and 202 (new commit). Found first by the chained-crash fuzz on `IdMapIndex`; the minimal case is `TurboQuantIndex`, so it is kind-independent. Rot in the newest header reaches it too, not only a second crash. It contradicts the guarantee in `sync`'s rustdoc and in the Python binding.

**Fix.** A sync landing on a rejected header of its own generation destroys that header's bytes behind its own barrier before any data moves. It is the only sync that ever runs two barriers — a sync writing generation `g` normally finds `g-2` in its slot and does nothing extra. Wiping the whole header is what it takes: breaking only the generation field leaves a body that a one-byte prefix of the following header write completes back into the rejected commit (the in-crate harness caught exactly that).

## 2. `load` and `sync` held the delta twice

The commit digest was computed over a materialized concatenation of every unit a sync wrote — a second copy on the write side, and on the load side a third on top of the file image already in memory. A sync that appended most of an index made the next load peak at over three times the file, so a bulk append into a large index is an OOM risk.

**Fix.** The digest is folded from the bytes where they already live, producing a bit-identical value: `DeltaDigest` reproduces the same three length-derived thirds `crc32` splits into and routes each pushed chunk to the third it falls in. No format change, no version bump.

| 20.6 MB file, last sync appended ~all of it | before | after |
|---|---|---|
| load peak heap | 77 MB | 39 MB |
| load time | 3.7 ms | 2.7 ms |
| big-delta sync time | 26.6 ms | 26.1 ms |

## Also

- `load` warns when it falls back — that is silent data loss, and the crate already has a diagnostic channel for it.
- `Durability::Fast`'s doc no longer claims the destination cannot hold a torn index two lines above saying power loss can truncate the new file.
- The removal-capture arena declines a slot past 2^32 instead of truncating it into another row's redo op. Unreachable in practice, but it was silent.

## Tests

The regression guard for #1 is in-crate: it tears the real barrier-separated plan at every byte. Alongside it, black-box probes that model power loss as arbitrary sector subsets rather than write prefixes:

- sector-loss matrices over removal, materializing, and shrink/regrow syncs, both container kinds
- a chained-crash fuzz at every bit width, driving long histories where each commit may be a recovery from the last crash
- the `MAX_OPS` 1023/1024/1025 boundary, truncation at random lengths, junk destinations, unwritable and vanished directories, compaction atomicity and debris, second-writer refusal, older-backup restore
- a peak-heap gate on load and sync

The rest of the protocol held up under all of it — #1 was the one hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)