### PR TITLE
perf(v7): size allocations from content, not from convenient bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A synced index no longer holds the whole file in RAM, and a sync no
+  longer holds its payload twice.** `load` carried the entire `fs::read`
+  allocation into the blocked cache for the index's lifetime — header
+  reserve, per-block scale and id sections and post-`n` padding included —
+  because `truncate` does not release capacity and the following `resize`
+  stayed inside it. And `unit_bytes` received a codes buffer allocated to
+  exactly its codes, so appending scales and ids grew it, and amortized
+  growth doubled every unit held in the write batch. Measured at dim 3072
+  with 564 rows: retained heap after load drops from 1.00x the file to
+  0.22x (the codes, which is what a v6 load holds). At dim 768 with 100k
+  rows a large incremental sync peaks at 0.99x the file instead of 1.95x.
 - **A crash-recovered synced index can no longer resurrect the commit it
   rolled back past.** A commit generation is not unique over a file's
   life: when `load` falls back, the rejected header stays in its slot and

--- a/turbovec/src/io_v7.rs
+++ b/turbovec/src/io_v7.rs
@@ -584,8 +584,16 @@ fn header_slot(
 fn unit_bytes(src: &SyncSource<'_>, block: usize) -> Vec<u8> {
     let geo = src.geo();
     let from = block * BLOCK;
-    let mut u = (src.seq_blocks)(from, from + BLOCK);
-    debug_assert_eq!(u.len(), BLOCK * geo.row_bytes());
+    // Sized for the whole unit up front. `seq_blocks` hands back a
+    // Vec allocated to exactly its codes, so appending the scales and
+    // ids below used to grow it — and amortized growth doubles, leaving
+    // every unit in `batch.ops` holding ~2x its bytes for the life of
+    // the sync (#483).
+    let codes = (src.seq_blocks)(from, from + BLOCK);
+    debug_assert_eq!(codes.len(), BLOCK * geo.row_bytes());
+    let mut u = Vec::with_capacity(geo.unit_len());
+    u.extend_from_slice(&codes);
+    drop(codes);
     for lane in 0..BLOCK {
         let r = from + lane;
         let v = if r < src.n_vectors { src.scales[r] } else { 0.0 };
@@ -1260,6 +1268,13 @@ pub(crate) fn load(path: &Path, expect_calib_gen: u64, expect_kind: u8) -> io::R
     }
     raw.truncate(n_blocks * block_bytes);
     raw.resize(total_blocks * block_bytes, 0);
+    // `truncate` never releases capacity and the `resize` stays inside
+    // it, so without this the whole-file `fs::read` allocation — header
+    // reserve, per-block scale and id sections, post-`n` padding, all
+    // bytes the search path never reads — is carried in the blocked
+    // cache for the index's lifetime (#480). The shrinking realloc
+    // releases the tail rather than copying.
+    raw.shrink_to_fit();
     let mut seq_blocked = raw;
 
     // Pending ops override their slots in the compacted buffer.


### PR DESCRIPTION
Two places where an allocation was sized by something easy to reach for rather than by what was needed. Opposite ends of the file lifecycle, same root cause.

### A loaded index retained the whole file — #480

`load` reads the file with `fs::read`, compacts the codes in place, then truncates and resizes. `Vec::truncate` never releases capacity and the following `resize` stays inside it, so the file-sized allocation was moved into `BlockedCache.data` and kept for the index's lifetime — carrying the header reserve, every block's scale and id section, and the post-`n` padding, none of which the search path ever reads.

Added the `shrink_to_fit` the issue proposed. The shrinking realloc releases the tail rather than copying.

### Every unit in a sync's write batch held ~2x its bytes — #483

`seq_blocks` returns a Vec allocated to exactly its codes; `unit_bytes` then appended the scales and ids to it. That grows the Vec, amortized growth doubles, and each unit then sat in `batch.ops` at roughly twice its content until the sync finished.

The buffer is now sized to `geo.unit_len()` up front. #512 already removed the other copy this issue described — the separate `delta_bytes` image — so this is the remaining half, and it's the sub-cause the issue itself named.

### Measured

Counting global allocator, same geometries as the issues:

| | before | after |
|---|---|---|
| retained after load — dim 3072, 564 rows | 1.00x file | **0.22x file** |
| sync peak — dim 768, 100k-row append | 1.95x file | **0.99x file** |

0.22x is the codes themselves, which is what a v6 load of the same data holds — matching #480's own comparison table.

A/B'd by reverting each fix in place and re-measuring, so the before column is this build rather than the issue's original numbers.

Full suite green; clippy clean on the touched file.

Closes #480, #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)