### PR TITLE
fix(llama_index): filter on the metadata the store actually returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **LlamaIndex: filters now run on the metadata the store returns.** Each
+  node was stored twice — the raw Python mapping for filtering and the
+  JSON-coerced copy for rebuilding the returned node — so any coercing
+  type diverged: a tuple filtered as `("a", "b")` and came back as
+  `["a", "b"]`, a datetime filtered as a datetime and came back as an ISO
+  string, and because `persist()` re-coerces, the same filter changed
+  answers across a save/reload cycle. The store now keeps and filters the
+  coerced dict, matching `SimpleVectorStore`, which is self-consistent and
+  persist-invariant.
 - **A synced index no longer holds the whole file in RAM, and a sync no
   longer holds its payload twice.** `load` carried the entire `fs::read`
   allocation into the blocked cache for the index's lifetime — header

--- a/turbovec-python/python/turbovec/llama_index.py
+++ b/turbovec-python/python/turbovec/llama_index.py
@@ -100,6 +100,43 @@ _TEXT_MATCH_INSENSITIVE = getattr(FilterOperator, "TEXT_MATCH_INSENSITIVE", None
 _CONDITION_NOT = getattr(FilterCondition, "NOT", None)
 
 
+def _payload_for(node: BaseNode) -> dict:
+    """The stored record for one node.
+
+    ``metadata`` holds the **JSON-coerced** view, not ``node.metadata``.
+    Filtering reads this field and ``_reconstruct_node`` rebuilds the
+    returned node from ``node_dict``, which is itself
+    ``model_dump(mode="json")`` — so keeping a raw copy here meant the
+    store filtered on values it would never hand back. A tuple filtered
+    as ``(1, 2)`` and returned as ``[1, 2]``; a datetime filtered as a
+    datetime and returned as an ISO string; and because ``persist()``
+    re-coerces through JSON, the same filter changed answers across a
+    save/reload cycle (#497).
+
+    ``SimpleVectorStore`` stores the coerced dict from
+    ``node_to_metadata_dict`` and filters on that same dict, so it is
+    self-consistent and persist-invariant. This matches it.
+    """
+    node_dict = node_to_metadata_dict(node, remove_text=False, flat_metadata=False)
+    # The coerced metadata lives inside the serialized node content; fall
+    # back to the raw mapping if a future llama-index shape omits it,
+    # since a filter on stale-but-present values beats crashing an add.
+    coerced = None
+    content = node_dict.get("_node_content")
+    if isinstance(content, str):
+        try:
+            coerced = json.loads(content).get("metadata")
+        except (ValueError, AttributeError):
+            coerced = None
+    if not isinstance(coerced, dict):
+        coerced = dict(node.metadata)
+    return {
+        "metadata": coerced,
+        "ref_doc_id": node.ref_doc_id,
+        "node_dict": node_dict,
+    }
+
+
 def _validate_namespace(namespace: str) -> str:
     """Reject a ``namespace`` that would escape the caller-chosen
     ``persist_dir`` when composed into a filename.
@@ -341,16 +378,7 @@ class TurboQuantVectorStore(BasePydanticVectorStore):
         # start/end_char_idx and mimetype on retrieval. The narrow
         # `{text, metadata, ref_doc_id}` schema we used to keep lost
         # all of those silently.
-        payloads = [
-            {
-                "metadata": dict(node.metadata),
-                "ref_doc_id": node.ref_doc_id,
-                "node_dict": node_to_metadata_dict(
-                    node, remove_text=False, flat_metadata=False
-                ),
-            }
-            for node in nodes
-        ]
+        payloads = [_payload_for(node) for node in nodes]
 
         # Cosine mode: L2-normalize outside the lock (pure computation)
         # so the engine's raw inner product is true cosine similarity.

--- a/turbovec-python/tests/test_llama_index.py
+++ b/turbovec-python/tests/test_llama_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import numpy as np
 import pytest
 
@@ -215,6 +216,22 @@ def test_failed_persist_preserves_previous_store(tmp_path):
         )
 
     store.add([_make_node("bad", seed=3, metadata={"bad": {1, 2, 3}})])
+
+    # The store keeps the JSON-coerced metadata rather than the raw
+    # mapping (#497), so a set in node metadata is a list by the time it
+    # is stored and persist() no longer trips on it. Where that is true
+    # the mid-persist failure is unreachable from metadata at all — the
+    # same situation the upstream probe above skips for, one layer down.
+    try:
+        json.dumps(store._nodes)
+    except TypeError:
+        pass
+    else:
+        pytest.skip(
+            "stored payloads are JSON-coerced at add() time, so a "
+            "persist-time TypeError cannot be provoked through metadata"
+        )
+
     with pytest.raises(TypeError):
         store.persist(str(persist_path))
 
@@ -1898,3 +1915,73 @@ def test_from_persist_dir_rejects_a_rewound_next_u64_watermark(tmp_path):
 
     with pytest.raises(ValueError, match="next_u64"):
         TurboQuantVectorStore.from_persist_dir(str(tmp_path))
+
+
+def test_filters_operate_on_the_metadata_that_is_returned(tmp_path):
+    """The store filtered raw Python metadata but returned the JSON-coerced
+    copy, so a filter could match a value the caller never sees — and,
+    because persist() re-coerces, the same filter changed answers across a
+    save/reload cycle (#497). SimpleVectorStore stores and filters the
+    coerced dict; this pins that we do the same."""
+    import datetime
+
+    from llama_index.core.vector_stores.types import (
+        FilterOperator,
+        MetadataFilter,
+        MetadataFilters,
+        VectorStoreQuery,
+    )
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    node = _make_node("tup", seed=1, metadata={"tags": ("a", "b"), "n": 3})
+    store.add([node])
+
+    # What is stored for filtering must be what a query hands back.
+    stored = list(store._nodes.values())[0]["metadata"]
+    q = VectorStoreQuery(query_embedding=_unit_vec(1, 64), similarity_top_k=1)
+    returned = store.query(q).nodes[0]
+    assert stored == returned.metadata, (
+        f"filtered-on {stored!r} but returned {returned.metadata!r}"
+    )
+    # And it is the coerced shape, not the raw tuple.
+    assert stored["tags"] == ["a", "b"]
+
+    # A filter written against the returned value matches.
+    flt = MetadataFilters(
+        filters=[MetadataFilter(key="tags", value=["a", "b"], operator=FilterOperator.EQ)]
+    )
+    q2 = VectorStoreQuery(
+        query_embedding=_unit_vec(1, 64), similarity_top_k=5, filters=flt
+    )
+    assert len(store.query(q2).nodes) == 1
+
+    # Persist-invariance: the same filter must give the same answer after
+    # a reload, which is what the raw/coerced split broke.
+    p = tmp_path / "s.json"
+    store.persist(str(p))
+    reloaded = TurboQuantVectorStore.from_persist_path(str(p))
+    assert len(reloaded.query(q2).nodes) == 1
+    assert list(reloaded._nodes.values())[0]["metadata"] == stored
+
+
+def test_datetime_metadata_round_trips_consistently(tmp_path):
+    """A datetime is coerced to an ISO string on the way out; the filter
+    side must agree, before and after a persist (#497)."""
+    import datetime
+
+    from llama_index.core.vector_stores.types import VectorStoreQuery
+
+    store = TurboQuantVectorStore.from_params(dim=64, bit_width=4)
+    when = datetime.datetime(2020, 1, 1, 12, 0, 0)
+    store.add([_make_node("dt", seed=2, metadata={"when": when})])
+
+    stored = list(store._nodes.values())[0]["metadata"]["when"]
+    q = VectorStoreQuery(query_embedding=_unit_vec(2, 64), similarity_top_k=1)
+    returned = store.query(q).nodes[0].metadata["when"]
+    assert stored == returned, f"stored {stored!r} but returned {returned!r}"
+    assert isinstance(stored, str), "expected the JSON-coerced ISO string"
+
+    p = tmp_path / "d.json"
+    store.persist(str(p))
+    reloaded = TurboQuantVectorStore.from_persist_path(str(p))
+    assert list(reloaded._nodes.values())[0]["metadata"]["when"] == stored


### PR DESCRIPTION
Each node was kept twice: `metadata` held the raw Python mapping and was what every filter read, while `node_dict` held `model_dump(mode="json")` and was what `_reconstruct_node` rebuilt the returned node from.

For any JSON-coercing type the two disagreed, so the store filtered on values it would never hand back:

| metadata | filtered on | returned |
|---|---|---|
| `("a", "b")` | tuple | `["a", "b"]` |
| `datetime(2020, 1, 1)` | datetime | `"2020-01-01T00:00:00"` |

And because `persist()` re-coerces the raw copy through JSON, the same filter produced different results before and after a save/reload cycle.

`SimpleVectorStore.add` stores the coerced dict from `node_to_metadata_dict` and filters on that same dict — self-consistent and persist-invariant. This matches it: the stored `metadata` is now the coerced view lifted out of `_node_content`, with a fallback to the raw mapping if a future llama-index shape omits it.

### Tests

Two regression tests, one on tuples and one on datetimes, each asserting that what is filtered equals what is returned, and that a filter written against the returned value still matches after a persist/reload. Both verified failing with the coercion reverted.

**One existing test needed its skip widened.** `test_failed_persist_preserves_previous_store` provokes #159 by adding a node whose metadata holds a `set` and expecting `persist()` to raise `TypeError`. Coercing at add time makes that unreachable *through metadata* — the payload is JSON-safe by the time it is stored. That is the same situation the test's existing upstream probe already skips for, one layer down, so it now probes the stored payload too and skips with that reason. The #159 guarantee itself is unchanged and still tested wherever the failure is reachable.

### Pre-existing failure, not from this PR

`test_query_returns_node_with_full_field_fidelity` fails on `main` in this environment too — `metadata_separator` does not survive the round trip on the installed llama-index-core. I confirmed by stashing this change and re-running. Untouched here.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)