### PR TITLE
test: stop the reader-race test asserting on timing

### DIFF
--- a/turbovec/tests/adversarial_durability_round2.rs
+++ b/turbovec/tests/adversarial_durability_round2.rs
@@ -241,8 +241,17 @@ fn a_reader_racing_a_writer_only_ever_sees_committed_states() {
     // Every commit is identified by its row count, which only grows.
     let committed = Arc::new(Mutex::new(vec![idx.len()]));
     let stop = Arc::new(AtomicBool::new(false));
+    // Shared so the writer can keep committing until the reader has
+    // actually straddled a commit. A fixed round count made this
+    // timing-dependent: in a debug build a load is slow enough that the
+    // reader can finish every one of its loads at a single row count,
+    // and the anti-vacuity assertion below then fires on a run where
+    // nothing was wrong.
+    let observed: Arc<Mutex<std::collections::HashSet<usize>>> =
+        Arc::new(Mutex::new(std::collections::HashSet::new()));
     let reader = {
-        let (path, committed, stop) = (path.clone(), committed.clone(), stop.clone());
+        let (path, committed, stop, observed) =
+            (path.clone(), committed.clone(), stop.clone(), observed.clone());
         std::thread::spawn(move || {
             let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             while !stop.load(Ordering::Relaxed) {
@@ -267,22 +276,34 @@ fn a_reader_racing_a_writer_only_ever_sees_committed_states() {
                     "a raced load served non-finite scores"
                 );
                 seen.insert(n);
+                observed.lock().unwrap().insert(n);
             }
             seen
         })
     };
 
-    for round in 0..60u64 {
-        idx.add(&rows(17, 100 + round));
+    // Commit until the reader has seen two distinct states, with a
+    // generous cap so a pathologically slow runner ends the test rather
+    // than hanging it.
+    let start = std::time::Instant::now();
+    let mut rounds = 0u64;
+    while rounds < 4000 && start.elapsed() < std::time::Duration::from_secs(60) {
+        idx.add(&rows(17, 100 + rounds));
         // Record the new count BEFORE it can be observed on disk.
         committed.lock().unwrap().push(idx.len());
         idx.sync(&path).unwrap();
+        rounds += 1;
+        if rounds >= 60 && observed.lock().unwrap().len() > 1 {
+            break;
+        }
     }
     stop.store(true, Ordering::Relaxed);
     let seen = reader.join().expect("the reader must not have tripped");
     assert!(
         seen.len() > 1,
-        "the reader never raced a commit (saw only {seen:?}); the test proved nothing"
+        "after {rounds} commits in {:?} the reader still saw only {seen:?}; \
+         the race never happened and the test proved nothing",
+        start.elapsed()
     );
 }
 


### PR DESCRIPTION
A test I added in the round-2 durability sweep is flaky in the debug profile and is now on main, so it reds unrelated PRs. It failed the debug leg of #515 — a docs-only change — with:

```
the reader never raced a commit (saw only {500}); the test proved nothing
```

**Cause.** The test runs a fixed 60 commits while a reader thread loads in a loop, then asserts the reader observed more than one distinct row count. That assertion is deliberate — it stops the test passing vacuously if the reader never straddles a commit — but it is a timing assertion. In a debug build a load is slow enough that the reader can complete every one of its loads at a single count, so it fires on runs where nothing is wrong.

**Fix.** The writer now keeps committing until the reader has actually seen two states, capped at 4000 commits or 60 seconds so a pathological runner ends the test rather than hanging it. The anti-vacuity assertion stays — it is the point of the test — but now reports the commit count and elapsed time it gave up after, so a genuine failure reads differently from a slow machine.

Nothing about the correctness checks changes: every load is still asserted to match a committed row count and to return finite scores.

Five consecutive debug runs green, plus release. Worth landing ahead of the other open PRs since it is currently failing their CI too.