### PR TITLE
perf: converge a built index onto the search layout alone (#475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,10 +148,20 @@ appears under each surface it touches.
   the first search stops paying a repack (78.9 ms to 0.5 ms). Steady-state
   search throughput is unchanged. The trade is that the repack is no longer
   skippable: a build-then-`write()` flow that never searches now pays it,
-  worth about +8-12% on total one-time build cost. Nothing else changes —
-  `packed_codes()` and `calibrate` rebuild the packed rows on demand, and
-  subsequent adds take the existing lazy-append path straight into the
-  blocked layout.
+  worth about +8-12% on total one-time build cost. `packed_codes()` and
+  `calibrate` rebuild the packed rows on demand, and subsequent adds take
+  the existing lazy-append path straight into the blocked layout.
+
+  **`packed_ready()` changes observably.** It reports which layout is
+  materialized, so dropping the packed rows makes it `false` after any
+  `add`: `new()` → `true`, `add` → `false`, `packed_codes()` → `true`,
+  `add` → `false`. Two properties it had before are gone — it no longer
+  only goes `false` → `true`, and `false` no longer identifies a
+  v6-loaded index, since a built index now reaches the same state. No
+  in-tree consumer gates behaviour on it (the Python binding dropped its
+  probes in #392), and it was never a "has this been loaded" probe — but
+  it is public API, and the docs on it, on `IdMapIndex::slots_ready` and
+  on `IdMapIndex::prepare` are updated to match.
 - **`VALIDATE_CHUNK` is exported as `#[doc(hidden)]` so its test derives
   the chunk size instead of copying it (#463).** The input-validation
   reporting test needs an input that genuinely spans more than one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,23 @@ appears under each surface it touches.
 
 #### Changed
 
+- **A built index now holds one code layout in RAM instead of two (#475).**
+  The encoder writes the bit-plane (mutation) layout and the first search
+  derived the SIMD-blocked (search) layout from it; nothing ever freed the
+  first, so an index built in-process carried both for its lifetime while
+  an index *loaded* from disk had always lived on the blocked layout alone.
+  `add` now builds the blocked layout at its commit point — work search,
+  `save` and `prepare` all had to do anyway, only moved earlier — and drops
+  the packed rows, converging a built index onto exactly the blocked-only
+  state the load path has always used. Measured at 100k x 768d 4-bit: 136.9
+  MB retained after build-then-search becomes 69.3 MB, a 49% reduction, and
+  the first search stops paying a repack (78.9 ms to 0.5 ms). Steady-state
+  search throughput is unchanged. The trade is that the repack is no longer
+  skippable: a build-then-`write()` flow that never searches now pays it,
+  worth about +8-12% on total one-time build cost. Nothing else changes —
+  `packed_codes()` and `calibrate` rebuild the packed rows on demand, and
+  subsequent adds take the existing lazy-append path straight into the
+  blocked layout.
 - **`VALIDATE_CHUNK` is exported as `#[doc(hidden)]` so its test derives
   the chunk size instead of copying it (#463).** The input-validation
   reporting test needs an input that genuinely spans more than one

--- a/turbovec/src/id_map.rs
+++ b/turbovec/src/id_map.rs
@@ -776,8 +776,10 @@ impl IdMapIndex {
     /// which is the same steady state a first allowlist search would
     /// have reached.
     ///
-    /// Idempotent and O(1) once warm: [`Self::slots_ready`] and
-    /// [`Self::packed_ready`] both only go false → true.
+    /// Idempotent and O(1) once warm: nothing here tears down what it
+    /// builds, and [`Self::slots_ready`] only goes false → true.
+    /// ([`Self::packed_ready`] is not monotonic since #475 — an `add`
+    /// drops the packed rows — but `prepare` never unsets it.)
     pub fn prepare(&self) {
         self.inner.prepare();
         self.ids();
@@ -825,7 +827,10 @@ impl IdMapIndex {
     /// leaves it empty (see the internal `ids` accessor), so the first `remove` after a
     /// load pays an O(n) map build; callers that must not stall on that
     /// (the Python binding, which would hold the GIL — issue #319) probe
-    /// this first. Like [`Self::packed_ready`] it only goes false → true.
+    /// this first. It only goes false → true: the map is built once and
+    /// no path tears it down. (Not an analogy to [`Self::packed_ready`],
+    /// which since #475 also goes true → false — an `add` drops the
+    /// packed rows it reports on.)
     pub fn slots_ready(&self) -> bool {
         self.id_to_slot.get().is_some()
     }

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1303,9 +1303,13 @@ mod eager_add_unwind {
         let dim = 64;
         let mut idx = TurboQuantIndex::new(dim, 4).unwrap();
         idx.add_2d(&rows(1200, dim, 1), dim).unwrap();
-        // Materialize the blocked cache so the eager path takes the patch
-        // branch at all.
+        // The patch branch needs BOTH layouts live. Since #475 an add
+        // converges the index to blocked-only, so the cache alone is not
+        // enough — the next add would take `lazy_append` and never reach
+        // the repack. Materializing the packed rows through the public
+        // accessor restores the both-live state the branch is defined for.
         idx.prepare();
+        let _ = idx.packed_codes();
         let before_len = idx.len();
         let before_bytes = idx.to_bytes();
 

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -531,25 +531,35 @@ impl TurboQuantIndex {
 
     /// Whether the packed bit-plane rows are materialized.
     ///
-    /// On a **non-empty** v6 [`Self::load`], `false` until something
-    /// calls [`Self::packed_codes`] — and **nothing else does**. The
-    /// blocked cache the load seeds is authoritative in that state, so
-    /// [`Self::add`] takes the lazy-append branch, [`Self::swap_remove`]
+    /// It answers exactly one question: which of the two code layouts is
+    /// currently materialized. In particular it is **not monotonic** and
+    /// **not** a "has this index been loaded" probe.
+    ///
+    /// Since #475 an [`Self::add`] converges the index onto the blocked
+    /// layout alone — it drops the packed rows at its commit point — so
+    /// this reports `false` after any add, and a built index is
+    /// indistinguishable here from a loaded one. It goes back to `true`
+    /// if something re-materializes the rows ([`Self::packed_codes`],
+    /// [`Self::calibrate`]), and `false` again on the next add:
+    ///
+    /// ```text
+    /// new()  true -> add  false -> packed_codes()  true -> add  false
+    /// ```
+    ///
+    /// Before #475 it only ever went `false` → `true`, and `false`
+    /// therefore identified a v6-loaded index. Neither holds now.
+    ///
+    /// On a **non-empty** v6 [`Self::load`] it likewise starts `false`.
+    /// The blocked cache the load seeds is authoritative in that state,
+    /// so [`Self::add`] takes the lazy-append branch, [`Self::swap_remove`]
     /// patches the cache with O(dim) lane ops, and serialization copies
     /// the cache verbatim; none of them triggers the O(n·dim)
-    /// reconstruction, and none of them sets this flag. Such an index can
-    /// therefore report `false` for its entire lifetime however much it
-    /// is mutated.
+    /// reconstruction. (A v6 load of an **empty** index seeds the lock
+    /// directly, so that one starts `true`.)
     ///
-    /// The one path that does set it without `packed_codes` is out of
-    /// reach there: a v6 load of an **empty** index seeds the lock
-    /// directly.
-    ///
-    /// So this is **not** a "first mutation after a load" probe, and
-    /// gating a binding's fast path on it means gating it off forever on
-    /// every loaded index — the defect behind #392. It answers exactly
-    /// one question: which of the two code layouts is currently
-    /// materialized.
+    /// So gating a binding's fast path on it means gating it off on every
+    /// loaded index, and now on every mutated one too — the defect behind
+    /// #392.
     pub fn packed_ready(&self) -> bool {
         self.packed_codes.get().is_some()
     }

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -929,10 +929,41 @@ impl TurboQuantIndex {
         // Maintain the blocked cache incrementally instead of discarding
         // it: appended rows only affect the (possibly partial) tail block
         // and the new blocks after it, so recompute exactly those from
-        // the packed rows. A cold cache stays cold (first search builds
-        // it). Rotation, boundaries, and centroids remain valid (they
-        // only depend on `(dim, ROTATION_SEED)` and `(bit_width, dim)`).
-        if self.blocked.get().is_some() {
+        // the packed rows. Rotation, boundaries, and centroids remain
+        // valid (they only depend on `(dim, ROTATION_SEED)` and
+        // `(bit_width, dim)`).
+        //
+        // A cold cache is built here rather than left for the first search:
+        // this is the last point that holds the packed rows, and converging
+        // to a blocked-only index (at the commit point below) is what lets
+        // them go. A built index then costs one layout in RAM, exactly like
+        // a loaded one, instead of carrying both for its lifetime (#475).
+        // The repack is not extra work — search, save and prepare all
+        // needed it anyway; it only moves earlier.
+        if self.blocked.get().is_none() {
+            let bit_width = self.bit_width;
+            // Same unwind contract as the patch path below: the buffers are
+            // owned locally here, so a panicking repack must put them back
+            // before resuming (#388).
+            let built = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                #[cfg(test)]
+                if FORCE_REPACK_PANIC.with(|f| f.replace(false)) {
+                    panic!("forced repack panic (test)");
+                }
+                pack::repack(&packed_codes, new_n, bit_width, dim)
+            })) {
+                Ok(built) => built,
+                Err(panic) => {
+                    packed_codes.truncate(packed_len_before);
+                    scales_buf.truncate(scales_len_before);
+                    self.packed_codes = OnceLock::from(packed_codes);
+                    self.scales = scales_buf;
+                    std::panic::resume_unwind(panic);
+                }
+            };
+            let (data, n_blocks) = built;
+            let _ = self.blocked.set(BlockedCache { data, n_blocks });
+        } else {
             let (new_n_blocks, n_byte_groups, _) =
                 pack::blocked_geometry(new_n, self.bit_width, dim);
             let block_bytes = n_byte_groups * BLOCK;
@@ -978,7 +1009,17 @@ impl TurboQuantIndex {
             cache.n_blocks = new_n_blocks;
         }
         // Commit point: every fallible step above has succeeded.
-        self.packed_codes = OnceLock::from(packed_codes);
+        //
+        // `packed_codes` is deliberately NOT republished — dropping it here
+        // is the whole of #475. The blocked cache is guaranteed present by
+        // the branch above and is byte-for-byte sufficient: `packed()`
+        // rebuilds these rows from it on the rare paths that want them
+        // (`calibrate`, the `packed_codes()` accessor), and every hot path
+        // — search, save, swap_remove, and the next add via `lazy_append`
+        // — reads the cache directly. This is the state a v6/v7-loaded
+        // index has always lived in, so no new mode is introduced; the
+        // build path simply stops being the exception.
+        drop(packed_codes);
         self.scales = scales_buf;
         self.n_vectors = new_n;
     }

--- a/turbovec/tests/io_v6.rs
+++ b/turbovec/tests/io_v6.rs
@@ -906,3 +906,35 @@ fn v6_load_does_not_pay_for_a_codebook_solve() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// `packed_ready` reports which code layout is materialized *right now*.
+/// Since #475 an `add` converges the index onto the blocked layout and
+/// drops the packed rows, so the probe is no longer monotonic and `false`
+/// no longer identifies a loaded index — a built one reaches the same
+/// state. Both properties were previously documented, and `slots_ready`
+/// cited this one by analogy, so pin the real sequence.
+#[test]
+fn packed_ready_tracks_the_live_layout_and_is_not_monotonic() {
+    let dim = 64;
+    let mut idx = turbovec::TurboQuantIndex::new(dim, 4).unwrap();
+    // A freshly constructed index seeds the lock with an empty vec.
+    assert!(idx.packed_ready(), "a fresh index starts with packed rows");
+
+    idx.add(&vec![0.1f32; dim * 100]);
+    assert!(
+        !idx.packed_ready(),
+        "add must converge onto the blocked layout and drop the packed rows (#475)"
+    );
+
+    // Re-materializing flips it back...
+    let _ = idx.packed_codes();
+    assert!(idx.packed_ready(), "packed_codes() re-materializes the rows");
+
+    // ...and the next add drops them again: true -> false -> true -> false.
+    idx.add(&vec![0.2f32; dim * 10]);
+    assert!(
+        !idx.packed_ready(),
+        "the probe oscillates; it is not a one-way latch"
+    );
+    assert_eq!(idx.len(), 110);
+}


### PR DESCRIPTION
An index built in-process kept both code layouts in RAM. The encoder writes the bit-plane (mutation) rows, the first search derives the SIMD-blocked (search) layout from them, and nothing ever freed the first — so a built index carried both for its lifetime. An index *loaded* from disk never had that problem: the file reader doesn't materialise packed rows, so a loaded index has always lived on the blocked layout alone.

So this isn't a new mode — it's the build path finally doing what the load path already does.

## The change

`add` builds the blocked layout at its commit point and drops the packed rows there. Every path that genuinely wants packed rows (`calibrate`, the `packed_codes()` accessor) already rebuilds them on demand, and the next `add` takes the existing lazy-append path straight into the blocked layout — the same one loaded indexes have always used.

The cold-build repack is wrapped in the same unwind guard as the existing patch path, so a panicking repack still restores the pre-call buffers (#388's contract).

## Measured — 100k x 768d, 4-bit

| | before | after |
|---|---|---|
| retained after build-then-search | 136.9 MB | **69.3 MB** (-49%) |
| first search | 78.9 ms | 0.5 ms |
| steady-state search | 1655-1708 us | 1710-1739 us (noise, see below) |

One copy of the codes is 36.6 MB, so before was carrying two and after carries one.

The steady-state search numbers overlap but don't look identical, so I checked them against the **load path, which this diff does not touch and which is byte-identical in both builds**: it measured 1667-1714 us on the baseline build and 1730-1731 us on the fixed build. The same spread on identical code, so the search delta is machine noise, not a regression.

**The real cost:** the repack is no longer skippable. A build-then-`write()` flow that never searches now pays it, worth about +8-12% on total one-time build cost — and that holds single-threaded (302-326 ms -> 346-351 ms at `RAYON_NUM_THREADS=1`) as well as multi-threaded. Everything that searches, saves or prepares was paying it anyway; it only moves earlier.

## Tests

Full Rust suite green. One existing test changed: `a_panicking_cache_repack_leaves_the_index_at_its_pre_call_state` now materialises the packed rows explicitly, because after this change an index is blocked-only after its first add, so the second add takes lazy-append and never reaches the eager patch branch the test exists to cover. The branch is unchanged and still covered.

Closes #475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)