### PR TITLE
ci: exercise the abi3 floor on all three OSes, and the integrations at release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,16 +429,6 @@ jobs:
         shell: bash
         run: pytest turbovec-python/tests/ -v
 
-  # pyproject.toml promises `haystack-ai>=2.23.0` and `agno>=2.5.4`, but the
-  # matrix above installs `>=2.0` for both and pip resolves that to the newest
-  # release — so the floors users are told to trust have never once been
-  # executed (#306). This leg installs each extra at exactly its declared
-  # floor and runs the four integration suites against it.
-  #
-  # The pins are derived from pyproject rather than copied here, so raising a
-  # floor automatically moves what CI tests and the two cannot drift apart.
-  # ubuntu-only: a floor is a dependency-resolution property, not a platform
-  # one, so a three-OS matrix would buy nothing for three times the build.
   # The wheel is abi3-py39: one artifact claims 3.9 through 3.14, but the
   # `python` matrix above only ever runs 3.11. Import-testing the floor on
   # all three OSes is where limited-API breakage shows up — a symbol that
@@ -500,6 +490,16 @@ jobs:
           # themselves via importorskip, which is the intended shape.
           python -m pytest tests/test_index.py tests/test_id_map.py -q
 
+  # pyproject.toml promises `haystack-ai>=2.23.0` and `agno>=2.5.4`, but the
+  # matrix above installs `>=2.0` for both and pip resolves that to the newest
+  # release — so the floors users are told to trust have never once been
+  # executed (#306). This leg installs each extra at exactly its declared
+  # floor and runs the four integration suites against it.
+  #
+  # The pins are derived from pyproject rather than copied here, so raising a
+  # floor automatically moves what CI tests and the two cannot drift apart.
+  # ubuntu-only: a floor is a dependency-resolution property, not a platform
+  # one, so a three-OS matrix would buy nothing for three times the build.
   integration-floors:
     name: Integration extras at their declared floors
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,67 @@ jobs:
   # floor automatically moves what CI tests and the two cannot drift apart.
   # ubuntu-only: a floor is a dependency-resolution property, not a platform
   # one, so a three-OS matrix would buy nothing for three times the build.
+  # The wheel is abi3-py39: one artifact claims 3.9 through 3.14, but the
+  # `python` matrix above only ever runs 3.11. Import-testing the floor on
+  # all three OSes is where limited-API breakage shows up — a symbol that
+  # exists in 3.11 but not 3.9, or a macOS/Windows loader difference the
+  # Linux-only release check never sees (#306).
+  #
+  # Deliberately a separate job rather than another matrix axis on
+  # `python`: that job's name is a required status check, and adding an
+  # axis renames every leg of it.
+  #
+  # Floor only. The 3.14 ceiling stays in release-pypi.yml, where a wheel
+  # is already being built for publication; running it here as well would
+  # double this job for the version least likely to break the *limited*
+  # API.
+  python-abi3-floor:
+    name: Python abi3 floor (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14, windows-latest]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Build with 3.11 — maturin needs an interpreter it supports, and the
+      # abi3 wheel it produces is not tied to it.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Build the abi3 wheel
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install maturin
+          maturin build --release --locked --out dist
+
+      # Now switch to the floor and load that same artifact.
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.9"
+
+      - name: Install the wheel on the abi3 floor and exercise it
+        shell: bash
+        working-directory: turbovec-python
+        run: |
+          python -VV
+          python -m pip install --upgrade pip
+          python -m pip install pytest numpy
+          python -m pip install dist/*.whl
+          # Import first: a limited-API violation fails here, before any
+          # test collection noise.
+          python -c "import turbovec; print(turbovec.__file__)"
+          # Then the core suites. The integration extras are not installed
+          # here — several do not support 3.9 — so those files skip
+          # themselves via importorskip, which is the intended shape.
+          python -m pytest tests/test_index.py tests/test_id_map.py -q
+
   integration-floors:
     name: Integration extras at their declared floors
     runs-on: ubuntu-latest

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -77,6 +77,11 @@ jobs:
       # regressions that produce structurally-correct .so files which
       # fail at Python import time — exactly the class of bug that was
       # silently shipping in Linux wheels until this PR.
+      # The integration extras go in alongside the wheel. Without them
+      # every haystack / langchain / llama-index / agno test file
+      # `importorskip`s out, so the run that gates a release exercised
+      # none of the four integrations — the gap ci.yml's `python` job
+      # already closes for PRs (#306).
       - name: Install wheel and smoke test
         shell: bash
         working-directory: turbovec-python
@@ -84,6 +89,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pytest
           python -m pip install dist/*.whl
+          python -m pip install \
+            "langchain-core>=0.3" \
+            "llama-index-core>=0.12.1" \
+            "haystack-ai>=2.0" \
+            "agno>=2.0"
           python -m pytest tests/ -v
       # The wheel is abi3-py39: a single artifact claims Python 3.9-3.14,
       # but only 3.11 is exercised above. Import-test the same wheel on


### PR DESCRIPTION
The last two items of #306. Five of its seven were closed by earlier work; these were still open.

### Only Python 3.11 ran tests

The wheel is `abi3-py39` — one artifact claiming 3.9 through 3.14 — but ci.yml's `python` matrix pins 3.11 on every OS, and the floor was import-tested only in `release-pypi.yml`, only on Linux. So a limited-API violation, or a macOS/Windows loader difference at 3.9, had nothing looking for it until publish time.

New `python-abi3-floor` job: build the wheel on 3.11, switch the interpreter to 3.9, install that same artifact, import it, and run the core suites. On ubuntu, macOS and Windows.

**Separate job, not another matrix axis.** The `python` job's name is a required status check; adding an axis renames every leg of it and every renamed check stops reporting. This was worth avoiding given how the repo's gates are wired.

**Floor only.** The 3.14 ceiling stays in `release-pypi.yml`, where a wheel is already being built for publication. The floor is the end where the limited API actually bites, and doubling this job for the ceiling buys little.

The integration extras are deliberately *not* installed in the floor job — several don't support 3.9 — so those files skip themselves, which is the intended shape rather than an oversight.

### The release smoke skipped every integration

`release-pypi.yml` installed the wheel and pytest and nothing else, so all four integration test files `importorskip`ed out of the very run that gates a publish. The extras now go in alongside the wheel, matching what ci.yml already does for PRs.

### Checks

Both workflow files parse as YAML, and the existing `python` job's name is unchanged — no required status check is renamed by this.

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)