### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,40 @@ The Rust crate (`turbovec` on crates.io) and the Python distribution
 is split by surface — a single feature can affect both, and its bullet
 appears under each surface it touches.
 
-## [Unreleased]
+## turbovec 1.0.0 (Python package) + turbovec 1.0.0 (Rust crate) — 2026-08-18
 
-### turbovec — Rust crate
+First stable release, and the two packages are now on one version — the
+crate and the Python package had drifted to 0.9.0 and 0.8.0 and both go
+to 1.0.0 here. What 1.0 commits to is the on-disk format: v7 is what
+turbovec reads and writes, and a file written by this release will be
+readable by later ones.
+
+**Breaking: v7 is the only format turbovec reads or writes.** A `.tv` or
+`.tvim` file written by any earlier release no longer loads — it is
+refused with an error naming its version rather than misread. Use
+[`turbovec::convert`], added in this release, to bring a v5 or v6 file
+forward (or take a v7 file back); `cargo run --example convert -- <in>
+<out> v7` does it from a shell. Files older than v5 predate the rotation
+change that altered every encoded byte and can only be rebuilt from the
+source vectors.
+
+What v7 buys is `sync()`: saving an index that has changed writes the
+rows that changed rather than the whole file, and `write()` / `to_bytes()`
+now produce the same container so there is one format to reason about
+instead of two.
+
+The rest of the release is bug fixes, several of them long-lived. A
+delete could stall for seconds behind concurrent searches; the first
+small add after a load permanently doubled the codes buffer; a load
+allocated from a file's apparent length rather than its declared
+contents; a built index carried two copies of its codes for its lifetime;
+the stale-temp sweep never fired for long filenames; an aarch64 search
+got slower the moment an index crossed 32768 vectors; and Agno's async
+writes paid for embeddings before discovering the store was not created.
+
+[`turbovec::convert`]: https://docs.rs/turbovec/1.0.0/turbovec/convert/
+
+### turbovec — Rust crate (current: 0.9.0 → next: 1.0.0)
 
 #### Added
 
@@ -1612,7 +1643,7 @@ appears under each surface it touches.
   result count) and the `scores_for_query` / `indices_for_query`
   accessors. (#162)
 
-### turbovec — Python package
+### turbovec — Python package (current: 0.8.0 → next: 1.0.0)
 
 #### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The Rust crate (`turbovec` on crates.io) and the Python distribution
 is split by surface — a single feature can affect both, and its bullet
 appears under each surface it touches.
 
+## [Unreleased]
+
 ## turbovec 1.0.0 (Python package) + turbovec 1.0.0 (Rust crate) — 2026-08-18
 
 First stable release, and the two packages are now on one version — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3696,6 +3696,8 @@ turbovec 0.4.4 or later.
   `schema_version` field; loaders reject unknown versions instead of
   silently misinterpreting bytes.
 
-[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/RyanCodrai/turbovec/compare/v1.0.0...HEAD
+[v1.0.0]: https://github.com/RyanCodrai/turbovec/compare/v0.9.0...v1.0.0
+[py-v1.0.0]: https://github.com/RyanCodrai/turbovec/compare/py-v0.8.0...py-v1.0.0
 [py-v0.4.2]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.1...py-v0.4.2
 [py-v0.4.1]: https://github.com/RyanCodrai/turbovec/compare/py-v0.4.0...py-v0.4.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "turbovec"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "ordered-float",
  "rand",
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec-python"
-version = "0.8.0"
+version = "1.0.0"
 dependencies = [
  "libc",
  "numpy",

--- a/examples/downstream-smoke/Cargo.lock
+++ b/examples/downstream-smoke/Cargo.lock
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "turbovec"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "ordered-float",
  "rand",

--- a/turbovec-python/Cargo.toml
+++ b/turbovec-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec-python"
-version = "0.8.0"
+version = "1.0.0"
 edition = "2021"
 # Kept in lockstep with turbovec's `rust-version` — the `msrv` leg in ci.yml
 # fails if the two manifests disagree. The rationale for the number, and why

--- a/turbovec-python/pyproject.toml
+++ b/turbovec-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "turbovec"
-version = "0.8.0"
+version = "1.0.0"
 description = "Fast vector quantization with 2-4 bit compression and SIMD search"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/turbovec/Cargo.toml
+++ b/turbovec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "turbovec"
-version = "0.9.0"
+version = "1.0.0"
 edition = "2021"
 # 1.89 is a floor the code actually needs, not a rounded-up default, and it has
 # now been reported as over-declared twice (#351). The AVX-512 search kernel is


### PR DESCRIPTION
Prepares the release. **No code changes** — versions, the changelog cut, and the lockfile.

## Versions

Both packages go to **1.0.0**. They had drifted (crate 0.9.0, Python 0.8.0) and are one version from here.

| file | before | after |
|---|---|---|
| `turbovec/Cargo.toml` | 0.9.0 | 1.0.0 |
| `turbovec-python/Cargo.toml` | 0.8.0 | 1.0.0 |
| `turbovec-python/pyproject.toml` | 0.8.0 | 1.0.0 |
| `Cargo.lock` | — | both entries |

All four move together because each release workflow checks the tag against the manifests before building anything (#343) — `release-crates.yml` against `turbovec/Cargo.toml`, `release-pypi.yml` against *both* python manifests — so a mismatch fails in seconds rather than at upload.

## What 1.0 says

The on-disk format. v7 is what turbovec reads and writes, and a file written by this release will be readable by later ones. That is a claim worth making now that there is one format instead of two, and a converter for anything older.

## Breaking

A `.tv` or `.tvim` from any earlier release no longer loads — it is refused with an error naming its version rather than misread. `turbovec::convert` brings v5 and v6 forward (and back), including from a shell via `cargo run --example convert`. Files older than v5 predate the rotation change that altered every encoded byte and can only be rebuilt from source vectors. The changelog leads with all of this.

## How to cut it, once this merges

Two independent tags, either order:

```
git tag v1.0.0     && git push origin v1.0.0      # -> crates.io
git tag py-v1.0.0  && git push origin py-v1.0.0   # -> PyPI wheels
```

Both workflows also accept `workflow_dispatch`. Tagging and publishing are yours — I have not tagged anything.

## Verification

Rust suite and 482 Python tests green at these versions; the wheel builds as `turbovec-1.0.0`.

## Not included

Three open items I would not call blockers, listed so the choice is explicit: #463 (seven `encode.rs` mutants, three in the calibration fit), #351's MSRV over-declaration (declares 1.89, needs ~1.83), and #439 (the `target-cpu` flag, needs an x86 host to settle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Changelog gate

The three version bumps register as public-surface changes, and `## [Unreleased]` is legitimately empty on a release cut — everything that was under it is now under the 1.0.0 heading. That is exactly the case the gate's opt-out exists for, so it is armed rather than worked around by inventing an entry.

[skip changelog]
