### PR TITLE
ci: make two gates enforce what they advertise

### DIFF
--- a/.github/scripts/changelog_gate.py
+++ b/.github/scripts/changelog_gate.py
@@ -391,6 +391,23 @@ def main() -> int:
     ap.add_argument("--head", default="HEAD")
     args = ap.parse_args()
 
+    # Anchor every comparison to the merge-base, not to the base branch
+    # tip. `substantive` numbers deleted lines in three-dot (merge-base)
+    # coordinates while reading its `#[cfg(test)]` exemption map from the
+    # blob at `--base`; those agree only when `--base` *is* the merge-base.
+    # CI passes `pull_request.base.sha`, which is the branch tip, so any
+    # PR left open while main moves put the two in different coordinate
+    # spaces and a deleted line could land inside a base-tip test region
+    # and be silently exempted (#490). Resolving here rather than in the
+    # workflow keeps every caller correct, and is idempotent: the
+    # merge-base of a merge-base is itself. The sibling mutation gate
+    # already does this in `mutants.yml`.
+    mb = subprocess.run(
+        ["git", "merge-base", args.base, args.head], capture_output=True, text=True
+    )
+    if mb.returncode == 0 and mb.stdout.strip():
+        args.base = mb.stdout.strip()
+
     hatch = escape_hatch()
     if hatch:
         print(f"{hatch} - changelog gate skipped.")

--- a/.github/scripts/test_changelog_gate.py
+++ b/.github/scripts/test_changelog_gate.py
@@ -267,3 +267,73 @@ class EndToEnd(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class MergeBaseAnchoring(unittest.TestCase):
+    """The gate must compare against the merge-base, not the base tip.
+
+    `substantive` numbers deleted lines in three-dot (merge-base)
+    coordinates but reads its `#[cfg(test)]` exemption map from the blob
+    at `--base`. CI passes the base *branch tip*, so once main moves past
+    the merge-base the two disagree, and a deleted shipped line whose
+    merge-base number happens to fall inside a base-tip test region is
+    silently exempted (#490). Reproduces that shape end to end.
+    """
+
+    def git(self, *args: str) -> str:
+        return subprocess.run(
+            ["git", "-C", self.repo, *args],
+            check=True, capture_output=True, text=True,
+        ).stdout.strip()
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = self.tmp.name
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.email", "t@example.com")
+        self.git("config", "user.name", "t")
+        src = Path(self.repo) / "turbovec" / "src"
+        src.mkdir(parents=True)
+        (Path(self.repo) / "CHANGELOG.md").write_text("# Changelog\n")
+        # Merge-base: the shipped fn sits on line 5.
+        (src / "x.rs").write_text(
+            "// one\n// two\n// three\n// four\n"
+            "pub fn shipped_secret() -> u8 { 7 }\n"
+        )
+        self.git("add", "-A")
+        self.git("commit", "-qm", "base")
+        self.merge_base = self.git("rev-parse", "HEAD")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_deleted_public_fn_is_caught_when_base_branch_moved_on(self) -> None:
+        src = Path(self.repo) / "turbovec" / "src" / "x.rs"
+        # Head branches from the merge-base and deletes the shipped fn,
+        # with no CHANGELOG entry.
+        self.git("checkout", "-q", "-b", "head")
+        src.write_text("// one\n// two\n// three\n// four\n")
+        self.git("commit", "-qam", "delete shipped fn")
+        head = self.git("rev-parse", "HEAD")
+
+        # Base tip advances so that base-tip line 5 is inside a test region.
+        self.git("checkout", "-q", "main")
+        src.write_text(
+            "#[cfg(test)]\nmod t {\n    fn a() {}\n    fn b() {}\n    fn c() {}\n}\n"
+            "pub fn shipped_secret() -> u8 { 7 }\n"
+        )
+        self.git("commit", "-qam", "wrap early lines in a test module")
+        base_tip = self.git("rev-parse", "HEAD")
+        self.assertNotEqual(base_tip, self.merge_base)
+
+        proc = subprocess.run(
+            ["python3", GATE, "--base", base_tip, "--head", head],
+            cwd=self.repo, capture_output=True, text=True,
+            env={"PR_BODY": "", "PR_LABELS": "", "PATH": "/usr/bin:/bin:/usr/local/bin"},
+        )
+        self.assertEqual(
+            proc.returncode, 1,
+            "deleting a shipped public fn with no CHANGELOG entry must fail the "
+            f"gate even when the base branch moved on.\nstdout: {proc.stdout}\n"
+            f"stderr: {proc.stderr}",
+        )

--- a/.github/scripts/test_changelog_gate.py
+++ b/.github/scripts/test_changelog_gate.py
@@ -265,8 +265,6 @@ class EndToEnd(unittest.TestCase):
         self.assertIn("No substantive changes", out)
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 class MergeBaseAnchoring(unittest.TestCase):
@@ -337,3 +335,7 @@ class MergeBaseAnchoring(unittest.TestCase):
             f"gate even when the base branch moved on.\nstdout: {proc.stdout}\n"
             f"stderr: {proc.stderr}",
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,12 @@ all-features = true
 
 [advisories]
 version = 2
+# `supply-chain.yml` advertises this gate as "RustSec vulnerabilities +
+# yanked crates", but cargo-deny defaults `yanked` to Warn and
+# `cargo deny check` only exits non-zero on Deny-level findings — so a
+# yanked dependency produced a warning and a green run (#491). A yank is
+# the registry telling us not to use a version; treat it as blocking.
+yanked = "deny"
 # New RustSec advisories filed against already-pinned dependencies are the
 # main thing the weekly scheduled run exists to surface. Keep this list tight
 # and documented — every entry is a consciously accepted residual.


### PR DESCRIPTION
Two gates that read as passing while not checking what their own documentation says they check. Same root cause, different files: correct intent, weaker predicate, and no test on the gate itself.

### Yanked crates were never blocking — #491

`supply-chain.yml:56` describes the advisories gate as "RustSec vulnerabilities + yanked crates". `deny.toml` set no `yanked` level, and cargo-deny defaults it to `Warn`; `cargo deny check` exits non-zero only on Deny-level findings. So a yanked dependency produced a warning and a green run.

Set `yanked = "deny"`. Verified `cargo deny check advisories` still passes on the current lockfile.

### The changelog gate could silently exempt deletions of shipped code — #490

`substantive` numbers deleted lines in three-dot (merge-base) coordinates, but builds its `#[cfg(test)]` exemption map from the blob at `--base`. CI passes `pull_request.base.sha` — the base *branch tip* — so as soon as main advances past the merge-base, the deletion line numbers and the exemption map are in different coordinate spaces. A deleted shipped line whose merge-base number happened to land inside a base-tip test region was treated as a test-region change and exempted.

That matters because "a removed importable module" is one of the four misses this gate exists to catch, and the gate's own doctrine is that it must never silently disable itself.

**Fix:** resolve the merge-base inside the script. The sibling mutation gate does this in `mutants.yml`, but doing it in the script keeps every caller correct rather than only the one that remembers, and it's idempotent — the merge-base of a merge-base is itself. Unrelated histories fall back to the supplied base rather than raising.

**Regression test** builds the exact shape from the report: a head that deletes a public fn with no CHANGELOG entry, and a base tip that has since wrapped those line numbers in `#[cfg(test)]`. I confirmed it fails without the fix — the gate prints "No substantive changes to shipped surface; no changelog entry required" and exits 0. Full suite: 23 tests, green.

### Not included

#306's two remaining items (Python version matrix, integration extras in the release smoke) are a CI-cost tradeoff rather than a defect, so they get their own PR.

Closes #491, #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)