### PR TITLE
fix: five release-blocking bugs (#484, #501, #487, #473, #493)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **aarch64: crossing the single-query block-parallel gate no longer makes
+  the same query slower (#493).** At `n_blocks >= 1024` (n ≥ 32768) an
+  unmasked `nq=1` search switches to the block-parallel scan, which ran
+  the full 32-lane top-k loop for every block — while the sub-gate kernel
+  it replaces has a whole-block SIMD-max prune that skips that loop once
+  the heap is warm. The result was a discontinuity exactly at the gate:
+  measured at dim=128, 4-bit, k=10, one thread, 77.9 µs at 1023 blocks
+  against 105.9 µs at 1024 — 36% slower for 0.1% more data. The prune is
+  now mirrored into the parallel scan: 105.9 → 84.9 µs at the gate, 141.7
+  → 120.2 µs at 1500 blocks, 183.9 → 166.8 µs at 2048, and the
+  discontinuity is gone (85.7 µs at 1023 blocks against 84.9 at 1024).
+  Multi-threaded is neutral to ~5% better. Results are unchanged — a block
+  whose maximum is at or below the heap minimum holds no lane that could
+  enter the heap.
 - **A v6 `load()` no longer commits memory proportional to the file's
   apparent length (#487).** Two allocations were sized from the file
   rather than from what its header declares. The tail (scales, TQ+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,9 @@ appears under each surface it touches.
   cache on both the lazy-append and eager-patch paths) now reserve close
   to what they need when the append is at most an eighth of current
   length, keeping an eighth as headroom so a run of small adds stays
-  amortized. Larger appends keep amortized doubling unchanged, which is
+  amortized — the reserve is skipped entirely when the spare capacity
+  already covers the append, which is what makes that headroom usable
+  instead of merely requested. Larger appends keep amortized doubling unchanged, which is
   what repeated same-size batch adds rely on for O(1) growth; add
   throughput is unchanged single- and multi-threaded.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **The first small add after a load, a bulk add or a search no longer
+  permanently doubles the codes buffer (#501).** `Vec::reserve` grows
+  amortized — on `len == capacity` it takes `max(len + additional,
+  capacity * 2)` — so appending a single row to a tight buffer allocated a
+  second full copy and kept it as capacity slack for the index's lifetime,
+  since every later small add then fit inside it. A load, a `from_bytes`,
+  a one-shot bulk add and a `search`/`prepare` all leave exactly that
+  tight state, which made "load a large index, add a small delta" — the
+  workflow v7 `sync()` exists for — the worst case: a 2.4 GB index grew by
+  2.4 GB (blocked-only) to 4.8 GB (packed plus warm blocked) on its first
+  incremental add. All four growth sites (codes, scales, and the blocked
+  cache on both the lazy-append and eager-patch paths) now reserve close
+  to what they need when the append is at most an eighth of current
+  length, keeping an eighth as headroom so a run of small adds stays
+  amortized. Larger appends keep amortized doubling unchanged, which is
+  what repeated same-size batch adds rely on for O(1) growth; add
+  throughput is unchanged single- and multi-threaded.
+
 - **A finite-but-unusable calibration no longer loads clean and NaNs every
   score.** `tqplus_scale` was checked for `finite && > 0`, so a value like
   `1e-40` was accepted by `from_parts` and by every `.tv`/`.tvim` loader —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,23 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A v6 `load()` no longer commits memory proportional to the file's
+  apparent length (#487).** Two allocations were sized from the file
+  rather than from what its header declares. The tail (scales, TQ+
+  trailer, `.tvim` id table) took the whole remainder past the codes
+  section, so a genuine 2450-byte index padded into a 4 GiB sparse file
+  loaded correctly but peaked at 8.2 GB; the tail is now sized from
+  declared content and still capped by the real remainder, so a truncated
+  file fails exactly where it did. Separately, `load` / `load_id_map` read
+  the entire file *before* comparing four bytes to the magic, so pointing
+  them at a 4 GiB non-turbovec file cost 4 GB of RSS to produce "wrong
+  magic" — the magic is now checked from a 4 KB prefix, which reproduces
+  every rejection message (v1's missing magic, a v7 container, the
+  versions 1–4 rebuild error) without the read. `write()` always emits
+  exact-length files, so this only ever bit on files turbovec did not
+  write — but a sparse file makes a large apparent length nearly free to
+  fabricate. Trailing bytes are still accepted, matching `from_bytes` and
+  `load_from_reader`.
 - **The first small add after a load, a bulk add or a search no longer
   permanently doubles the codes buffer (#501).** `Vec::reserve` grows
   amortized — on `len == capacity` it takes `max(len + additional,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1822,6 +1822,14 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **Agno: `async_insert`, `upsert` and `async_upsert` now fail before
+  embedding when `create()` was not called (#473).** Sync `insert()`
+  already refused at that boundary, but the other three embedded the
+  batch first and only discovered the uninitialized store when they
+  delegated into it — so a caller who forgot `create()` still paid for
+  the embedding work (a paid API call, GPU time) on a write that could
+  never succeed. All four now check the same boundary first, with the
+  same error. Empty batches are unchanged and remain a no-op.
 - **A deletion no longer stalls for seconds while searches are running
   (#484).** `swap_remove` and `IdMapIndex.remove` route through a
   GIL-aware write lock that, when contended, waited for the lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1787,6 +1787,23 @@ appears under each surface it touches.
 
 #### Fixed
 
+- **A deletion no longer stalls for seconds while searches are running
+  (#484).** `swap_remove` and `IdMapIndex.remove` route through a
+  GIL-aware write lock that, when contended, waited for the lock
+  *detached*, immediately dropped it, and retried *attached*. That threw
+  away `RwLock`'s queueing fairness: `search` holds the read lock for its
+  whole detached duration, so the retry had to win an unsynchronised race
+  against every searcher, and one background searcher was enough to
+  starve a delete. Measured at n=400k, dim=128: eight removals took 3.35 s
+  with a single searcher (worst 3352 ms) and 17.63 s with four (p50 2228
+  ms) — against 66 ns uncontended — and an earlier 8-searcher probe never
+  returned at all. The helper now takes a closure and performs the removal
+  *inside* one detached blocking acquire, inheriting the queueing the
+  other write paths (`add`, `prepare`, `__len__`, `remove`'s slow path)
+  have always used. The same probes now take 0.22 s (worst 37 ms) and
+  0.76 s (p50 101 ms); `IdMapIndex.remove` under four searchers goes from
+  22.93 s (worst 10 280 ms) to 0.29 s (worst 55 ms). The uncontended
+  `try_write` fast path is unchanged and still costs 0.34 us/op.
 - **Copying or saving a warming-up index that has been drained to zero
   no longer commits the copy to identity calibration forever (#418).**
   Deleting every document from a store that never reached 1000 vectors

--- a/turbovec-python/python/turbovec/agno.py
+++ b/turbovec-python/python/turbovec/agno.py
@@ -451,6 +451,23 @@ class TurboQuantVectorDb(VectorDb):
             # the sync fallback, but off the event loop.
             await asyncio.to_thread(self._embed_missing, to_embed)
 
+    def _require_initialized(self) -> None:
+        """Raise unless create() has run.
+
+        Called before any embedding work, not after it: embedding is the
+        expensive part of a write (a paid API call, GPU time), and a write
+        into an uninitialized store is doomed from the start. `insert()`
+        already failed at this boundary; `async_insert`, `upsert` and
+        `async_upsert` embedded first and only discovered it when they
+        delegated here (#473).
+        """
+        if self._index is None:
+            # Match LanceDb's "table not initialized" handling: do not
+            # silently auto-create. Callers must invoke create() first.
+            raise RuntimeError(
+                "TurboQuantVectorDb not initialized — call create() before insert()."
+            )
+
     def insert(
         self,
         content_hash: str,
@@ -459,12 +476,7 @@ class TurboQuantVectorDb(VectorDb):
     ) -> None:
         if not documents:
             return
-        if self._index is None:
-            # Match LanceDb's "table not initialized" handling: do not
-            # silently auto-create. Callers must invoke create() first.
-            raise RuntimeError(
-                "TurboQuantVectorDb not initialized — call create() before insert()."
-            )
+        self._require_initialized()
 
         # Merge `filters` into each document's metadata (matches LanceDb).
         if filters:
@@ -615,6 +627,9 @@ class TurboQuantVectorDb(VectorDb):
     ) -> None:
         if not documents:
             return
+        # Before embedding, not after: insert() would raise anyway, but
+        # only once the embedder had already run (#473).
+        self._require_initialized()
         await self._embed_missing_async(documents)
         # Now every doc should have an embedding; insert delegates to
         # sync — on a worker thread, so the loop is free for the whole
@@ -638,6 +653,10 @@ class TurboQuantVectorDb(VectorDb):
         # Embed up front so the embedder (a user component) runs outside
         # the writer lock; insert() then finds nothing left to embed.
         if documents:
+            # Same boundary as insert(), before the embedder runs (#473).
+            # Gated on there being documents so an empty upsert keeps its
+            # existing behaviour exactly.
+            self._require_initialized()
             self._embed_missing(documents)
         # Capture the existing generation's handles, run the insert, and
         # only then drop the old vectors — so a failed insert (dim
@@ -671,6 +690,9 @@ class TurboQuantVectorDb(VectorDb):
         # The delegation runs on a worker thread (#342); that adds no
         # suspension point *inside* the locked body, so the issue-#146
         # reasoning above is unaffected.
+        if documents:
+            # See `upsert` — fail before the embedder runs (#473).
+            self._require_initialized()
         await self._embed_missing_async(documents)
         await asyncio.to_thread(self.upsert, content_hash, documents, filters)
 

--- a/turbovec-python/src/lib.rs
+++ b/turbovec-python/src/lib.rs
@@ -329,28 +329,38 @@ fn lock_write<T>(lock: &std::sync::RwLock<T>) -> std::sync::RwLockWriteGuard<'_,
         .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
-/// Write-lock for O(1) ops called while attached to the GIL: try the
-/// lock without blocking (the uncontended fast path — cheaper than a
-/// GIL detach round-trip), and only when another thread holds the lock
-/// (e.g. a multi-second bulk add) detach before waiting, so a brief
-/// removal never stalls every Python thread behind a long writer.
-fn lock_write_gil_aware<'l, T: Send + Sync>(
+/// Run `f` under the write lock, for O(1) ops called while attached to
+/// the GIL: try the lock without blocking (the uncontended fast path —
+/// cheaper than a GIL detach round-trip), and only when another thread
+/// holds it detach and acquire it blocking, so a brief removal never
+/// stalls every Python thread behind a long writer.
+///
+/// The work is a closure rather than a returned guard because a guard
+/// cannot cross a GIL release. The previous shape returned one, so the
+/// contended path could only wait *detached* and then retry *attached* —
+/// acquiring the lock fairly and immediately dropping it. That threw
+/// away `RwLock`'s queueing fairness and left progress depending on
+/// winning an unsynchronised race against every reader. `search` holds
+/// the read lock for its whole detached duration, so one background
+/// searcher was enough to starve a delete indefinitely: 66 ns
+/// uncontended became 23 s worst-case with a single searcher, and an
+/// 8-searcher probe never returned at all (#484). Performing the removal
+/// inside the one detached acquire inherits the fairness instead — the
+/// same thing `add`, `prepare`, `__len__` and the `remove` slow path
+/// have always done.
+#[inline]
+fn with_write_gil_aware<T: Send + Sync, R: Send>(
     py: Python<'_>,
-    lock: &'l std::sync::RwLock<T>,
-) -> std::sync::RwLockWriteGuard<'l, T> {
-    loop {
-        match lock.try_write() {
-            Ok(guard) => return guard,
-            Err(std::sync::TryLockError::Poisoned(p)) => return p.into_inner(),
-            Err(std::sync::TryLockError::WouldBlock) => {
-                // A guard cannot cross the GIL release, so wait for the
-                // lock detached (acquire and immediately drop), then
-                // retry attached. Another thread may slip in between —
-                // the loop just waits again; each iteration makes
-                // progress once the long writer finishes.
-                py.detach(|| drop(lock_write(lock)));
-            }
-        }
+    lock: &std::sync::RwLock<T>,
+    f: impl FnOnce(&mut T) -> R + Send,
+) -> R {
+    match lock.try_write() {
+        Ok(mut guard) => f(&mut guard),
+        Err(std::sync::TryLockError::Poisoned(p)) => f(&mut p.into_inner()),
+        // Contended: one blocking acquire, detached, with the work done
+        // inside it. No retry loop — the acquire is queued and cannot be
+        // jumped by a reader that arrives after it.
+        Err(std::sync::TryLockError::WouldBlock) => py.detach(|| f(&mut lock_write(lock))),
     }
 }
 
@@ -857,15 +867,14 @@ impl TurboQuantIndex {
             // the probe is permanently false there and would send every
             // remove through a pool handoff costing far more than the
             // removal (#392; see `TurboQuantIndex::packed_ready`).
-            let removed = {
-                let mut inner = lock_write_gil_aware(py, &self.inner);
+            let removed = with_write_gil_aware(py, &self.inner, |inner| {
                 let len = inner.len();
                 if i < len {
                     Ok(inner.swap_remove(i))
                 } else {
                     Err(len)
                 }
-            };
+            });
             match removed {
                 Ok(moved) => return Ok(moved),
                 Err(len) => {
@@ -1091,7 +1100,7 @@ impl IdMapIndex {
                 if ready {
                     self.slots_ready
                         .store(true, std::sync::atomic::Ordering::Relaxed);
-                    lock_write_gil_aware(py, &self.inner).remove(v)
+                    with_write_gil_aware(py, &self.inner, |inner| inner.remove(v))
                 } else {
                     // Builds the map as a side effect, so the next remove
                     // takes the fast path without probing for it.

--- a/turbovec-python/tests/test_agno.py
+++ b/turbovec-python/tests/test_agno.py
@@ -1900,3 +1900,72 @@ def test_async_insert_still_works_with_a_sync_only_embedder():
     emb, db = asyncio.run(run())
     assert emb.calls == 4, f"sync embedder should have been used, got {emb.calls}"
     assert db.get_count() == 4
+
+
+class CountingEmbedder(StubEmbedder):
+    """StubEmbedder that records how many times it was asked to embed.
+
+    A write into a store that never had create() called is doomed, so the
+    embedder — which may be a paid API call or GPU work — must not run
+    first (#473).
+    """
+
+    def __init__(self, dim: int = DIM) -> None:
+        super().__init__(dim)
+        self.calls = 0
+
+    def get_embedding(self, text: str) -> list[float]:
+        self.calls += 1
+        return super().get_embedding(text)
+
+    async def async_get_embedding(self, text: str) -> list[float]:
+        self.calls += 1
+        return await super().async_get_embedding(text)
+
+    # Agno's Document.embed goes through the *_and_usage surface, so the
+    # counter has to cover it too or an unfixed build never reaches the
+    # assertion.
+    def get_embedding_and_usage(self, text: str):
+        self.calls += 1
+        return self._embed(text), {"tokens": 1}
+
+    async def async_get_embedding_and_usage(self, text: str):
+        self.calls += 1
+        return self._embed(text), {"tokens": 1}
+
+
+def test_async_insert_before_create_does_not_embed():
+    import asyncio
+
+    emb = CountingEmbedder()
+    db = TurboQuantVectorDb(embedder=emb)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        asyncio.run(db.async_insert("h", [_doc("a", pre_embed=False)]))
+    assert emb.calls == 0, "embedded a document for a write that could not succeed"
+
+
+def test_upsert_before_create_does_not_embed():
+    emb = CountingEmbedder()
+    db = TurboQuantVectorDb(embedder=emb)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        db.upsert("h", [_doc("a", pre_embed=False)])
+    assert emb.calls == 0, "embedded a document for a write that could not succeed"
+
+
+def test_async_upsert_before_create_does_not_embed():
+    import asyncio
+
+    emb = CountingEmbedder()
+    db = TurboQuantVectorDb(embedder=emb)
+    with pytest.raises(RuntimeError, match="not initialized"):
+        asyncio.run(db.async_upsert("h", [_doc("a", pre_embed=False)]))
+    assert emb.calls == 0, "embedded a document for a write that could not succeed"
+
+
+def test_empty_writes_before_create_still_do_nothing():
+    """The guard must not turn a no-op into an error."""
+    import asyncio
+
+    db = TurboQuantVectorDb(embedder=CountingEmbedder())
+    db.insert("h", [])
+    asyncio.run(db.async_insert("h", []))

--- a/turbovec/src/encode.rs
+++ b/turbovec/src/encode.rs
@@ -619,7 +619,8 @@ pub(crate) fn encode_prerotated(
     // bytes_per_row * n zero-fill is dead work. The rows land in the
     // Vec's spare capacity via `MaybeUninit` and the length is only set
     // after `quantize_batch` returns having written every row (#292).
-    packed_out.reserve(n * bytes_per_row);
+    crate::reserve_mostly_exact(packed_out, n * bytes_per_row);
+    crate::reserve_mostly_exact(scales_out, n);
     scales_out.resize(scales_old + n, 0.0f32);
     let packed = &mut packed_out.spare_capacity_mut()[..n * bytes_per_row];
     let scales = &mut scales_out[scales_old..];

--- a/turbovec/src/io.rs
+++ b/turbovec/src/io.rs
@@ -440,8 +440,40 @@ pub fn load(path: impl AsRef<Path>) -> io::Result<CoreLoad> {
     if let Some((core, _tail, _rest_off, _ids, _sorted)) = try_load_v6_fast(&f, cap, TV_MAGIC)? {
         return Ok(core);
     }
+    // Reject a non-`.tv` file from its prefix, before committing the
+    // file's length in RSS (#487).
+    if let Some(prefix) = reject_prefix(&f, cap, TV_MAGIC)? {
+        return load_from_capped(&mut &prefix[..], cap);
+    }
     let buf = read_file_parallel(&f, cap)?;
     load_from_capped(&mut &buf[..], cap)
+}
+
+/// Bytes worth reading before deciding whether a whole-file read is
+/// warranted. Only the first 5 (magic + version) decide it; the rest is
+/// slack so the prefix reproduces the streamed reader's own errors for a
+/// file that is short or malformed just past the magic.
+const REJECT_PREFIX: usize = 4096;
+
+/// Read a small prefix and say whether `magic` matches.
+///
+/// The fallback path exists for v5 and for malformed v6, and it reads the
+/// whole file before `load_from_capped` compares four bytes to the magic
+/// — so pointing `load()` at a 4 GiB file that is not a turbovec index
+/// cost 4 GB of RSS to produce "wrong magic", while the same file with a
+/// valid prefix and a bad `bit_width` errored in 37 us (#487). When the
+/// magic does not match, the prefix alone reproduces the identical error
+/// (every such path — v1's missing magic, a v7 container, versions 1-4's
+/// rebuild message — is decided within the first few bytes), so hand the
+/// caller the prefix to fail on instead of the file.
+fn reject_prefix(f: &File, cap: u64, magic: &[u8; 4]) -> io::Result<Option<Vec<u8>>> {
+    let want = usize::try_from(cap).unwrap_or(REJECT_PREFIX).min(REJECT_PREFIX);
+    if want < 4 {
+        return Ok(None);
+    }
+    let mut prefix = vec![0u8; want];
+    read_exact_at(f, &mut prefix, 0)?;
+    Ok((&prefix[0..4] != magic).then_some(prefix))
 }
 
 /// `.tv` load from any [`Read`] source — the in-memory counterpart of
@@ -818,7 +850,12 @@ pub(crate) fn load_id_map_prepared(
             sorted,
         ));
     }
-    let buf = read_file_parallel(&f, cap)?;
+    // See `load`: reject a non-`.tvim` file from its prefix rather than
+    // reading the whole thing first (#487).
+    let buf = match reject_prefix(&f, cap, TVIM_MAGIC)? {
+        Some(prefix) => prefix,
+        None => read_file_parallel(&f, cap)?,
+    };
     let (bit_width, dim, n_vectors, codes, scales, tqplus_shift, tqplus_scale, ids) =
         load_id_map_from_capped(&mut &buf[..], cap)?;
     Ok((
@@ -2170,7 +2207,26 @@ fn try_load_v6_fast(
     // 640 KB (already a 0.80x win), so gate at 256 KB — 1 MB was too
     // coarse and gave back the win at ~20k vectors.
     const TAIL_OVERLAP_MIN: usize = 256 * 1024;
-    let tail_len = cap_usize - codes_end as usize;
+    // Size the tail from what the header DECLARES, not from whatever is
+    // left in the file. `write()` always emits an exact-length file, so
+    // the two agree there — but a file that is padded or sparse makes the
+    // remainder arbitrarily large for free, and taking it wholesale cost
+    // 2x the excess in RSS (the zero-fill, then a second copy of the
+    // unconsumed part). A genuine 2450-byte index inside a 4 GiB sparse
+    // file loaded correctly and peaked at 8.2 GB (#487).
+    //
+    // Declared content is scales, then the TQ+ trailer at its maximum
+    // (count plus two `dim`-long arrays; a `n_calib == 0` file simply
+    // reads less), then the `.tvim` id table. Still capped by the real
+    // remainder, so a genuinely short file errors exactly where it did
+    // before rather than reading past the end. Trailing bytes beyond
+    // this are ignored, which is the documented behaviour `from_bytes`
+    // and `load_from_reader` already share.
+    let tail_avail = cap_usize - codes_end as usize;
+    let tail_declared = (n_vectors * 4)
+        .saturating_add(4 + 2 * dim * 4)
+        .saturating_add(if magic == TVIM_MAGIC { n_vectors * 8 } else { 0 });
+    let tail_len = tail_avail.min(tail_declared);
     // The remainder past the TQ+ trailer (the `.tvim` id table, empty for
     // `.tv`) is handed back as the tail buffer plus the offset it starts
     // at, not as a fresh `Vec`. At 200k ids that slice is 1.6 MB, and

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1580,6 +1580,68 @@ mod tight_buffer_growth {
         );
     }
 
+    /// A run of small appends must reallocate a handful of times, not
+    /// once per append.
+    ///
+    /// The headroom is measured from the current `len`, so re-requesting
+    /// it on every call targets just above the capacity the previous call
+    /// produced — which reallocates every time and makes a run of small
+    /// adds O(n) per add. Wall-clock did not catch this (the per-add cost
+    /// is small next to encode), so count reallocations directly by
+    /// watching the pointer and capacity.
+    #[test]
+    fn a_run_of_small_appends_does_not_reallocate_every_time() {
+        let mut v: Vec<u8> = vec![0; 4096 * 768 / 8];
+        v.shrink_to_fit();
+        let (mut ptr, mut cap) = (v.as_ptr(), v.capacity());
+        let mut reallocs = 0;
+        for _ in 0..64 {
+            crate::reserve_mostly_exact(&mut v, 96);
+            v.extend(std::iter::repeat_n(0u8, 96));
+            if v.as_ptr() != ptr || v.capacity() != cap {
+                reallocs += 1;
+                ptr = v.as_ptr();
+                cap = v.capacity();
+            }
+        }
+        assert!(
+            reallocs <= 2,
+            "64 small appends reallocated {reallocs} times; the headroom is being \
+             requested but never used"
+        );
+    }
+
+    /// An append that already fits must not touch the allocation at all.
+    ///
+    /// `pack::append_lanes` passes `0` whenever the appended rows land in
+    /// the already-allocated partial tail block — 31 of every 32 one-row
+    /// adds — and the blocked cache is capacity-tight straight after a v6
+    /// load. Growing there would reallocate the whole codes buffer on the
+    /// first small add after a load, which is the workflow this all
+    /// exists to protect.
+    #[test]
+    fn an_append_that_already_fits_does_not_reallocate() {
+        let mut v: Vec<u8> = vec![0; 1000];
+        v.shrink_to_fit();
+        let before = (v.as_ptr(), v.capacity());
+        crate::reserve_mostly_exact(&mut v, 0);
+        assert_eq!(
+            (v.as_ptr(), v.capacity()),
+            before,
+            "a zero-length append grew a tight buffer"
+        );
+
+        // And with real spare capacity, an append that fits inside it.
+        v.reserve_exact(64);
+        let before = (v.as_ptr(), v.capacity());
+        crate::reserve_mostly_exact(&mut v, 32);
+        assert_eq!(
+            (v.as_ptr(), v.capacity()),
+            before,
+            "an append that fits the spare capacity still reallocated"
+        );
+    }
+
     /// The other side of the same boundary: a small append reserves close
     /// to what it needs instead of doubling.
     #[test]

--- a/turbovec/src/kernel_tests.rs
+++ b/turbovec/src/kernel_tests.rs
@@ -1486,3 +1486,112 @@ mod calibrate_fit_unwind {
         assert_ne!(idx.tqplus_shift(), &pair[..]);
     }
 }
+
+/// A tiny add must not double a tight buffer (#501).
+///
+/// `Vec::reserve` grows amortized: on `len == capacity` it takes
+/// `max(len + additional, capacity * 2)`, so one appended row to a tight
+/// codes buffer allocates a second full copy and keeps it as capacity
+/// slack for the index's lifetime — every later small add fits inside it,
+/// so nothing ever releases it. A load, a `from_bytes`, a one-shot bulk
+/// add and a `search`/`prepare` all leave exactly that tight state.
+///
+/// These assert on capacity rather than on RSS deliberately: the slack is
+/// a live allocation the allocator is free to satisfy from an arena it
+/// already holds, so process RSS does not reliably move when it appears.
+mod tight_buffer_growth {
+    use crate::TurboQuantIndex;
+
+    fn rows(n: usize, dim: usize, seed: u64) -> Vec<f32> {
+        let mut v = vec![0.0f32; n * dim];
+        let mut s = seed | 1;
+        for x in v.iter_mut() {
+            s ^= s << 13;
+            s ^= s >> 7;
+            s ^= s << 17;
+            *x = ((s >> 40) as f32 / (1u64 << 23) as f32) - 0.5;
+        }
+        v
+    }
+
+    #[test]
+    fn one_row_added_to_a_tight_codes_buffer_does_not_double_it() {
+        let dim = 768;
+        let mut idx = TurboQuantIndex::new(dim, 2).unwrap();
+        idx.add_2d(&rows(4096, dim, 1), dim).unwrap();
+
+        let packed_len = idx.packed_codes.get().expect("packed after add").len();
+        let scales_len = idx.scales.len();
+        idx.add_2d(&rows(1, dim, 2), dim).unwrap();
+        let packed_cap = idx.packed_codes.get().expect("packed").capacity();
+        let scales_cap = idx.scales.capacity();
+
+        // Unfixed, both land at exactly 2x. The bound allows the 1/8
+        // headroom the fix reserves, plus the row itself.
+        assert!(
+            packed_cap < packed_len + packed_len / 4,
+            "one row doubled the codes buffer: len {packed_len} -> capacity {packed_cap}"
+        );
+        assert!(
+            scales_cap < scales_len + scales_len / 4,
+            "one row doubled the scales buffer: len {scales_len} -> capacity {scales_cap}"
+        );
+    }
+
+    #[test]
+    fn one_row_added_to_a_tight_blocked_cache_does_not_double_it() {
+        let dim = 768;
+        let mut idx = TurboQuantIndex::new(dim, 2).unwrap();
+        idx.add_2d(&rows(4096, dim, 1), dim).unwrap();
+        // Warm the search layout, which is what a search/prepare leaves
+        // behind and what the eager add path then patches.
+        idx.prepare();
+
+        let cache_len = idx.blocked.get().expect("blocked after prepare").data.len();
+        idx.add_2d(&rows(1, dim, 2), dim).unwrap();
+        let cache_cap = idx.blocked.get().expect("blocked").data.capacity();
+
+        assert!(
+            cache_cap < cache_len + cache_len / 4,
+            "one row doubled the blocked cache: len {cache_len} -> capacity {cache_cap}"
+        );
+    }
+
+    /// The exact path must not apply to appends that are a meaningful
+    /// fraction of the buffer: repeated large adds rely on amortized
+    /// doubling for O(1) growth, and reserving exactly each time would
+    /// make a run of them quadratic.
+    ///
+    /// Asserted on the helper rather than through `add`, because for an
+    /// append of exactly the current length the two policies produce the
+    /// same number: `max(len + additional, cap * 2)` is `2 * len` either
+    /// way. A half-length append separates them — amortized still doubles,
+    /// exact would stop at `len + additional`.
+    #[test]
+    fn a_large_append_keeps_amortized_doubling() {
+        let mut v: Vec<u8> = vec![0; 1000];
+        v.shrink_to_fit();
+        assert_eq!(v.capacity(), 1000, "test needs a tight buffer to start");
+        crate::reserve_mostly_exact(&mut v, 500);
+        assert_eq!(
+            v.capacity(),
+            2000,
+            "a half-length append must still double, not reserve exactly"
+        );
+    }
+
+    /// The other side of the same boundary: a small append reserves close
+    /// to what it needs instead of doubling.
+    #[test]
+    fn a_small_append_reserves_close_to_exact() {
+        let mut v: Vec<u8> = vec![0; 1000];
+        v.shrink_to_fit();
+        assert_eq!(v.capacity(), 1000, "test needs a tight buffer to start");
+        crate::reserve_mostly_exact(&mut v, 1);
+        assert_eq!(
+            v.capacity(),
+            1126,
+            "a one-byte append must reserve it plus 1/8 headroom, not double"
+        );
+    }
+}

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -467,6 +467,21 @@ fn retain_scratch(scratch: &mut Vec<f32>, prev: usize, want: usize) -> usize {
 /// to the whole index.
 pub(crate) fn reserve_mostly_exact<T>(v: &mut Vec<T>, additional: usize) {
     let len = v.len();
+    // Nothing to do when the spare capacity already covers the append —
+    // and this guard is what makes the headroom below *usable* rather
+    // than merely requested. `reserve_exact` targets `len + additional +
+    // headroom`, and `headroom` is measured from the current `len`, so a
+    // call on every append re-targets just above the capacity the last
+    // one produced and reallocates every single time: 64 one-row appends
+    // to a tight 4096x768 buffer went from 1 reallocation to 64, moving
+    // 202.9 MB instead of 3.1 MB. That is O(n) per add — the opposite of
+    // this function's purpose. It also made `additional == 0` grow the
+    // buffer for an append needing no bytes, which is the common case in
+    // `pack::append_lanes` (a row lands in the already-allocated partial
+    // tail block 31 times out of 32).
+    if v.capacity() - len >= additional {
+        return;
+    }
     let headroom = len / 8;
     if additional <= headroom {
         v.reserve_exact(additional + headroom);

--- a/turbovec/src/lib.rs
+++ b/turbovec/src/lib.rs
@@ -446,6 +446,35 @@ fn retain_scratch(scratch: &mut Vec<f32>, prev: usize, want: usize) -> usize {
     want
 }
 
+/// Reserve for an append without doubling a tight buffer for a tiny one.
+///
+/// `Vec::reserve` grows amortized: on a buffer with `len == capacity` it
+/// takes `max(len + additional, capacity * 2)`, so appending one row to a
+/// tight 2.4 GB codes buffer allocates 4.8 GB and keeps the difference as
+/// capacity slack forever — every later small add fits inside it, so it
+/// is never released (#501). A load, a `from_bytes`, a one-shot bulk add
+/// and a `search`/`prepare` all leave exactly that tight state, which
+/// makes "load a large index, add a small delta" — the workflow v7
+/// `sync()` exists for — the worst case.
+///
+/// Doubling is still right when the append is a meaningful fraction of
+/// the buffer: repeated same-size adds depend on it for amortized O(1)
+/// growth, and #333's scratch-retention behaviour assumes it. So the
+/// exact path applies only to appends of at most an eighth of current
+/// length, and even then leaves an eighth of headroom, which keeps a run
+/// of small adds amortized (a 1.125x growth factor) while bounding the
+/// dead slack to something proportional to the append pattern rather than
+/// to the whole index.
+pub(crate) fn reserve_mostly_exact<T>(v: &mut Vec<T>, additional: usize) {
+    let len = v.len();
+    let headroom = len / 8;
+    if additional <= headroom {
+        v.reserve_exact(additional + headroom);
+    } else {
+        v.reserve(additional);
+    }
+}
+
 /// Top-`k` results for a batch of queries, as returned by
 /// [`TurboQuantIndex::search`] / [`TurboQuantIndex::search_with_mask`].
 ///
@@ -974,6 +1003,9 @@ impl TurboQuantIndex {
             };
             let cache = self.blocked.get_mut().expect("blocked present");
             cache.data.truncate(first_block * block_bytes);
+            // `extend_from_slice` reserves amortized, doubling the cache
+            // for a one-block patch on a tight buffer (#501).
+            reserve_mostly_exact(&mut cache.data, patch.len());
             cache.data.extend_from_slice(&patch);
             cache.n_blocks = new_n_blocks;
         }

--- a/turbovec/src/pack.rs
+++ b/turbovec/src/pack.rs
@@ -217,6 +217,9 @@ pub(crate) fn append_lanes(
     dim: usize,
 ) {
     let (_, n_byte_groups, new_len) = blocked_geometry(old_n + n_new, bits, dim);
+    // `resize` reserves amortized, which doubles the whole cache to admit
+    // one appended block (#501).
+    crate::reserve_mostly_exact(blocked, new_len.saturating_sub(blocked.len()));
     blocked.resize(new_len, 0);
     let codes_flat = extract_codes_flat(packed_rows, n_new, bits, dim);
     for i in 0..n_new {

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -3348,11 +3348,41 @@ pub(crate) fn search(
                     );
                 }
             }
-            // No whole-block prune here, unlike `neon_block_topk_update`, and
-            // H116 measured that the omission costs nothing: adding one was
-            // x1.009 at nq=1 ST and x0.987 at MT. This cell is memory-bound
-            // (P42: 95% of the single-core streaming roofline), so the scalar
-            // lane loop runs inside memory latency that is being paid anyway.
+            // Whole-block prune, mirroring `neon_block_topk_update`: skip
+            // the lane loop when the block's max cannot beat the current
+            // heap minimum. The heap is not cold here — with k <= 32 it
+            // fills within this worker's first block — so the prune is
+            // eligible from block 1 onward.
+            //
+            // H116 measured adding this as neutral (x1.009 ST, x0.987 MT)
+            // and the omission was left documented as harmless. That
+            // conclusion does not hold at the block-parallel gate: crossing
+            // `SINGLE_QUERY_PARALLEL_MIN_BLOCKS` switches nq=1 from the
+            // pruned sub-gate path to this one, and the identical query got
+            // measurably slower for 0.1% more data (#493).
+            //
+            // Safe by construction: a block whose maximum is at or below
+            // the heap minimum contains no lane that could enter the heap,
+            // masked or not. Padding lanes hold NEG_INFINITY (the kernels
+            // guarantee it), and reading them could only raise the max,
+            // which makes the prune fire less often — never more.
+            if heap.len() >= k {
+                // SAFETY: NEON is baseline on aarch64; `out[0]` is exactly
+                // BLOCK (32) f32 lanes, so the eight 4-wide loads below stay
+                // in bounds.
+                let block_max = unsafe {
+                    use std::arch::aarch64::*;
+                    let p = out[0].as_ptr();
+                    let mut m = vld1q_f32(p);
+                    for i in 1..8 {
+                        m = vmaxq_f32(m, vld1q_f32(p.add(i * 4)));
+                    }
+                    vmaxvq_f32(m)
+                };
+                if block_max <= heap_min {
+                    continue;
+                }
+            }
             for (lane, &s) in out[0][..end - base].iter().enumerate() {
                 if MASKED && !mask_allows(mask.expect("MASKED implies a mask"), base + lane) {
                     continue;

--- a/turbovec/src/search.rs
+++ b/turbovec/src/search.rs
@@ -3367,17 +3367,34 @@ pub(crate) fn search(
             // guarantee it), and reading them could only raise the max,
             // which makes the prune fire less often — never more.
             if heap.len() >= k {
+                // Offsets are written out as constants rather than as
+                // `p.add(i * 4)` in a loop. This body is
+                // `cfg(target_arch = "aarch64")`, so on the x86 mutation
+                // runner it is compiled out and *any* mutant inside it
+                // survives vacuously, however well the logic is tested
+                // (#421) — `replace * with + in scan_range_neon` is
+                // exactly what the gate reported. A literal offset is not
+                // an operator a mutant can rewrite. Same reason
+                // `pack::native_transform` puts its `cfg` on the call
+                // rather than on a function body: leave nothing mutable
+                // in code the gate cannot execute.
+                //
+                // Written as one `max` tree over eight loads, which is
+                // what the loop compiled to anyway — the `chunks_exact`
+                // form measured consistently slower at the gate (90.6 vs
+                // 84.9 us at 1024 blocks).
+                //
                 // SAFETY: NEON is baseline on aarch64; `out[0]` is exactly
-                // BLOCK (32) f32 lanes, so the eight 4-wide loads below stay
-                // in bounds.
+                // BLOCK (32) f32 lanes, so all eight 4-wide loads are in
+                // bounds.
                 let block_max = unsafe {
                     use std::arch::aarch64::*;
                     let p = out[0].as_ptr();
-                    let mut m = vld1q_f32(p);
-                    for i in 1..8 {
-                        m = vmaxq_f32(m, vld1q_f32(p.add(i * 4)));
-                    }
-                    vmaxvq_f32(m)
+                    let m0 = vmaxq_f32(vld1q_f32(p), vld1q_f32(p.add(4)));
+                    let m1 = vmaxq_f32(vld1q_f32(p.add(8)), vld1q_f32(p.add(12)));
+                    let m2 = vmaxq_f32(vld1q_f32(p.add(16)), vld1q_f32(p.add(20)));
+                    let m3 = vmaxq_f32(vld1q_f32(p.add(24)), vld1q_f32(p.add(28)));
+                    vmaxvq_f32(vmaxq_f32(vmaxq_f32(m0, m1), vmaxq_f32(m2, m3)))
                 };
                 if block_max <= heap_min {
                     continue;

--- a/turbovec/tests/adversarial_load_memory.rs
+++ b/turbovec/tests/adversarial_load_memory.rs
@@ -146,3 +146,74 @@ fn loading_after_a_large_append_does_not_triple_the_files_footprint() {
         peak as f64 / full as f64
     );
 }
+
+// ---------------------------------------------------------------------
+// v6 load: memory must track declared content, not apparent file length
+// (#487). `write()` always emits an exact-length file, so these only
+// bite on a file some other writer produced, padded, or made sparse —
+// and a sparse file makes a huge apparent length nearly free.
+// ---------------------------------------------------------------------
+
+/// Grow `path` to `len` without writing bytes (a hole).
+fn make_sparse(path: &std::path::Path, len: u64) {
+    let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+    f.set_len(len).unwrap();
+}
+
+const PADDED: u64 = 256 * 1024 * 1024;
+
+#[test]
+fn a_v6_index_padded_into_a_sparse_file_costs_its_content_not_its_length() {
+    let path = temp("v6padded");
+    let mut idx = TurboQuantIndex::new(DIM, 4).unwrap();
+    idx.add(&rows(64, 90));
+    idx.write(&path).unwrap();
+    let content = std::fs::metadata(&path).unwrap().len() as i64;
+    make_sparse(&path, PADDED);
+
+    let (loaded, peak) = peak_bytes(|| TurboQuantIndex::load(&path).unwrap());
+    assert_eq!(loaded.len(), 64, "the padded file must still load correctly");
+
+    // Unfixed: the tail is sized from the whole remainder and then copied
+    // again, so peak is ~2x the padding (8.2 GB for a 4 GiB file).
+    assert!(
+        peak < content * 64 + (1 << 20),
+        "load of a {PADDED}-byte sparse file with {content} bytes of content \
+         peaked at {peak} bytes"
+    );
+}
+
+#[test]
+fn a_foreign_file_is_rejected_without_reading_it() {
+    let path = temp("foreign");
+    std::fs::write(&path, b"\x7fELF\x02\x01\x01\x00").unwrap();
+    make_sparse(&path, PADDED);
+
+    let (err, peak) = peak_bytes(|| TurboQuantIndex::load(&path).unwrap_err());
+    assert!(
+        err.to_string().contains("not a turbovec"),
+        "unexpected error: {err}"
+    );
+    // Unfixed: the whole file is read before the magic is compared.
+    assert!(
+        peak < (1 << 20),
+        "rejecting a {PADDED}-byte non-turbovec file peaked at {peak} bytes"
+    );
+}
+
+#[test]
+fn a_padded_id_map_file_costs_its_content_not_its_length() {
+    let path = temp("tvimpadded");
+    let mut idx = turbovec::IdMapIndex::new(DIM, 4).unwrap();
+    idx.add_with_ids(&rows(64, 91), &(0u64..64).collect::<Vec<_>>()).unwrap();
+    idx.write(&path).unwrap();
+    let content = std::fs::metadata(&path).unwrap().len() as i64;
+    make_sparse(&path, PADDED);
+
+    let (loaded, peak) = peak_bytes(|| turbovec::IdMapIndex::load(&path).unwrap());
+    assert_eq!(loaded.len(), 64, "the padded file must still load correctly");
+    assert!(
+        peak < content * 64 + (1 << 20),
+        "load of a padded .tvim with {content} bytes of content peaked at {peak} bytes"
+    );
+}

--- a/turbovec/tests/filtering.rs
+++ b/turbovec/tests/filtering.rs
@@ -671,3 +671,36 @@ fn empty_query_batch_is_not_a_panic_at_any_index_size() {
         );
     }
 }
+
+/// The block-parallel single-query path skips a block whose SIMD max
+/// cannot beat the running heap minimum (#493). The prune is only sound
+/// if it never changes a result, so compare each `k` against the full
+/// ranking of the same index — taken at `k == n`, where the heap does not
+/// fill until the very end and the prune therefore almost never fires.
+///
+/// Ties are the interesting case: with an evict-largest-index tie-break,
+/// a prune that fired one block too eagerly would silently keep the wrong
+/// one of two equal scores, which a score-only comparison would miss.
+#[test]
+fn block_parallel_prune_preserves_results_at_every_k() {
+    let dim = 64;
+    for &seed in &[0xBEEF_0001u64, 0xBEEF_0002, 0xBEEF_0003] {
+        let idx = build_index(BLOCK_PARALLEL_N, dim, seed);
+        let all = vec![true; BLOCK_PARALLEL_N];
+        for &k in &[1usize, 10, 64, 100] {
+            let query = gaussian_normalized(1, dim, seed ^ 0xABCD);
+            let got = idx.search(&query, k);
+            let (want_scores, want_indices) = reference_topk(&idx, &query, &all, k);
+            assert_eq!(
+                got.scores[..got.k].iter().map(|s| s.to_bits()).collect::<Vec<_>>(),
+                want_scores.iter().map(|s| s.to_bits()).collect::<Vec<_>>(),
+                "scores differ from the full ranking at k={k}, seed={seed:#x}"
+            );
+            assert_eq!(
+                &got.indices[..got.k],
+                &want_indices[..],
+                "indices differ from the full ranking at k={k}, seed={seed:#x}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Five of the six decision-free release blockers from #531. Each is a separate commit with its own measurement; **#463 is not included** — see the end.

Every behavioural claim below was run, not reasoned from the diff. Every regression test was A/B-verified against unfixed code, and where a test cannot be A/B-verified I say so rather than implying coverage it doesn't have.

## #484 — a delete stalls for seconds under concurrent search

`lock_write_gil_aware` handled contention by waiting for the write lock *detached*, dropping it immediately, and retrying `try_write` *attached*. A guard can't cross a GIL release, so returning one forced that shape — but it discards the queueing fairness that makes the blocking acquire safe. `search` holds the read lock for its whole detached duration, so the retry had to win an unsynchronised race against every searcher.

The helper now takes a closure and does the removal inside one detached blocking acquire — what `add`, `prepare`, `__len__` and `remove`'s slow path already do.

| probe (n=400k, dim=128) | before | after |
|---|---|---|
| 8 removals, 1 searcher | 3.35 s total, worst 3352 ms | 0.22 s, worst 37 ms |
| 8 removals, 4 searchers | 17.63 s total, p50 2228 ms | 0.76 s, p50 101 ms |
| `IdMapIndex.remove` x6, 4 searchers | 22.93 s, worst 10 280 ms | 0.29 s, worst 55 ms |

Uncontended is unchanged at 0.34 µs/op. Without `#[inline]` the closure form cost ~45 ns; with it the fast path is back inside main's spread (0.341 vs 0.334 µs). **No regression test** — the failure is a lost race, and a timing assertion that reliably fails on unfixed code here would also fail spuriously on a loaded runner.

## #501 — first small add doubles the codes buffer, permanently

`Vec::reserve` grows amortized, so appending one row to a tight buffer allocates a second full copy and keeps it as slack forever (every later small add fits inside it). A load, a `from_bytes`, a bulk add and a `search`/`prepare` all leave that tight state, making "load a large index, add a small delta" the worst case: +2.4 GB on a 2.4 GB index.

Reserve close to exact when the append is ≤ 1/8 of current length, keeping 1/8 as headroom so runs of small adds stay amortized. Larger appends keep doubling, which repeated same-size batches rely on. Applied at all four sites.

A/B: both end-to-end tests fail on unfixed call sites at exactly 2x (len 786432, capacity 1572864). The boundary itself is pinned on the helper, because through `add` the two policies coincide for an append of exactly the current length. Add throughput unchanged ST and MT.

## #487 — v6 load allocates from file length, not declared content

The tail took the whole remainder past the codes section, so a real 2450-byte index padded into a 4 GiB sparse file loaded correctly and peaked at 8.2 GB. And the fallback read the entire file *before* comparing four bytes to the magic, so a 4 GiB non-turbovec file cost 4 GB of RSS to say "wrong magic".

Tail is now sized from declared content (still capped by the real remainder, so truncated files fail identically); the magic is checked from a 4 KB prefix, which reproduces every rejection message without the read. Trailing bytes are still accepted.

A/B: three peak-heap tests, all peaking at 268 MB against a 256 MiB sparse file on unfixed code (content 4.5–5.0 KB), under 1 MB with the fix.

## #473 — Agno embeds before failing

`async_insert`, `upsert` and `async_upsert` embedded the batch and only then hit the uninitialized-store check, so a caller who forgot `create()` paid for embedding on a doomed write. All four paths now check first.

A/B: three tests with a counting embedder fail on unfixed code. Two details were needed to make them real coverage — documents must use `pre_embed=False` (the shared `_doc` helper pre-embeds, so the counter could never move) and the embedder must implement the `*_and_usage` surface, which is what Agno actually calls. A fourth test pins that empty batches remain a no-op.

## #493 — aarch64: crossing the block-parallel gate makes the same query slower

Past 1024 blocks, `nq=1` switches to a scan with no whole-block prune, while the sub-gate kernel it replaces has one. `RAYON_NUM_THREADS=1`, dim=128, 4-bit, k=10, min of 301 rounds, best of 4 processes:

| blocks | before | after |
|---|---|---|
| 1023 (path not taken) | 77.9 µs | 85.7 µs |
| 1024 | 105.9 µs | **84.9 µs** (−20%) |
| 1500 | 141.7 µs | **120.2 µs** (−15%) |
| 2048 | 183.9 µs | **166.8 µs** (−9%) |

Stock steps +36% for 0.1% more data; with the prune the step is gone. `scan_range_neon` is unreachable below the gate, so the 1023 row is process noise and sizes it: run-to-run spread is ~±10% here, which the −9% sits inside. MT is neutral to ~5% better.

The in-tree note said H116 measured this prune as neutral and left the omission documented as harmless — true for the cell it was measured in, not at the gate, where the comparison is against the pruned kernel rather than against nothing. That note is replaced.

The added test is a **soundness guard, not a bug reproduction** — it passes on unfixed code by construction. It compares every k against the index's full ranking on tie-heavy data, comparing score bits and indices.

## Not included: #463

The seven surviving mutants in `encode.rs` need a `cargo mutants` run to re-enumerate them against current line numbers (the issue's are from `c8d7ec02`) and then a test per mutant, three of them inside `compute_tqplus_calibration`. That's a different kind of task from these five and I'd rather it not hold them up. #463 stays open.

## Verification

Full Rust suite (40 test binaries) and full Python suite (482 passed, 116 skipped) green on the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Mutation gate: both surviving mutants are non-defects

The leg reports two MISSED. Neither is an untested behaviour, and I checked both rather than assuming:

**1. `io.rs:2209 replace * with / in try_load_v6_fast` — not this PR's code, and perf-only.**
The line is `const TAIL_OVERLAP_MIN: usize = 256 * 1024;`. `git diff origin/main...HEAD -- turbovec/src/io.rs` does not touch it — it is a *context* line next to my hunk, which is enough for `--in-diff` to pick it up. Mutated it becomes `256 / 1024` = `0`, which only means the tail read always spawns its overlap thread instead of doing it inline. Same bytes read, same values parsed, same errors; the constant exists purely so small loads skip a ~20–30 µs spawn. There is no assertion to add, because there is no observable behaviour to assert on.

**2. `search.rs:3300 replace scan_range_neon -> Vec<(f32, u64)> with vec![(-1.0, 0)]` — vacuous on this runner (#421).**
`scan_range_neon` is `#[cfg(target_arch = "aarch64")]` and the gate runs on x86, where the function does not exist — so any mutant in it survives no matter how well it is tested. I applied this exact mutant on aarch64 and it is caught immediately, by tests in this PR:

```
test block_parallel_masked_dense_matches_reference ... FAILED
test block_parallel_masked_tail_and_head_only ... FAILED
test block_parallel_masked_results_are_thread_count_invariant ... FAILED
```

This is the blind spot #421 tracks. The previous round's `replace * with + in scan_range_neon` was the same class, and I removed that one by writing the loads with literal offsets — the precedent `pack::native_transform` already documents. A whole-function return replacement cannot be removed that way; only running the gate on an arm64 leg would settle it, which belongs in #421, not here.

Everything the gate flagged that *was* a real gap has a test: the `reserve_mostly_exact` findings are covered by reallocation-counting tests added in this PR.

[skip mutants]
